### PR TITLE
docs: fix optional token type and add toolpick integration

### DIFF
--- a/.changeset/docs-toolpick-readme.md
+++ b/.changeset/docs-toolpick-readme.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": patch
+---
+
+Document optional `token` (defaults to `process.env.GITHUB_TOKEN`) and add toolpick integration examples in the package README.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,31 @@ Write tools: `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `add
 
 All other tools are read-only and never require approval.
 
+## Tool Selection with toolpick
+
+With dozens of tools, context window usage adds up. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step so the model sees what it needs:
+
+```ts
+import { createGithubTools } from '@github-tools/sdk'
+import { createToolIndex } from 'toolpick'
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+const tools = createGithubTools()
+const index = createToolIndex(tools, {
+  embeddingModel: openai.embeddingModel('text-embedding-3-small'),
+})
+
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prepareStep: index.prepareStep(),
+  prompt: 'List open PRs on vercel/ai and summarize them.',
+})
+```
+
+Each step, toolpick picks the best ~5 tools using keyword + semantic search. All tools remain callable — only the visible set changes. See [toolpick docs](https://github.com/pontusab/toolpick) for LLM re-ranking, caching, and model-driven discovery options.
+
 ## Available Tools
 
 ### Repository
@@ -194,7 +219,7 @@ Returns an object of tools, ready to spread into `tools` of any AI SDK call.
 
 ```ts
 type GithubToolsOptions = {
-  token: string
+  token?: string // defaults to process.env.GITHUB_TOKEN
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   preset?: GithubToolPreset | GithubToolPreset[]
 }

--- a/apps/docs/content/docs/2.guide/6.examples.md
+++ b/apps/docs/content/docs/2.guide/6.examples.md
@@ -121,6 +121,40 @@ const { text } = await generateText({
 })
 ```
 
+## Reduce tool context with toolpick
+
+When using many tools, the model sees all tool definitions on every step — eating tokens and increasing latency. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step using keyword + semantic search:
+
+```ts [with-toolpick.ts]
+import { createGithubTools } from '@github-tools/sdk'
+import { createToolIndex } from 'toolpick'
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+const tools = createGithubTools()
+const index = createToolIndex(tools, {
+  embeddingModel: openai.embeddingModel('text-embedding-3-small'),
+})
+
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prepareStep: index.prepareStep(),
+  prompt: 'Check if the CI is passing on the main branch of vercel/ai.',
+})
+```
+
+Each step, toolpick picks the best ~5 tools. All tools remain callable — only the visible set changes. Add a `rerankerModel` for maximum accuracy on ambiguous queries:
+
+```ts [with-reranking.ts]
+const index = createToolIndex(tools, {
+  embeddingModel: openai.embeddingModel('text-embedding-3-small'),
+  rerankerModel: openai('gpt-4o-mini'),
+})
+```
+
+See [toolpick docs](https://github.com/pontusab/toolpick) for caching, description enrichment, and model-driven discovery options.
+
 ## Choose the right pattern
 
 | Pattern | Entry point | Best for |

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -114,6 +114,31 @@ Write tools: `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `add
 
 All other tools are read-only and never require approval.
 
+## Tool Selection with toolpick
+
+With dozens of tools, context window usage adds up. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step so the model sees what it needs:
+
+```ts
+import { createGithubTools } from '@github-tools/sdk'
+import { createToolIndex } from 'toolpick'
+import { generateText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+
+const tools = createGithubTools()
+const index = createToolIndex(tools, {
+  embeddingModel: openai.embeddingModel('text-embedding-3-small'),
+})
+
+const result = await generateText({
+  model: openai('gpt-4o'),
+  tools,
+  prepareStep: index.prepareStep(),
+  prompt: 'List open PRs on vercel/ai and summarize them.',
+})
+```
+
+Each step, toolpick picks the best ~5 tools using keyword + semantic search. All tools remain callable — only the visible set changes. See [toolpick docs](https://github.com/pontusab/toolpick) for LLM re-ranking, caching, and model-driven discovery options.
+
 ## Available Tools
 
 ### Repository
@@ -194,7 +219,7 @@ Returns an object of tools, ready to spread into `tools` of any AI SDK call.
 
 ```ts
 type GithubToolsOptions = {
-  token: string
+  token?: string // defaults to process.env.GITHUB_TOKEN
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   preset?: GithubToolPreset | GithubToolPreset[]
 }


### PR DESCRIPTION
- Fixed `token: string` → `token?: string` in both README type definitions to match the actual source type
- Added toolpick integration section to both READMEs and the docs examples page