### PR TITLE
feat: add per-tool overrides

### DIFF
--- a/.changeset/add-tool-overrides.md
+++ b/.changeset/add-tool-overrides.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Add per-tool `overrides` option to `createGithubTools` for customizing tool behavior (description, title, needsApproval, etc.) without changing the underlying implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,10 @@ export const myTool = (token: string, { needsApproval = true }: ToolOptions = {}
 - **Standard**: `createGithubAgent()` → `ToolLoopAgent` — supports `requireApproval` for human-in-the-loop
 - **Durable**: `createDurableGithubAgent()` → `DurableAgent` — crash-safe, retryable; `requireApproval` is accepted but currently ignored
 
+### Tool Overrides
+
+`createGithubTools` accepts an `overrides` option for per-tool customization (description, title, needsApproval, etc.) without changing the tool's implementation. `execute`, `inputSchema`, and `outputSchema` cannot be overridden. The `ToolOverrides` type is re-exported for consumers.
+
 ### Presets
 
 Five presets (`code-review`, `issue-triage`, `repo-explorer`, `ci-ops`, `maintainer`) defined in `src/index.ts` as tool name arrays, with matching system prompts in `src/agents.ts`. Composable via arrays.

--- a/apps/docs/content/docs/2.guide/3.approval-control.md
+++ b/apps/docs/content/docs/2.guide/3.approval-control.md
@@ -94,6 +94,21 @@ const tools = createGithubTools({
 | `cancelWorkflowRun` | High | Always require approval |
 | `rerunWorkflowRun` | Medium | Require in production repos |
 
+## Override approval per tool
+
+You can also set `needsApproval` via the [`overrides`](/api/reference#tool-overrides) option, which supports all AI SDK tool properties:
+
+```ts [override-approval.ts]
+createGithubTools({
+  overrides: {
+    addIssueComment: { needsApproval: false },
+    mergePullRequest: { needsApproval: true },
+  },
+})
+```
+
+When both `requireApproval` and `overrides` set `needsApproval` for the same tool, the `overrides` value wins (it is applied last).
+
 ::warning
 Approval is one safety layer, not the only one. Combine it with least-privilege [token scopes](/guide/token-permissions) and narrow [presets](/guide/presets).
 ::

--- a/apps/docs/content/docs/3.api/2.reference.md
+++ b/apps/docs/content/docs/3.api/2.reference.md
@@ -28,6 +28,7 @@ Returns a record of AI SDK tools you can pass to `generateText` or `streamText`.
 type GithubToolsOptions = {
   token?: string
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
+  overrides?: Partial<Record<string, ToolOverrides>>
   preset?: GithubToolPreset | GithubToolPreset[]
 }
 
@@ -59,6 +60,41 @@ const tools = createGithubTools({
 ```
 
 See [Scope with presets](/guide/presets) for preset details and [Control write safety](/guide/approval-control) for approval options.
+
+### Tool overrides
+
+The `overrides` option lets you customize any AI SDK [`tool()`](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling) property on a per-tool basis, keyed by tool name:
+
+```ts [overrides.ts]
+import { createGithubTools } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  overrides: {
+    deleteGist: { needsApproval: false },
+    listIssues: { description: 'List bugs for the current sprint' },
+  },
+})
+```
+
+```ts [type.ts]
+import type { ToolOverrides } from '@github-tools/sdk'
+```
+
+Supported override properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `description` | `string` | Custom tool description for the model |
+| `title` | `string` | Human-readable title |
+| `strict` | `boolean` | Strict mode for input generation |
+| `needsApproval` | `boolean \| function` | Gate execution behind approval |
+| `providerOptions` | `ProviderOptions` | Provider-specific metadata |
+| `onInputStart` | `function` | Callback when argument streaming starts |
+| `onInputDelta` | `function` | Callback on each streaming delta |
+| `onInputAvailable` | `function` | Callback when full input is available |
+| `toModelOutput` | `function` | Custom mapping of tool result to model output |
+
+Core properties (`execute`, `inputSchema`, `outputSchema`) cannot be overridden.
 
 ## `createGithubAgent(options)`
 

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -117,6 +117,30 @@ Write tools: `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `add
 
 All other tools are read-only and never require approval.
 
+### Tool overrides
+
+The `overrides` option lets you customize any AI SDK [`tool()`](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling) property on a per-tool basis, keyed by tool name.
+
+```ts
+import type { ToolOverrides } from "@github-tools/sdk";
+```
+
+Supported override properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `description` | `string` | Custom tool description for the model |
+| `title` | `string` | Human-readable title |
+| `strict` | `boolean` | Strict mode for input generation |
+| `needsApproval` | `boolean \| function` | Gate execution behind approval |
+| `providerOptions` | `ProviderOptions` | Provider-specific metadata |
+| `onInputStart` | `function` | Callback when argument streaming starts |
+| `onInputDelta` | `function` | Callback on each streaming delta |
+| `onInputAvailable` | `function` | Callback when full input is available |
+| `toModelOutput` | `function` | Custom mapping of tool result to model output |
+
+Core properties (`execute`, `inputSchema`, `outputSchema`) cannot be overridden.
+
 ## Tool Selection with toolpick
 
 With dozens of tools, context window usage adds up. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step so the model sees what it needs:

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -5,6 +5,7 @@ import { searchCode, searchRepositories } from './tools/search'
 import { listCommits, getCommit, getBlame } from './tools/commits'
 import { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 import { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
+import type { ToolOverrides } from './types'
 
 export type GithubWriteToolName =
   | 'createBranch'
@@ -104,6 +105,22 @@ export type GithubToolsOptions = {
   token?: string
   requireApproval?: ApprovalConfig
   /**
+   * Per-tool overrides for customizing tool behavior (description, title, needsApproval, etc.)
+   * without changing the underlying implementation. `execute`, `inputSchema`, and `outputSchema`
+   * cannot be overridden.
+   *
+   * @example
+   * ```ts
+   * createGithubTools({
+   *   overrides: {
+   *     deleteGist: { needsApproval: false },
+   *     listIssues: { description: 'List bugs for the current sprint' },
+   *   }
+   * })
+   * ```
+   */
+  overrides?: Partial<Record<string, ToolOverrides>>
+  /**
    * Restrict the returned tools to a predefined preset.
    * Omit to get all tools.
    *
@@ -164,7 +181,7 @@ function resolvePresetTools(preset: GithubToolPreset | GithubToolPreset[]): Set<
  * })
  * ```
  */
-export function createGithubTools({ token, requireApproval = true, preset }: GithubToolsOptions = {}) {
+export function createGithubTools({ token, requireApproval = true, preset, overrides }: GithubToolsOptions = {}) {
   const resolvedToken = token || process.env.GITHUB_TOKEN
   if (!resolvedToken) {
     throw new Error('GitHub token is required. Pass it as `token` or set the GITHUB_TOKEN environment variable.')
@@ -217,6 +234,14 @@ export function createGithubTools({ token, requireApproval = true, preset }: Git
     rerunWorkflowRun: rerunWorkflowRun(resolvedToken, approval('rerunWorkflowRun')),
   }
 
+  if (overrides) {
+    for (const [name, toolOverrides] of Object.entries(overrides)) {
+      if (name in allTools && toolOverrides) {
+        (allTools as Record<string, any>)[name] = { ...allTools[name as keyof typeof allTools], ...toolOverrides }
+      }
+    }
+  }
+
   if (!allowed) return allTools
 
   return Object.fromEntries(
@@ -235,6 +260,6 @@ export { searchCode, searchRepositories } from './tools/search'
 export { listCommits, getCommit, getBlame } from './tools/commits'
 export { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 export { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
-export type { Octokit, ToolOptions } from './types'
+export type { Octokit, ToolOptions, ToolOverrides } from './types'
 export { createGithubAgent } from './agents'
 export type { CreateGithubAgentOptions } from './agents'

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -237,7 +237,8 @@ export function createGithubTools({ token, requireApproval = true, preset, overr
   if (overrides) {
     for (const [name, toolOverrides] of Object.entries(overrides)) {
       if (name in allTools && toolOverrides) {
-        (allTools as Record<string, any>)[name] = { ...allTools[name as keyof typeof allTools], ...toolOverrides }
+        const key = name as keyof typeof allTools
+        Object.assign(allTools, { [key]: { ...allTools[key], ...toolOverrides } })
       }
     }
   }

--- a/packages/github-tools/src/types.ts
+++ b/packages/github-tools/src/types.ts
@@ -1,3 +1,24 @@
+import type { Tool } from 'ai'
+
 export type { Octokit } from 'octokit'
 
 export type ToolOptions = { needsApproval?: boolean }
+
+/**
+ * Per-tool overrides for customizing tool behavior without changing the underlying implementation.
+ * Properties like `execute`, `inputSchema`, and `outputSchema` are intentionally excluded.
+ */
+export type ToolOverrides = Partial<
+  Pick<
+    Tool,
+    | 'description'
+    | 'needsApproval'
+    | 'onInputAvailable'
+    | 'onInputDelta'
+    | 'onInputStart'
+    | 'providerOptions'
+    | 'strict'
+    | 'title'
+    | 'toModelOutput'
+  >
+>


### PR DESCRIPTION
- Added `ToolOverrides` type (`Partial<Pick<Tool, ...>>`) — allows customizing description, title, needsApproval, toModelOutput, and other AI SDK tool properties per tool
- Added `overrides` option to `createGithubTools`
- `execute`, `inputSchema`, and `outputSchema` cannot be overridden
- Documented in README, AGENTS.md, API reference, and approval control docs