### PR TITLE
feat: add gist and workflow tools

### DIFF
--- a/.changeset/add-gist-workflow-tools.md
+++ b/.changeset/add-gist-workflow-tools.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Add GitHub Gist and workflow tools, plus a CI-ops agent preset for operational tasks.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 GitHub tools for the [AI SDK](https://ai-sdk.dev) — wrap GitHub's REST API as ready-to-use tools for any agent or `generateText` / `streamText` call.
 
-21 tools covering repositories, branches, pull requests, issues, commits, and search. Write operations support granular approval control out of the box.
+35 tools covering repositories, branches, pull requests, issues, commits, search, gists, and workflows. Write operations support granular approval control out of the box.
 
 ## Installation
 
@@ -64,8 +64,9 @@ createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
 |---|---|
 | `code-review` | `getPullRequest`, `listPullRequests`, `getFileContent`, `listCommits`, `getCommit`, `getRepository`, `listBranches`, `searchCode`, `addPullRequestComment` |
 | `issue-triage` | `listIssues`, `getIssue`, `createIssue`, `addIssueComment`, `closeIssue`, `getRepository`, `searchRepositories`, `searchCode` |
-| `repo-explorer` | All read-only tools (no write operations) |
-| `maintainer` | All 21 tools |
+| `repo-explorer` | All read-only tools including gists and workflows (no write operations) |
+| `ci-ops` | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `getRepository`, `listBranches`, `listCommits`, `getCommit` |
+| `maintainer` | All 35 tools |
 
 Omit `preset` to get all tools (same as `maintainer`).
 
@@ -110,7 +111,7 @@ createGithubTools({
 })
 ```
 
-Write tools: `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `addPullRequestComment`, `createIssue`, `addIssueComment`, `closeIssue`.
+Write tools: `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `addPullRequestComment`, `createIssue`, `addIssueComment`, `closeIssue`, `createGist`, `updateGist`, `deleteGist`, `createGistComment`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`.
 
 All other tools are read-only and never require approval.
 
@@ -145,6 +146,30 @@ All other tools are read-only and never require approval.
 | `addIssueComment` | Post a comment on an issue |
 | `closeIssue` | Close an issue (completed or not planned) |
 
+### Gists
+
+| Tool | Description |
+|---|---|
+| `listGists` | List gists for the authenticated user or a specific user |
+| `getGist` | Get a gist including file contents |
+| `listGistComments` | List comments on a gist |
+| `createGist` | Create a new gist with one or more files |
+| `updateGist` | Update a gist's description or files |
+| `deleteGist` | Delete a gist permanently |
+| `createGistComment` | Post a comment on a gist |
+
+### Workflows
+
+| Tool | Description |
+|---|---|
+| `listWorkflows` | List GitHub Actions workflows in a repository |
+| `listWorkflowRuns` | List workflow runs filtered by workflow, branch, status, or event |
+| `getWorkflowRun` | Get a workflow run's status, timing, and trigger info |
+| `listWorkflowJobs` | List jobs in a workflow run with step-level status |
+| `triggerWorkflow` | Trigger a workflow via workflow_dispatch event |
+| `cancelWorkflowRun` | Cancel an in-progress workflow run |
+| `rerunWorkflowRun` | Re-run a workflow run, optionally only failed jobs |
+
 ### Commits
 
 | Tool | Description |
@@ -177,6 +202,11 @@ Create one at **GitHub → Settings → Developer settings → Personal access t
 | **Issues** | Read-only | `listIssues`, `getIssue` |
 | **Issues** | Read and write | `createIssue`, `addIssueComment`, `closeIssue` |
 
+| **Gists** | Read-only | `listGists`, `getGist`, `listGistComments` |
+| **Gists** | Read and write | `createGist`, `updateGist`, `deleteGist`, `createGistComment` |
+| **Actions** | Read-only | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs` |
+| **Actions** | Read and write | `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun` |
+
 Search tools (`searchCode`, `searchRepositories`) work with any token.
 
 ### Classic token
@@ -199,7 +229,7 @@ type GithubToolsOptions = {
   preset?: GithubToolPreset | GithubToolPreset[]
 }
 
-type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'maintainer'
+type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'ci-ops' | 'maintainer'
 ```
 
 ### `createGithubAgent(options)`

--- a/apps/chat/shared/utils/tools/github.ts
+++ b/apps/chat/shared/utils/tools/github.ts
@@ -31,7 +31,21 @@ export const GITHUB_TOOL_META: Record<GithubToolName, GithubToolMeta> = {
   searchCode: { title: 'Search Code', label: 'Code searched', labelActive: 'Searching code', icon: 'i-lucide-search-code' },
   searchRepositories: { title: 'Search Repositories', label: 'Repositories searched', labelActive: 'Searching repositories', icon: 'i-lucide-search' },
   listCommits: { title: 'List Commits', label: 'Commits listed', labelActive: 'Listing commits', icon: 'i-lucide-git-commit-horizontal' },
-  getCommit: { title: 'Get Commit', label: 'Commit fetched', labelActive: 'Fetching commit', icon: 'i-lucide-git-commit-horizontal' }
+  getCommit: { title: 'Get Commit', label: 'Commit fetched', labelActive: 'Fetching commit', icon: 'i-lucide-git-commit-horizontal' },
+  listGists: { title: 'List Gists', label: 'Gists listed', labelActive: 'Listing gists', icon: 'i-lucide-file-code-2' },
+  getGist: { title: 'Get Gist', label: 'Gist fetched', labelActive: 'Fetching gist', icon: 'i-lucide-file-code-2' },
+  listGistComments: { title: 'List Gist Comments', label: 'Comments listed', labelActive: 'Listing gist comments', icon: 'i-lucide-message-square' },
+  createGist: { title: 'Create Gist', label: 'Gist created', labelActive: 'Creating gist', icon: 'i-lucide-file-plus' },
+  updateGist: { title: 'Update Gist', label: 'Gist updated', labelActive: 'Updating gist', icon: 'i-lucide-file-pen' },
+  deleteGist: { title: 'Delete Gist', label: 'Gist deleted', labelActive: 'Deleting gist', icon: 'i-lucide-file-x' },
+  createGistComment: { title: 'Comment on Gist', label: 'Comment posted', labelActive: 'Posting gist comment', icon: 'i-lucide-message-square-plus' },
+  listWorkflows: { title: 'List Workflows', label: 'Workflows listed', labelActive: 'Listing workflows', icon: 'i-lucide-workflow' },
+  listWorkflowRuns: { title: 'List Workflow Runs', label: 'Runs listed', labelActive: 'Listing workflow runs', icon: 'i-lucide-play' },
+  getWorkflowRun: { title: 'Get Workflow Run', label: 'Run fetched', labelActive: 'Fetching workflow run', icon: 'i-lucide-play' },
+  listWorkflowJobs: { title: 'List Workflow Jobs', label: 'Jobs listed', labelActive: 'Listing workflow jobs', icon: 'i-lucide-list-checks' },
+  triggerWorkflow: { title: 'Trigger Workflow', label: 'Workflow triggered', labelActive: 'Triggering workflow', icon: 'i-lucide-rocket' },
+  cancelWorkflowRun: { title: 'Cancel Workflow Run', label: 'Run cancelled', labelActive: 'Cancelling workflow run', icon: 'i-lucide-circle-x' },
+  rerunWorkflowRun: { title: 'Re-run Workflow', label: 'Workflow re-run', labelActive: 'Re-running workflow', icon: 'i-lucide-refresh-cw' }
 }
 
 export const GITHUB_TOOL_NAMES = new Set<string>(Object.keys(GITHUB_TOOL_META))

--- a/apps/docs/app/pages/index.vue
+++ b/apps/docs/app/pages/index.vue
@@ -12,7 +12,7 @@ defineOgImage(false)
 const layers = [
   {
     title: 'Tools',
-    description: '21 AI-callable GitHub operations — repositories, branches, pull requests, issues, commits, and code search.',
+    description: '35 AI-callable GitHub operations — repositories, branches, pull requests, issues, commits, search, gists, and workflows.',
     to: '/api/tools-catalog',
     icon: 'i-custom:sdk',
   },

--- a/apps/docs/content/docs/1.getting-started/1.introduction.md
+++ b/apps/docs/content/docs/1.getting-started/1.introduction.md
@@ -21,7 +21,7 @@ Pass them to `generateText`, `streamText`, or any agent loop — the model decid
 
 ## Explore the tools
 
-The SDK ships **21 tools** covering repositories, branches, pull requests, issues, commits, and code search. Each tool maps to a single GitHub REST endpoint and is fully typed with [Zod](https://zod.dev) schemas.
+The SDK ships **35 tools** covering repositories, branches, pull requests, issues, commits, code search, gists, and workflows. Each tool maps to a single GitHub REST endpoint and is fully typed with [Zod](https://zod.dev) schemas.
 
 Browse the full list in the [Tools Catalog](/api/tools-catalog).
 
@@ -31,9 +31,10 @@ Instead of wiring tools individually, use a **preset** to get a curated subset f
 
 | Preset | Tools included | Use case |
 |---|---|---|
-| `repo-explorer` | repository metadata, branches, file content, code search | knowledge retrieval, repo Q&A |
+| `repo-explorer` | repository metadata, branches, file content, code search, gists, workflows | knowledge retrieval, repo Q&A |
 | `code-review` | pull requests, commits, file diffs, review comments | PR copilots, change summaries |
 | `issue-triage` | issues, labels, comments, close/create | support triage, backlog bots |
+| `ci-ops` | workflows, runs, jobs, commits, repository context | CI monitoring, build ops |
 | `maintainer` | all tool families | full operator workflows |
 
 Learn more in [Scope with Presets](/guide/presets).
@@ -63,7 +64,7 @@ See [Examples](/guide/examples) for more agent patterns.
   title: Tools
   to: /api/tools-catalog
   ---
-  21 individual GitHub operations you wire into any AI SDK call.
+  35 individual GitHub operations you wire into any AI SDK call.
   :::
 
   :::card

--- a/apps/docs/content/docs/2.guide/1.quick-start.md
+++ b/apps/docs/content/docs/2.guide/1.quick-start.md
@@ -51,7 +51,7 @@ const { text } = await generateText({
 console.log(text)
 ```
 
-The SDK reads `GITHUB_TOKEN` from your environment automatically. This gives the model access to all 21 tools — see the [Tools Catalog](/api/tools-catalog) for what each one does.
+The SDK reads `GITHUB_TOKEN` from your environment automatically. This gives the model access to all 35 tools — see the [Tools Catalog](/api/tools-catalog) for what each one does.
 
 ## Narrow tools with a preset
 

--- a/apps/docs/content/docs/2.guide/2.presets.md
+++ b/apps/docs/content/docs/2.guide/2.presets.md
@@ -45,10 +45,11 @@ const tools = createGithubTools({
 
 | Preset | Tools included | Use case |
 |---|---|---|
-| `repo-explorer` | repository metadata, branches, file content, code search | knowledge retrieval, repo Q&A |
+| `repo-explorer` | repository metadata, branches, file content, code search, gists, workflows | knowledge retrieval, repo Q&A |
+| `ci-ops` | workflows, runs, jobs, commits, repository context | CI monitoring, build ops |
 | `code-review` | pull requests, commits, file diffs, review comments | PR copilots, change summaries |
 | `issue-triage` | issues, labels, comments, close/create | support triage, backlog bots |
-| `maintainer` | all tool families including branch creation, forking, and repo creation | operator workflows with strict approvals |
+| `maintainer` | all tool families including branch creation, forking, repo creation, gists, and workflows | operator workflows with strict approvals |
 
 ## Pair presets with token scopes
 
@@ -57,6 +58,7 @@ Each preset maps to specific [GitHub token permissions](/guide/token-permissions
 - `repo-explorer` — read-only token, no write permissions needed
 - `code-review` — add `pull_requests: write` only if comments are needed
 - `issue-triage` — add `issues: write`
+- `ci-ops` — add `actions: write` for triggering, cancelling, and re-running workflows
 - `maintainer` — all write scopes, always paired with [approval control](/guide/approval-control)
 
 ::tip

--- a/apps/docs/content/docs/2.guide/3.approval-control.md
+++ b/apps/docs/content/docs/2.guide/3.approval-control.md
@@ -77,6 +77,13 @@ const tools = createGithubTools({
 | `createBranch` | Low | Usually skip |
 | `addPullRequestComment` | Low | Usually skip |
 | `addIssueComment` | Low | Usually skip |
+| `deleteGist` | High | Always require approval |
+| `createGist` | Medium | Optional in trusted CI |
+| `updateGist` | Medium | Require in production |
+| `createGistComment` | Low | Usually skip |
+| `triggerWorkflow` | High | Always require approval |
+| `cancelWorkflowRun` | High | Always require approval |
+| `rerunWorkflowRun` | Medium | Require in production repos |
 
 ::warning
 Approval is one safety layer, not the only one. Combine it with least-privilege [token scopes](/guide/token-permissions) and narrow [presets](/guide/presets).

--- a/apps/docs/content/docs/2.guide/5.token-and-permissions.md
+++ b/apps/docs/content/docs/2.guide/5.token-and-permissions.md
@@ -27,12 +27,13 @@ Fine-grained personal access tokens let you restrict access per repository and p
 
 ## Map permissions to presets
 
-| Preset | Repository access | Contents | Pull requests | Issues | Administration |
-|---|---|---|---|---|---|
-| `repo-explorer` | selected repos | `read` | — | — | — |
-| `code-review` | selected repos | `read` | `read` (or `write` for comments) | — | — |
-| `issue-triage` | selected repos | `read` | — | `write` | — |
-| `maintainer` | selected repos | `write` | `write` | `write` | `write` (for repo creation and forking) |
+| Preset | Repository access | Contents | Pull requests | Issues | Actions | Administration |
+|---|---|---|---|---|---|---|
+| `repo-explorer` | selected repos | `read` | — | — | — | — |
+| `code-review` | selected repos | `read` | `read` (or `write` for comments) | — | — | — |
+| `issue-triage` | selected repos | `read` | — | `write` | — | — |
+| `ci-ops` | selected repos | `read` | — | — | `write` | — |
+| `maintainer` | selected repos | `write` | `write` | `write` | `write` | `write` (for repo creation and forking) |
 
 ## Apply least-privilege step by step
 

--- a/apps/docs/content/docs/3.api/1.tools-catalog.md
+++ b/apps/docs/content/docs/3.api/1.tools-catalog.md
@@ -53,6 +53,34 @@ Available in `issue-triage` and `maintainer` presets:
 | `addIssueComment` | post a comment on an issue | Yes |
 | `closeIssue` | close an issue thread | Yes |
 
+## Gist tools
+
+Available in `repo-explorer` (read-only) and `maintainer` presets:
+
+| Tool | Capability | Write |
+|---|---|---|
+| `listGists` | list gists for the authenticated user or a specific user | — |
+| `getGist` | read a gist including file contents | — |
+| `listGistComments` | list comments on a gist | — |
+| `createGist` | create a new gist with one or more files | Yes |
+| `updateGist` | update gist description, files, or remove files | Yes |
+| `deleteGist` | permanently delete a gist | Yes |
+| `createGistComment` | post a comment on a gist | Yes |
+
+## Workflow tools
+
+Available in `repo-explorer` (read-only), `ci-ops`, and `maintainer` presets:
+
+| Tool | Capability | Write |
+|---|---|---|
+| `listWorkflows` | list GitHub Actions workflows in a repository | — |
+| `listWorkflowRuns` | list workflow runs filtered by workflow, branch, status, or event | — |
+| `getWorkflowRun` | read a workflow run's status, timing, and trigger info | — |
+| `listWorkflowJobs` | list jobs in a workflow run with step-level status | — |
+| `triggerWorkflow` | trigger a workflow via workflow_dispatch event | Yes |
+| `cancelWorkflowRun` | cancel an in-progress workflow run | Yes |
+| `rerunWorkflowRun` | re-run a workflow run, optionally only failed jobs | Yes |
+
 ## Search and commit tools
 
 Available in all presets:

--- a/apps/docs/content/docs/3.api/2.reference.md
+++ b/apps/docs/content/docs/3.api/2.reference.md
@@ -30,6 +30,7 @@ type GithubToolPreset =
   | 'code-review'
   | 'issue-triage'
   | 'repo-explorer'
+  | 'ci-ops'
   | 'maintainer'
 ```
 

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -9,7 +9,7 @@
 
 GitHub tools for the [AI SDK](https://ai-sdk.dev) — wrap GitHub's REST API as ready-to-use tools for any agent or `generateText` / `streamText` call.
 
-21 tools covering repositories, branches, pull requests, issues, commits, and search. Write operations support granular approval control out of the box.
+35 tools covering repositories, branches, pull requests, issues, commits, search, gists, and workflows. Write operations support granular approval control out of the box.
 
 ## Installation
 
@@ -64,8 +64,9 @@ createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
 |---|---|
 | `code-review` | `getPullRequest`, `listPullRequests`, `getFileContent`, `listCommits`, `getCommit`, `getRepository`, `listBranches`, `searchCode`, `addPullRequestComment` |
 | `issue-triage` | `listIssues`, `getIssue`, `createIssue`, `addIssueComment`, `closeIssue`, `getRepository`, `searchRepositories`, `searchCode` |
-| `repo-explorer` | All read-only tools (no write operations) |
-| `maintainer` | All 21 tools |
+| `repo-explorer` | All read-only tools including gists and workflows (no write operations) |
+| `ci-ops` | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `getRepository`, `listBranches`, `listCommits`, `getCommit` |
+| `maintainer` | All 35 tools |
 
 Omit `preset` to get all tools (same as `maintainer`).
 
@@ -110,7 +111,7 @@ createGithubTools({
 })
 ```
 
-Write tools: `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `addPullRequestComment`, `createIssue`, `addIssueComment`, `closeIssue`.
+Write tools: `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `addPullRequestComment`, `createIssue`, `addIssueComment`, `closeIssue`, `createGist`, `updateGist`, `deleteGist`, `createGistComment`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`.
 
 All other tools are read-only and never require approval.
 
@@ -145,6 +146,30 @@ All other tools are read-only and never require approval.
 | `addIssueComment` | Post a comment on an issue |
 | `closeIssue` | Close an issue (completed or not planned) |
 
+### Gists
+
+| Tool | Description |
+|---|---|
+| `listGists` | List gists for the authenticated user or a specific user |
+| `getGist` | Get a gist including file contents |
+| `listGistComments` | List comments on a gist |
+| `createGist` | Create a new gist with one or more files |
+| `updateGist` | Update a gist's description or files |
+| `deleteGist` | Delete a gist permanently |
+| `createGistComment` | Post a comment on a gist |
+
+### Workflows
+
+| Tool | Description |
+|---|---|
+| `listWorkflows` | List GitHub Actions workflows in a repository |
+| `listWorkflowRuns` | List workflow runs filtered by workflow, branch, status, or event |
+| `getWorkflowRun` | Get a workflow run's status, timing, and trigger info |
+| `listWorkflowJobs` | List jobs in a workflow run with step-level status |
+| `triggerWorkflow` | Trigger a workflow via workflow_dispatch event |
+| `cancelWorkflowRun` | Cancel an in-progress workflow run |
+| `rerunWorkflowRun` | Re-run a workflow run, optionally only failed jobs |
+
 ### Commits
 
 | Tool | Description |
@@ -177,6 +202,11 @@ Create one at **GitHub → Settings → Developer settings → Personal access t
 | **Issues** | Read-only | `listIssues`, `getIssue` |
 | **Issues** | Read and write | `createIssue`, `addIssueComment`, `closeIssue` |
 
+| **Gists** | Read-only | `listGists`, `getGist`, `listGistComments` |
+| **Gists** | Read and write | `createGist`, `updateGist`, `deleteGist`, `createGistComment` |
+| **Actions** | Read-only | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs` |
+| **Actions** | Read and write | `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun` |
+
 Search tools (`searchCode`, `searchRepositories`) work with any token.
 
 ### Classic token
@@ -199,7 +229,7 @@ type GithubToolsOptions = {
   preset?: GithubToolPreset | GithubToolPreset[]
 }
 
-type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'maintainer'
+type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'ci-ops' | 'maintainer'
 ```
 
 ### `createGithubAgent(options)`

--- a/packages/github-tools/src/agents.ts
+++ b/packages/github-tools/src/agents.ts
@@ -5,7 +5,7 @@ import type { GithubToolPreset, ApprovalConfig } from './index'
 
 const SHARED_RULES = `When a tool execution is denied by the user, do not retry it. Briefly acknowledge the decision and move on.`
 
-const DEFAULT_INSTRUCTIONS = `You are a helpful GitHub assistant. You can read and explore repositories, issues, pull requests, commits, and code. You can also create issues, pull requests, comments, and update files when asked.
+const DEFAULT_INSTRUCTIONS = `You are a helpful GitHub assistant. You can read and explore repositories, issues, pull requests, commits, code, gists, and workflows. You can also create issues, pull requests, comments, gists, trigger workflows, and update files when asked.
 
 ${SHARED_RULES}`
 
@@ -32,6 +32,18 @@ When triaging issues:
 
 ${SHARED_RULES}`,
 
+  'ci-ops': `You are a CI/CD operations assistant. Your job is to help monitor and manage GitHub Actions workflows.
+
+When working with workflows:
+- Check workflow run status and report failures clearly
+- Inspect job steps to identify exactly where a run failed
+- Re-run failed workflows when asked
+- Trigger workflow dispatches with the correct inputs and branch
+- Be careful with cancel and re-run operations — confirm the target run
+- Summarize run history and trends when asked
+
+${SHARED_RULES}`,
+
   'repo-explorer': `You are a repository explorer. Your job is to help users understand codebases and find information across GitHub repositories.
 
 When exploring repos:
@@ -43,7 +55,7 @@ When exploring repos:
 
 ${SHARED_RULES}`,
 
-  'maintainer': `You are a repository maintainer assistant. You have full access to manage repositories, issues, and pull requests.
+  'maintainer': `You are a repository maintainer assistant. You have full access to manage repositories, issues, pull requests, gists, and workflows.
 
 When maintaining repos:
 - Be careful with write operations — review before acting

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -4,6 +4,8 @@ import { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, 
 import { listIssues, getIssue, createIssue, addIssueComment, closeIssue } from './tools/issues'
 import { searchCode, searchRepositories } from './tools/search'
 import { listCommits, getCommit } from './tools/commits'
+import { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
+import { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
 
 export type GithubWriteToolName =
   | 'createBranch'
@@ -16,6 +18,13 @@ export type GithubWriteToolName =
   | 'createIssue'
   | 'addIssueComment'
   | 'closeIssue'
+  | 'createGist'
+  | 'updateGist'
+  | 'deleteGist'
+  | 'createGistComment'
+  | 'triggerWorkflow'
+  | 'cancelWorkflowRun'
+  | 'rerunWorkflowRun'
 
 /**
  * Whether write operations require user approval.
@@ -41,9 +50,10 @@ export type ApprovalConfig = boolean | Partial<Record<GithubWriteToolName, boole
  * - `'code-review'` — Review PRs: read PRs, file content, commits, and post comments
  * - `'issue-triage'` — Triage issues: read/create/close issues, search, and comment
  * - `'repo-explorer'` — Explore repos: read-only access to repos, branches, code, and search
+ * - `'ci-ops'`        — CI operations: monitor and manage GitHub Actions workflows
  * - `'maintainer'`   — Full maintenance: all read + create PRs, merge, manage issues
  */
-export type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'maintainer'
+export type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'ci-ops' | 'maintainer'
 
 const PRESET_TOOLS: Record<GithubToolPreset, string[]> = {
   'code-review': [
@@ -55,19 +65,29 @@ const PRESET_TOOLS: Record<GithubToolPreset, string[]> = {
     'listIssues', 'getIssue', 'createIssue', 'addIssueComment', 'closeIssue',
     'getRepository', 'searchRepositories', 'searchCode'
   ],
+  'ci-ops': [
+    'getRepository', 'listBranches',
+    'listCommits', 'getCommit',
+    'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs',
+    'triggerWorkflow', 'cancelWorkflowRun', 'rerunWorkflowRun'
+  ],
   'repo-explorer': [
     'getRepository', 'listBranches', 'getFileContent',
     'listPullRequests', 'getPullRequest',
     'listIssues', 'getIssue',
     'listCommits', 'getCommit',
-    'searchCode', 'searchRepositories'
+    'searchCode', 'searchRepositories',
+    'listGists', 'getGist', 'listGistComments',
+    'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs'
   ],
   'maintainer': [
     'getRepository', 'listBranches', 'getFileContent', 'createBranch', 'forkRepository', 'createRepository', 'createOrUpdateFile',
     'listPullRequests', 'getPullRequest', 'createPullRequest', 'mergePullRequest', 'addPullRequestComment',
     'listIssues', 'getIssue', 'createIssue', 'addIssueComment', 'closeIssue',
     'listCommits', 'getCommit',
-    'searchCode', 'searchRepositories'
+    'searchCode', 'searchRepositories',
+    'listGists', 'getGist', 'listGistComments', 'createGist', 'updateGist', 'deleteGist', 'createGistComment',
+    'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs', 'triggerWorkflow', 'cancelWorkflowRun', 'rerunWorkflowRun'
   ]
 }
 
@@ -170,6 +190,20 @@ export function createGithubTools({ token, requireApproval = true, preset }: Git
     createIssue: createIssue(octokit, approval('createIssue')),
     addIssueComment: addIssueComment(octokit, approval('addIssueComment')),
     closeIssue: closeIssue(octokit, approval('closeIssue')),
+    listGists: listGists(octokit),
+    getGist: getGist(octokit),
+    listGistComments: listGistComments(octokit),
+    createGist: createGist(octokit, approval('createGist')),
+    updateGist: updateGist(octokit, approval('updateGist')),
+    deleteGist: deleteGist(octokit, approval('deleteGist')),
+    createGistComment: createGistComment(octokit, approval('createGistComment')),
+    listWorkflows: listWorkflows(octokit),
+    listWorkflowRuns: listWorkflowRuns(octokit),
+    getWorkflowRun: getWorkflowRun(octokit),
+    listWorkflowJobs: listWorkflowJobs(octokit),
+    triggerWorkflow: triggerWorkflow(octokit, approval('triggerWorkflow')),
+    cancelWorkflowRun: cancelWorkflowRun(octokit, approval('cancelWorkflowRun')),
+    rerunWorkflowRun: rerunWorkflowRun(octokit, approval('rerunWorkflowRun')),
   }
 
   if (!allowed) return allTools
@@ -188,6 +222,8 @@ export { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, 
 export { listIssues, getIssue, createIssue, addIssueComment, closeIssue } from './tools/issues'
 export { searchCode, searchRepositories } from './tools/search'
 export { listCommits, getCommit } from './tools/commits'
+export { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
+export { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
 export type { Octokit, ToolOptions } from './types'
 export { createGithubAgent } from './agents'
 export type { CreateGithubAgentOptions } from './agents'

--- a/packages/github-tools/src/tools/gists.ts
+++ b/packages/github-tools/src/tools/gists.ts
@@ -1,0 +1,168 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { Octokit, ToolOptions } from '../types'
+
+export const listGists = (octokit: Octokit) =>
+  tool({
+    description: 'List gists for the authenticated user or a specific user',
+    inputSchema: z.object({
+      username: z.string().optional().describe('GitHub username — omit to list your own gists'),
+      perPage: z.number().optional().default(30).describe('Number of results to return (max 100)'),
+      page: z.number().optional().default(1).describe('Page number for pagination'),
+    }),
+    execute: async ({ username, perPage, page }) => {
+      const { data } = username
+        ? await octokit.rest.gists.listForUser({ username, per_page: perPage, page })
+        : await octokit.rest.gists.list({ per_page: perPage, page })
+      return data.map(gist => ({
+        id: gist.id,
+        description: gist.description,
+        public: gist.public,
+        url: gist.html_url,
+        files: Object.keys(gist.files ?? {}),
+        owner: gist.owner?.login,
+        comments: gist.comments,
+        createdAt: gist.created_at,
+        updatedAt: gist.updated_at,
+      }))
+    },
+  })
+
+export const getGist = (octokit: Octokit) =>
+  tool({
+    description: 'Get a gist by ID, including file contents',
+    inputSchema: z.object({
+      gistId: z.string().describe('Gist ID'),
+    }),
+    execute: async ({ gistId }) => {
+      const { data } = await octokit.rest.gists.get({ gist_id: gistId })
+      return {
+        id: data.id,
+        description: data.description,
+        public: data.public,
+        url: data.html_url,
+        owner: data.owner?.login,
+        files: Object.values(data.files ?? {}).map(file => ({
+          filename: file?.filename,
+          language: file?.language,
+          size: file?.size,
+          content: file?.content,
+        })),
+        comments: data.comments,
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+      }
+    },
+  })
+
+export const listGistComments = (octokit: Octokit) =>
+  tool({
+    description: 'List comments on a gist',
+    inputSchema: z.object({
+      gistId: z.string().describe('Gist ID'),
+      perPage: z.number().optional().default(30).describe('Number of results to return (max 100)'),
+      page: z.number().optional().default(1).describe('Page number for pagination'),
+    }),
+    execute: async ({ gistId, perPage, page }) => {
+      const { data } = await octokit.rest.gists.listComments({ gist_id: gistId, per_page: perPage, page })
+      return data.map(comment => ({
+        id: comment.id,
+        body: comment.body,
+        author: comment.user?.login,
+        url: comment.url,
+        createdAt: comment.created_at,
+        updatedAt: comment.updated_at,
+      }))
+    },
+  })
+
+export const createGist = (octokit: Octokit, { needsApproval = true }: ToolOptions = {}) =>
+  tool({
+    description: 'Create a new gist with one or more files',
+    needsApproval,
+    inputSchema: z.object({
+      description: z.string().optional().describe('Gist description'),
+      files: z.record(z.string(), z.object({ content: z.string().describe('File content') }))
+        .describe('Files to include, keyed by filename'),
+      isPublic: z.boolean().optional().default(false).describe('Whether the gist is public'),
+    }),
+    execute: async ({ description, files, isPublic }) => {
+      const { data } = await octokit.rest.gists.create({
+        description,
+        files,
+        public: isPublic,
+      })
+      return {
+        id: data.id,
+        description: data.description,
+        public: data.public,
+        url: data.html_url,
+        files: Object.keys(data.files ?? {}),
+        owner: data.owner?.login,
+      }
+    },
+  })
+
+export const updateGist = (octokit: Octokit, { needsApproval = true }: ToolOptions = {}) =>
+  tool({
+    description: 'Update an existing gist — edit description, update files, or remove files',
+    needsApproval,
+    inputSchema: z.object({
+      gistId: z.string().describe('Gist ID'),
+      description: z.string().optional().describe('New gist description'),
+      files: z.record(z.string(), z.object({ content: z.string().describe('New file content') }))
+        .optional().describe('Files to add or update, keyed by filename'),
+      filesToDelete: z.array(z.string()).optional().describe('Filenames to remove from the gist'),
+    }),
+    execute: async ({ gistId, description, files, filesToDelete }) => {
+      const fileUpdates: Record<string, { content: string } | null> = {}
+      if (files) Object.assign(fileUpdates, files)
+      if (filesToDelete) {
+        for (const name of filesToDelete) fileUpdates[name] = null
+      }
+      const { data } = await octokit.rest.gists.update({
+        gist_id: gistId,
+        description,
+        files: fileUpdates as Record<string, { content: string }>,
+      })
+      return {
+        id: data.id,
+        description: data.description,
+        url: data.html_url,
+        files: Object.keys(data.files ?? {}),
+      }
+    },
+  })
+
+export const deleteGist = (octokit: Octokit, { needsApproval = true }: ToolOptions = {}) =>
+  tool({
+    description: 'Delete a gist permanently',
+    needsApproval,
+    inputSchema: z.object({
+      gistId: z.string().describe('Gist ID to delete'),
+    }),
+    execute: async ({ gistId }) => {
+      await octokit.rest.gists.delete({ gist_id: gistId })
+      return { deleted: true, gistId }
+    },
+  })
+
+export const createGistComment = (octokit: Octokit, { needsApproval = true }: ToolOptions = {}) =>
+  tool({
+    description: 'Add a comment to a gist',
+    needsApproval,
+    inputSchema: z.object({
+      gistId: z.string().describe('Gist ID'),
+      body: z.string().describe('Comment text (supports Markdown)'),
+    }),
+    execute: async ({ gistId, body }) => {
+      const { data } = await octokit.rest.gists.createComment({ gist_id: gistId, body })
+      return {
+        id: data.id,
+        url: data.url,
+        body: data.body,
+        author: data.user?.login,
+        createdAt: data.created_at,
+      }
+    },
+  })

--- a/packages/github-tools/src/tools/workflows.ts
+++ b/packages/github-tools/src/tools/workflows.ts
@@ -1,0 +1,196 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+import type { Octokit, ToolOptions } from '../types'
+
+export const listWorkflows = (octokit: Octokit) =>
+  tool({
+    description: 'List GitHub Actions workflows in a repository',
+    inputSchema: z.object({
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      perPage: z.number().optional().default(30).describe('Number of results to return (max 100)'),
+      page: z.number().optional().default(1).describe('Page number for pagination'),
+    }),
+    execute: async ({ owner, repo, perPage, page }) => {
+      const { data } = await octokit.rest.actions.listRepoWorkflows({ owner, repo, per_page: perPage, page })
+      return {
+        totalCount: data.total_count,
+        workflows: data.workflows.map(wf => ({
+          id: wf.id,
+          name: wf.name,
+          path: wf.path,
+          state: wf.state,
+          url: wf.html_url,
+          createdAt: wf.created_at,
+          updatedAt: wf.updated_at,
+        })),
+      }
+    },
+  })
+
+export const listWorkflowRuns = (octokit: Octokit) =>
+  tool({
+    description: 'List workflow runs for a repository, optionally filtered by workflow, branch, status, or event',
+    inputSchema: z.object({
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      workflowId: z.union([z.string(), z.number()]).optional().describe('Workflow ID or filename (e.g. "ci.yml") to filter by'),
+      branch: z.string().optional().describe('Branch name to filter by'),
+      event: z.string().optional().describe('Event type to filter by (e.g. "push", "pull_request")'),
+      status: z.enum(['completed', 'action_required', 'cancelled', 'failure', 'neutral', 'skipped', 'stale', 'success', 'timed_out', 'in_progress', 'queued', 'requested', 'waiting', 'pending']).optional().describe('Status to filter by'),
+      perPage: z.number().optional().default(30).describe('Number of results to return (max 100)'),
+      page: z.number().optional().default(1).describe('Page number for pagination'),
+    }),
+    execute: async ({ owner, repo, workflowId, branch, event, status, perPage, page }) => {
+      const params: Record<string, unknown> = { owner, repo, per_page: perPage, page }
+      if (branch) params.branch = branch
+      if (event) params.event = event
+      if (status) params.status = status
+
+      const { data } = workflowId
+        ? await octokit.rest.actions.listWorkflowRuns({ owner, repo, workflow_id: workflowId, per_page: perPage, page, ...branch && { branch }, ...event && { event }, ...status && { status } })
+        : await octokit.rest.actions.listWorkflowRunsForRepo({ owner, repo, per_page: perPage, page, ...branch && { branch }, ...event && { event }, ...status && { status } })
+
+      return {
+        totalCount: data.total_count,
+        runs: data.workflow_runs.map(run => ({
+          id: run.id,
+          name: run.name,
+          status: run.status,
+          conclusion: run.conclusion,
+          branch: run.head_branch,
+          event: run.event,
+          url: run.html_url,
+          actor: run.actor?.login,
+          createdAt: run.created_at,
+          updatedAt: run.updated_at,
+          runNumber: run.run_number,
+          runAttempt: run.run_attempt,
+        })),
+      }
+    },
+  })
+
+export const getWorkflowRun = (octokit: Octokit) =>
+  tool({
+    description: 'Get details of a specific workflow run including status, timing, and trigger info',
+    inputSchema: z.object({
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      runId: z.number().describe('Workflow run ID'),
+    }),
+    execute: async ({ owner, repo, runId }) => {
+      const { data } = await octokit.rest.actions.getWorkflowRun({ owner, repo, run_id: runId })
+      return {
+        id: data.id,
+        name: data.name,
+        status: data.status,
+        conclusion: data.conclusion,
+        branch: data.head_branch,
+        sha: data.head_sha,
+        event: data.event,
+        url: data.html_url,
+        actor: data.actor?.login,
+        runNumber: data.run_number,
+        runAttempt: data.run_attempt,
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+        runStartedAt: data.run_started_at,
+      }
+    },
+  })
+
+export const listWorkflowJobs = (octokit: Octokit) =>
+  tool({
+    description: 'List jobs for a workflow run, including step-level status and timing',
+    inputSchema: z.object({
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      runId: z.number().describe('Workflow run ID'),
+      filter: z.enum(['latest', 'all']).optional().default('latest').describe('Filter by the latest attempt or all attempts'),
+      perPage: z.number().optional().default(30).describe('Number of results to return (max 100)'),
+      page: z.number().optional().default(1).describe('Page number for pagination'),
+    }),
+    execute: async ({ owner, repo, runId, filter, perPage, page }) => {
+      const { data } = await octokit.rest.actions.listJobsForWorkflowRun({ owner, repo, run_id: runId, filter, per_page: perPage, page })
+      return {
+        totalCount: data.total_count,
+        jobs: data.jobs.map(job => ({
+          id: job.id,
+          name: job.name,
+          status: job.status,
+          conclusion: job.conclusion,
+          url: job.html_url,
+          startedAt: job.started_at,
+          completedAt: job.completed_at,
+          runnerName: job.runner_name,
+          steps: job.steps?.map(step => ({
+            name: step.name,
+            status: step.status,
+            conclusion: step.conclusion,
+            number: step.number,
+            startedAt: step.started_at,
+            completedAt: step.completed_at,
+          })),
+        })),
+      }
+    },
+  })
+
+export const triggerWorkflow = (octokit: Octokit, { needsApproval = true }: ToolOptions = {}) =>
+  tool({
+    description: 'Trigger a workflow via workflow_dispatch event',
+    needsApproval,
+    inputSchema: z.object({
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      workflowId: z.union([z.string(), z.number()]).describe('Workflow ID or filename (e.g. "deploy.yml")'),
+      ref: z.string().describe('Git ref (branch or tag) to run the workflow on'),
+      inputs: z.record(z.string(), z.string()).optional().describe('Input parameters defined in the workflow_dispatch trigger'),
+    }),
+    execute: async ({ owner, repo, workflowId, ref, inputs }) => {
+      await octokit.rest.actions.createWorkflowDispatch({
+        owner,
+        repo,
+        workflow_id: workflowId,
+        ref,
+        inputs,
+      })
+      return { triggered: true, workflowId, ref }
+    },
+  })
+
+export const cancelWorkflowRun = (octokit: Octokit, { needsApproval = true }: ToolOptions = {}) =>
+  tool({
+    description: 'Cancel an in-progress workflow run',
+    needsApproval,
+    inputSchema: z.object({
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      runId: z.number().describe('Workflow run ID to cancel'),
+    }),
+    execute: async ({ owner, repo, runId }) => {
+      await octokit.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId })
+      return { cancelled: true, runId }
+    },
+  })
+
+export const rerunWorkflowRun = (octokit: Octokit, { needsApproval = true }: ToolOptions = {}) =>
+  tool({
+    description: 'Re-run a workflow run, optionally only the failed jobs',
+    needsApproval,
+    inputSchema: z.object({
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      runId: z.number().describe('Workflow run ID to re-run'),
+      onlyFailedJobs: z.boolean().optional().default(false).describe('Only re-run failed jobs instead of the entire workflow'),
+    }),
+    execute: async ({ owner, repo, runId, onlyFailedJobs }) => {
+      if (onlyFailedJobs) {
+        await octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: runId })
+      } else {
+        await octokit.rest.actions.reRunWorkflow({ owner, repo, run_id: runId })
+      }
+      return { rerun: true, runId, onlyFailedJobs }
+    },
+  })


### PR DESCRIPTION
## Gists

- Added 7 gist tools: `listGists`, `getGist`, `listGistComments`, `createGist`, `updateGist`, `deleteGist`, `createGistComment`
- Read-only gist tools added to `repo-explorer` preset
- All gist tools added to `maintainer` preset
- Write tools gated with `requireApproval` by default

## Workflows

- Added 7 workflow tools: `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`
- Read-only workflow tools added to `repo-explorer` preset
- All workflow tools added to `maintainer` preset
- New `ci-ops` preset with all 7 workflow tools plus `getRepository`, `listBranches`, `listCommits`, `getCommit`
- Agent instructions added for the `ci-ops` preset
- Updated token permissions matrix with Actions column and `ci-ops` row