### PR TITLE
feat(sdk): adding support for adding coauthors in tool config

### DIFF
--- a/.changeset/nice-tigers-mix.md
+++ b/.changeset/nice-tigers-mix.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Adding support for coauthors on code authoring tools

--- a/apps/docs/content/docs/2.guide/4.commit-attribution.md
+++ b/apps/docs/content/docs/2.guide/4.commit-attribution.md
@@ -1,0 +1,126 @@
+---
+
+title: Commit Attribution
+description: Configure author, committer, and co-authorship for commits created by GitHub tools.
+path: /guide/commit-attribution
+links:
+
+- label: API reference
+icon: i-lucide-braces
+to: /api/reference
+color: neutral
+variant: subtle
+- label: Token permissions
+icon: i-lucide-key-round
+to: /guide/token-permissions
+color: neutral
+variant: subtle
+
+---
+
+When tools like `createOrUpdateFile` or `mergePullRequest` create commits, you can control how those commits are attributed. This is useful for AI agents, bots, and automated workflows where you want clear accountability.
+
+## AI assistant prompt (commit attribution)
+
+```txt [Prompt]
+Configure commit attribution in this @github-tools/sdk project: use coAuthors on createGithubTools or createGithubAgent to credit the bot or AI assistant on commits while keeping the human user as the primary author. See https://github-tools.com/guide/commit-attribution.
+```
+
+## Understanding Git attribution
+
+Git tracks three types of attribution on commits:
+
+
+| Role          | Description                       | Set by                                     |
+| ------------- | --------------------------------- | ------------------------------------------ |
+| **Author**    | The person who wrote the code     | `author` option or authenticated user      |
+| **Committer** | The person who applied the commit | `committer` option or authenticated user   |
+| **Co-author** | Additional contributors           | `Co-authored-by` trailer in commit message |
+
+
+When using GitHub's API (which this SDK does), the default author and committer is the authenticated user (the owner of the token).
+
+## Add co-authors to commits
+
+The most common pattern is keeping the human as author while crediting a bot or AI assistant as co-author:
+
+```ts [co-authors.ts]
+import { createGithubTools } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  token: userToken,
+  coAuthors: [
+    { name: 'my-bot[bot]', email: '12345+my-bot[bot]@users.noreply.github.com' }
+  ]
+})
+```
+
+This appends a `Co-authored-by` trailer to every commit message:
+
+```txt [commit-message.txt]
+Update README.md
+
+Co-authored-by: my-bot[bot] <12345+my-bot[bot]@users.noreply.github.com>
+```
+
+GitHub recognizes these trailers and displays co-authors in the commit UI.
+
+## Override author and committer
+
+You can also override the author and committer identity:
+
+```ts [author-override.ts]
+import { createGithubTools } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  token: botToken,
+  author: { name: 'Jane Doe', email: 'jane@example.com' },
+  committer: { name: 'my-bot[bot]', email: '12345+my-bot[bot]@users.noreply.github.com' }
+})
+```
+
+::warning
+The GitHub API has restrictions on author/committer overrides. The token owner must have push access, and some organizations restrict which identities can be used.
+::
+
+## Use with agents
+
+The same options work with `createGithubAgent` and `createDurableGithubAgent`:
+
+```ts [agent-attribution.ts]
+import { createGithubAgent } from '@github-tools/sdk'
+
+const agent = createGithubAgent({
+  model: 'anthropic/claude-sonnet-4.6',
+  preset: 'maintainer',
+  coAuthors: [
+    { name: 'my-bot[bot]', email: '12345+my-bot[bot]@users.noreply.github.com' }
+  ]
+})
+```
+
+## Commit signing
+
+Commits created through the GitHub API are **automatically signed** by GitHub's web-flow signing key. This means:
+
+- Commits show as "Verified" in the GitHub UI
+- They pass branch protection rules requiring signed commits
+- No GPG or SSH key configuration needed
+
+This is different from local git commits, which require explicit GPG or SSH signing configuration.
+
+## Attribution patterns
+
+
+| Scenario                     | Author           | Committer       | Co-author |
+| ---------------------------- | ---------------- | --------------- | --------- |
+| Human using AI assistant     | Human (default)  | Human (default) | Bot       |
+| Bot acting on behalf of user | Human (override) | Bot (override)  | —         |
+| Fully automated CI           | Bot (default)    | Bot (default)   | —         |
+
+
+## External references
+
+- [GitHub: Creating a commit with multiple authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors)
+- [GitHub: About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+

--- a/apps/docs/content/docs/3.api/2.reference.md
+++ b/apps/docs/content/docs/3.api/2.reference.md
@@ -8,14 +8,14 @@ links:
     to: /api/tools-catalog
     color: neutral
     variant: subtle
+  - label: Commit attribution
+    icon: i-lucide-git-commit-horizontal
+    to: /guide/commit-attribution
+    color: neutral
+    variant: subtle
   - label: Durable workflows
     icon: i-lucide-refresh-cw
     to: /guide/durable-workflows
-    color: neutral
-    variant: subtle
-  - label: See examples
-    icon: i-lucide-code
-    to: /guide/examples
     color: neutral
     variant: subtle
 ---
@@ -30,6 +30,14 @@ type GithubToolsOptions = {
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   overrides?: Partial<Record<string, ToolOverrides>>
   preset?: GithubToolPreset | GithubToolPreset[]
+  author?: CommitIdentity
+  committer?: CommitIdentity
+  coAuthors?: CommitIdentity[]
+}
+
+type CommitIdentity = {
+  name: string
+  email: string
 }
 
 type GithubToolPreset =
@@ -96,6 +104,31 @@ Supported override properties:
 
 Core properties (`execute`, `inputSchema`, `outputSchema`) cannot be overridden.
 
+### Commit attribution
+
+The `author`, `committer`, and `coAuthors` options control how commits are attributed when using `createOrUpdateFile` or `mergePullRequest`:
+
+```ts [attribution.ts]
+import { createGithubTools } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  token: 'github_pat_xxxxxxxxxxxx',
+  coAuthors: [
+    { name: 'my-bot[bot]', email: '12345+my-bot[bot]@users.noreply.github.com' }
+  ]
+})
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `author` | `CommitIdentity` | The person who wrote the code. Falls back to the authenticated user. |
+| `committer` | `CommitIdentity` | The person who applied the commit. Falls back to the authenticated user. |
+| `coAuthors` | `CommitIdentity[]` | Additional contributors. Added as `Co-authored-by` trailers to commit messages. |
+
+Commits made via the GitHub API are **automatically signed** by GitHub's web-flow key, passing branch protection rules that require signed commits.
+
+See [Commit attribution](/guide/commit-attribution) for detailed guidance.
+
 ## `createGithubAgent(options)`
 
 Returns a `ToolLoopAgent` with GitHub tools and system instructions pre-configured. The token is also auto-detected from `GITHUB_TOKEN`:
@@ -107,6 +140,9 @@ type GithubAgentOptions = {
   preset?: GithubToolPreset | GithubToolPreset[]
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   system?: string
+  author?: CommitIdentity
+  committer?: CommitIdentity
+  coAuthors?: CommitIdentity[]
 }
 ```
 

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -141,6 +141,31 @@ Supported override properties:
 
 Core properties (`execute`, `inputSchema`, `outputSchema`) cannot be overridden.
 
+## Commit Attribution
+
+Control how commits are attributed when using `createOrUpdateFile` or `mergePullRequest`:
+
+```ts
+import { createGithubTools } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  token,
+  coAuthors: [
+    { name: 'my-bot[bot]', email: '12345+my-bot[bot]@users.noreply.github.com' }
+  ]
+})
+```
+
+This appends `Co-authored-by` trailers to commit messages, crediting additional contributors.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `author` | `{ name: string, email: string }` | The person who wrote the code. Falls back to the authenticated user. |
+| `committer` | `{ name: string, email: string }` | The person who applied the commit. Falls back to the authenticated user. |
+| `coAuthors` | `{ name: string, email: string }[]` | Additional contributors added as `Co-authored-by` trailers. |
+
+Commits made via the GitHub API are **automatically signed** by GitHub's web-flow key, passing branch protection rules that require signed commits.
+
 ## Tool Selection with toolpick
 
 With dozens of tools, context window usage adds up. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step so the model sees what it needs:

--- a/packages/github-tools/src/agents.ts
+++ b/packages/github-tools/src/agents.ts
@@ -2,6 +2,7 @@ import { ToolLoopAgent } from 'ai'
 import type { ToolLoopAgentSettings } from 'ai'
 import { createGithubTools } from './index'
 import type { GithubToolPreset, ApprovalConfig } from './index'
+import type { CommitIdentity } from './types'
 
 const SHARED_RULES = `When a tool execution is denied by the user, do not retry it. Briefly acknowledge the decision and move on.`
 
@@ -99,6 +100,21 @@ export type CreateGithubAgentOptions = AgentOptions & {
   requireApproval?: ApprovalConfig
   instructions?: string
   additionalInstructions?: string
+  /**
+   * Default author for commit-creating tools.
+   * Falls back to the authenticated user when omitted.
+   */
+  author?: CommitIdentity
+  /**
+   * Default committer for commit-creating tools.
+   * Falls back to the authenticated user when omitted.
+   */
+  committer?: CommitIdentity
+  /**
+   * Co-authors to attribute on all commits.
+   * Added as "Co-authored-by" trailers to commit messages.
+   */
+  coAuthors?: CommitIdentity[]
 }
 
 /**
@@ -125,9 +141,12 @@ export function createGithubAgent({
   requireApproval,
   instructions,
   additionalInstructions,
+  author,
+  committer,
+  coAuthors,
   ...agentOptions
 }: CreateGithubAgentOptions) {
-  const tools = createGithubTools({ token, requireApproval, preset })
+  const tools = createGithubTools({ token, requireApproval, preset, author, committer, coAuthors })
 
   return new ToolLoopAgent({
     ...agentOptions,

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -5,7 +5,7 @@ import { searchCode, searchRepositories } from './tools/search'
 import { listCommits, getCommit, getBlame } from './tools/commits'
 import { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 import { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
-import type { ToolOverrides } from './types'
+import type { CommitIdentity, ToolOverrides } from './types'
 
 export type GithubWriteToolName =
   | 'createBranch'
@@ -134,6 +134,33 @@ export type GithubToolsOptions = {
    * ```
    */
   preset?: GithubToolPreset | GithubToolPreset[]
+  /**
+   * Default author for commit-creating tools.
+   * The author is the person who originally wrote the code.
+   * Falls back to the authenticated user when omitted.
+   */
+  author?: CommitIdentity
+  /**
+   * Default committer for commit-creating tools.
+   * The committer is the person who applied the commit.
+   * Falls back to the authenticated user when omitted.
+   */
+  committer?: CommitIdentity
+  /**
+   * Co-authors to attribute on all commits created by tools.
+   * Added as "Co-authored-by" trailers to commit messages.
+   *
+   * @example
+   * ```ts
+   * createGithubTools({
+   *   token,
+   *   coAuthors: [
+   *     { name: 'my-bot[bot]', email: '12345+my-bot[bot]@users.noreply.github.com' }
+   *   ]
+   * })
+   * ```
+   */
+  coAuthors?: CommitIdentity[]
 }
 
 function resolveApproval(toolName: GithubWriteToolName, config: ApprovalConfig): boolean {
@@ -181,7 +208,15 @@ function resolvePresetTools(preset: GithubToolPreset | GithubToolPreset[]): Set<
  * })
  * ```
  */
-export function createGithubTools({ token, requireApproval = true, preset, overrides }: GithubToolsOptions = {}) {
+export function createGithubTools({
+  token,
+  requireApproval = true,
+  preset,
+  overrides,
+  author,
+  committer,
+  coAuthors,
+}: GithubToolsOptions = {}) {
   const resolvedToken = token || process.env.GITHUB_TOKEN
   if (!resolvedToken) {
     throw new Error('GitHub token is required. Pass it as `token` or set the GITHUB_TOKEN environment variable.')
@@ -205,9 +240,9 @@ export function createGithubTools({ token, requireApproval = true, preset, overr
     createBranch: createBranch(resolvedToken, approval('createBranch')),
     forkRepository: forkRepository(resolvedToken, approval('forkRepository')),
     createRepository: createRepository(resolvedToken, approval('createRepository')),
-    createOrUpdateFile: createOrUpdateFile(resolvedToken, approval('createOrUpdateFile')),
+    createOrUpdateFile: createOrUpdateFile(resolvedToken, { ...approval('createOrUpdateFile'), author, committer, coAuthors }),
     createPullRequest: createPullRequest(resolvedToken, approval('createPullRequest')),
-    mergePullRequest: mergePullRequest(resolvedToken, approval('mergePullRequest')),
+    mergePullRequest: mergePullRequest(resolvedToken, { ...approval('mergePullRequest'), coAuthors }),
     addPullRequestComment: addPullRequestComment(resolvedToken, approval('addPullRequestComment')),
     listPullRequestFiles: listPullRequestFiles(resolvedToken),
     listPullRequestReviews: listPullRequestReviews(resolvedToken),
@@ -261,6 +296,6 @@ export { searchCode, searchRepositories } from './tools/search'
 export { listCommits, getCommit, getBlame } from './tools/commits'
 export { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 export { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
-export type { Octokit, ToolOptions, ToolOverrides } from './types'
+export type { CommitIdentity, CommitToolOptions, Octokit, ToolOptions, ToolOverrides } from './types'
 export { createGithubAgent } from './agents'
 export type { CreateGithubAgentOptions } from './agents'

--- a/packages/github-tools/src/tools/pull-requests.ts
+++ b/packages/github-tools/src/tools/pull-requests.ts
@@ -1,7 +1,12 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import { createOctokit } from '../client'
-import type { ToolOptions } from '../types'
+import type { CommitIdentity, ToolOptions } from '../types'
+import { composeCommitMessage } from './repository'
+
+export type MergeToolOptions = ToolOptions & {
+  coAuthors?: CommitIdentity[]
+}
 
 async function listPullRequestsStep({ token, owner, repo, state, perPage }: { token: string, owner: string, repo: string, state: 'open' | 'closed' | 'all', perPage: number }) {
   "use step"
@@ -100,15 +105,34 @@ export const createPullRequest = (token: string, { needsApproval = true }: ToolO
     execute: async args => createPullRequestStep({ token, ...args }),
   })
 
-async function mergePullRequestStep({ token, owner, repo, pullNumber, commitTitle, commitMessage, mergeMethod }: { token: string, owner: string, repo: string, pullNumber: number, commitTitle?: string, commitMessage?: string, mergeMethod: 'merge' | 'squash' | 'rebase' }) {
+async function mergePullRequestStep({
+  token,
+  owner,
+  repo,
+  pullNumber,
+  commitTitle,
+  commitMessage,
+  mergeMethod,
+  coAuthors,
+}: {
+  token: string
+  owner: string
+  repo: string
+  pullNumber: number
+  commitTitle?: string
+  commitMessage?: string
+  mergeMethod: 'merge' | 'squash' | 'rebase'
+  coAuthors?: CommitIdentity[]
+}) {
   "use step"
   const octokit = createOctokit(token)
+  const finalMessage = composeCommitMessage(commitMessage ?? '', coAuthors) || undefined
   const { data } = await octokit.rest.pulls.merge({
     owner,
     repo,
     pull_number: pullNumber,
     commit_title: commitTitle,
-    commit_message: commitMessage,
+    commit_message: finalMessage,
     merge_method: mergeMethod,
   })
   return {
@@ -118,7 +142,7 @@ async function mergePullRequestStep({ token, owner, repo, pullNumber, commitTitl
   }
 }
 
-export const mergePullRequest = (token: string, { needsApproval = true }: ToolOptions = {}) =>
+export const mergePullRequest = (token: string, { needsApproval = true, coAuthors }: MergeToolOptions = {}) =>
   tool({
     description: 'Merge a pull request',
     needsApproval,
@@ -130,7 +154,7 @@ export const mergePullRequest = (token: string, { needsApproval = true }: ToolOp
       commitMessage: z.string().optional().describe('Extra detail to append to automatic commit message'),
       mergeMethod: z.enum(['merge', 'squash', 'rebase']).optional().default('merge').describe('Merge strategy'),
     }),
-    execute: async args => mergePullRequestStep({ token, ...args }),
+    execute: async args => mergePullRequestStep({ token, coAuthors, ...args }),
   })
 
 async function addPullRequestCommentStep({ token, owner, repo, pullNumber, body }: { token: string, owner: string, repo: string, pullNumber: number, body: string }) {

--- a/packages/github-tools/src/tools/repository.ts
+++ b/packages/github-tools/src/tools/repository.ts
@@ -11,7 +11,7 @@ export function composeCommitMessage(
   const trailers = coAuthors
     .map(({ name, email }) => `Co-authored-by: ${name} <${email}>`)
     .join('\n')
-  return `${message}\n\n${trailers}`
+  return message ? `${message}\n\n${trailers}` : trailers
 }
 
 async function getRepositoryStep({ token, owner, repo }: { token: string, owner: string, repo: string }) {

--- a/packages/github-tools/src/tools/repository.ts
+++ b/packages/github-tools/src/tools/repository.ts
@@ -1,7 +1,18 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import { createOctokit } from '../client'
-import type { ToolOptions } from '../types'
+import type { CommitIdentity, CommitToolOptions, ToolOptions } from '../types'
+
+export function composeCommitMessage(
+  message: string,
+  coAuthors?: CommitIdentity[]
+): string {
+  if (!coAuthors?.length) return message
+  const trailers = coAuthors
+    .map(({ name, email }) => `Co-authored-by: ${name} <${email}>`)
+    .join('\n')
+  return `${message}\n\n${trailers}`
+}
 
 async function getRepositoryStep({ token, owner, repo }: { token: string, owner: string, repo: string }) {
   "use step"
@@ -204,18 +215,45 @@ export const createRepository = (token: string, { needsApproval = true }: ToolOp
     execute: async args => createRepositoryStep({ token, ...args }),
   })
 
-async function createOrUpdateFileStep({ token, owner, repo, path, message, content, branch, sha }: { token: string, owner: string, repo: string, path: string, message: string, content: string, branch?: string, sha?: string }) {
+async function createOrUpdateFileStep({
+  token,
+  owner,
+  repo,
+  path,
+  message,
+  content,
+  branch,
+  sha,
+  author,
+  committer,
+  coAuthors,
+}: {
+  token: string
+  owner: string
+  repo: string
+  path: string
+  message: string
+  content: string
+  branch?: string
+  sha?: string
+  author?: CommitIdentity
+  committer?: CommitIdentity
+  coAuthors?: CommitIdentity[]
+}) {
   "use step"
   const octokit = createOctokit(token)
   const encoded = Buffer.from(content).toString('base64')
+  const finalMessage = composeCommitMessage(message, coAuthors)
   const { data } = await octokit.rest.repos.createOrUpdateFileContents({
     owner,
     repo,
     path,
-    message,
+    message: finalMessage,
     content: encoded,
     branch,
     sha,
+    author,
+    committer,
   })
   return {
     path: data.content?.path,
@@ -225,7 +263,10 @@ async function createOrUpdateFileStep({ token, owner, repo, path, message, conte
   }
 }
 
-export const createOrUpdateFile = (token: string, { needsApproval = true }: ToolOptions = {}) =>
+export const createOrUpdateFile = (
+  token: string,
+  { needsApproval = true, author, committer, coAuthors }: CommitToolOptions = {}
+) =>
   tool({
     description: 'Create or update a file in a GitHub repository. Provide the SHA when updating an existing file.',
     needsApproval,
@@ -238,5 +279,5 @@ export const createOrUpdateFile = (token: string, { needsApproval = true }: Tool
       branch: z.string().optional().describe('Branch to commit to (defaults to the default branch)'),
       sha: z.string().optional().describe('SHA of the file being replaced (required when updating an existing file)'),
     }),
-    execute: async args => createOrUpdateFileStep({ token, ...args }),
+    execute: async args => createOrUpdateFileStep({ token, author, committer, coAuthors, ...args }),
   })

--- a/packages/github-tools/src/types.ts
+++ b/packages/github-tools/src/types.ts
@@ -5,6 +5,35 @@ export type { Octokit } from 'octokit'
 export type ToolOptions = { needsApproval?: boolean }
 
 /**
+ * Identity for commit author or committer.
+ */
+export type CommitIdentity = {
+  name: string
+  email: string
+}
+
+/**
+ * Options for commit-creating tools (createOrUpdateFile, mergePullRequest).
+ */
+export type CommitToolOptions = ToolOptions & {
+  /**
+   * The author of the commit, person who wrote the code patch.
+   * Falls back to the authenticated user when omitted.
+   */
+  author?: CommitIdentity
+  /**
+   * The committer of the commit, person who applied the commit.
+   * Falls back to the authenticated user when omitted.
+   */
+  committer?: CommitIdentity
+  /**
+   * Co-authors to attribute on commits.
+   * Added as "Co-authored-by" trailers to commit messages.
+   */
+  coAuthors?: CommitIdentity[]
+}
+
+/**
  * Per-tool overrides for customizing tool behavior without changing the underlying implementation.
  * Properties like `execute`, `inputSchema`, and `outputSchema` are intentionally excluded.
  */

--- a/packages/github-tools/src/workflow.ts
+++ b/packages/github-tools/src/workflow.ts
@@ -4,6 +4,7 @@ import type { ToolSet, StepResult, FinishReason, LanguageModelUsage, LanguageMod
 import { createGithubTools } from './index'
 import { resolveInstructions } from './agents'
 import type { GithubToolPreset, ApprovalConfig } from './index'
+import type { CommitIdentity } from './types'
 
 /**
  * Result of {@link DurableGithubAgent.generate}.
@@ -124,6 +125,21 @@ export type CreateDurableGithubAgentOptions =
     requireApproval?: ApprovalConfig
     instructions?: string
     additionalInstructions?: string
+    /**
+     * Default author for commit-creating tools.
+     * Falls back to the authenticated user when omitted.
+     */
+    author?: CommitIdentity
+    /**
+     * Default committer for commit-creating tools.
+     * Falls back to the authenticated user when omitted.
+     */
+    committer?: CommitIdentity
+    /**
+     * Co-authors to attribute on all commits.
+     * Added as "Co-authored-by" trailers to commit messages.
+     */
+    coAuthors?: CommitIdentity[]
   }
 
 /**
@@ -179,9 +195,12 @@ export function createDurableGithubAgent({
   requireApproval,
   instructions,
   additionalInstructions,
+  author,
+  committer,
+  coAuthors,
   ...agentOptions
 }: CreateDurableGithubAgentOptions) {
-  const tools = createGithubTools({ token, requireApproval, preset })
+  const tools = createGithubTools({ token, requireApproval, preset, author, committer, coAuthors })
 
   const resolvedModel = typeof model === 'string' || typeof model === 'function'
     ? model
@@ -196,5 +215,5 @@ export function createDurableGithubAgent({
 }
 
 export { createGithubTools, createGithubAgent } from './index'
-export type { GithubTools, GithubToolsOptions, GithubToolPreset, GithubWriteToolName, ApprovalConfig, ToolOverrides } from './index'
+export type { CommitIdentity, CommitToolOptions, GithubTools, GithubToolsOptions, GithubToolPreset, GithubWriteToolName, ApprovalConfig, ToolOverrides } from './index'
 export type { CreateGithubAgentOptions } from './agents'


### PR DESCRIPTION
Adding support for coauthors on code authoring tools (write and commit) on the tool config. 

<img width="1332" height="831" alt="image" src="https://github.com/user-attachments/assets/3c43f108-8823-40ef-ad7b-be8cd316b963" />