### PR TITLE
fix(sdk): signed commits with GraphQL API

### DIFF
--- a/apps/docs/content/docs/2.guide/4.commit-attribution.md
+++ b/apps/docs/content/docs/2.guide/4.commit-attribution.md
@@ -101,13 +101,26 @@ const agent = createGithubAgent({
 
 ## Commit signing
 
-Commits created through the GitHub API are **automatically signed** by GitHub's web-flow signing key. This means:
+The SDK automatically attempts to create **signed commits** using GitHub's `createCommitOnBranch` GraphQL mutation. Whether commits are actually signed depends on your token type:
 
-- Commits show as "Verified" in the GitHub UI
-- They pass branch protection rules requiring signed commits
-- No GPG or SSH key configuration needed
+| Token Type | Commits Signed? |
+|------------|-----------------|
+| GitHub App installation token | Yes |
+| `GITHUB_TOKEN` (Actions) | Yes |
+| User OAuth token | No |
+| Personal Access Token (PAT) | No |
 
-This is different from local git commits, which require explicit GPG or SSH signing configuration.
+Signed commits show as "Verified" in the GitHub UI and satisfy branch protection rules requiring signed commits.
+
+::note
+If you set a custom `author` or `committer`, the SDK uses the REST API instead of GraphQL, and commits will not be signed. Co-authors work with both methods.
+::
+
+### Why some tokens don't produce signed commits
+
+GitHub only signs commits made by bots (GitHub Apps). When you authenticate as a user (OAuth or PAT), GitHub cannot sign on your behalf because it doesn't have access to your private signing key. The commit still works—it just won't be marked as "Verified."
+
+For more details, see [GitHub's commit signature verification docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
 
 ## Attribution patterns
 

--- a/packages/github-tools/src/tools/repository.ts
+++ b/packages/github-tools/src/tools/repository.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { tool } from 'ai'
 import { z } from 'zod'
 import { createOctokit } from '../client'
@@ -46,6 +47,12 @@ async function createCommitOnBranch(octokit: Octokit, input: {
     }
     throw error
   }
+}
+
+/** Compute the git blob SHA (SHA-1 of "blob {size}\0{content}") for a given string. */
+function gitBlobSha(content: string): string {
+  const buf = Buffer.from(content)
+  return createHash('sha1').update(`blob ${buf.length}\0`).update(buf).digest('hex')
 }
 
 export function composeCommitMessage(
@@ -304,7 +311,7 @@ async function createOrUpdateFileStep({
         headline, body,
         additions: [{ path, contents: Buffer.from(content).toString('base64') }],
       })
-      return { path, commitSha: result.commitSha, commitUrl: result.commitUrl }
+      return { path, sha: gitBlobSha(content), commitSha: result.commitSha, commitUrl: result.commitUrl }
     } catch (error) {
       if (error instanceof CreateCommitOnBranchError && error.reason === 'stale_data') {
         throw error

--- a/packages/github-tools/src/tools/repository.ts
+++ b/packages/github-tools/src/tools/repository.ts
@@ -1,7 +1,52 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import { createOctokit } from '../client'
-import type { CommitIdentity, CommitToolOptions, ToolOptions } from '../types'
+import type { CommitIdentity, CommitToolOptions, Octokit, ToolOptions } from '../types'
+
+const CREATE_COMMIT_ON_BRANCH_MUTATION = `
+  mutation CreateCommitOnBranch($input: CreateCommitOnBranchInput!) {
+    createCommitOnBranch(input: $input) { commit { oid url } }
+  }
+`
+
+type CreateCommitOnBranchErrorReason = 'stale_data' | 'forbidden' | 'unknown'
+class CreateCommitOnBranchError extends Error {
+  constructor(message: string, public reason: CreateCommitOnBranchErrorReason) {
+    super(message)
+    this.name = 'CreateCommitOnBranchError'
+  }
+}
+
+async function createCommitOnBranch(octokit: Octokit, input: {
+  owner: string
+  repo: string
+  branch: string
+  expectedHeadOid: string
+  headline: string
+  body?: string
+  additions?: Array<{ path: string; contents: string }>
+  deletions?: Array<{ path: string }>
+}): Promise<{ commitSha: string; commitUrl: string }> {
+  try {
+    const result = await octokit.graphql<{ createCommitOnBranch: { commit: { oid: string; url: string } } }>(CREATE_COMMIT_ON_BRANCH_MUTATION, {
+      input: {
+        branch: { repositoryNameWithOwner: `${input.owner}/${input.repo}`, branchName: input.branch },
+        expectedHeadOid: input.expectedHeadOid,
+        message: input.body ? { headline: input.headline, body: input.body } : { headline: input.headline },
+        fileChanges: { additions: input.additions, deletions: input.deletions },
+      },
+    })
+    return { commitSha: result.createCommitOnBranch.commit.oid, commitUrl: result.createCommitOnBranch.commit.url }
+  } catch (error: unknown) {
+    const err = error as { errors?: Array<{ type?: string }>; status?: number; message?: string }
+    const types = new Set((err.errors ?? []).map((e) => e.type))
+    if (types.has('STALE_DATA')) throw new CreateCommitOnBranchError(err.message ?? 'Stale data', 'stale_data')
+    if (types.has('FORBIDDEN') || types.has('INSUFFICIENT_SCOPES') || err.status === 401 || err.status === 403) {
+      throw new CreateCommitOnBranchError(err.message ?? 'Forbidden', 'forbidden')
+    }
+    throw error
+  }
+}
 
 export function composeCommitMessage(
   message: string,
@@ -242,6 +287,34 @@ async function createOrUpdateFileStep({
 }) {
   "use step"
   const octokit = createOctokit(token)
+
+  // optimistically try to create a signed commit via GraphQL API
+  if (!author && !committer) {
+    try {
+      const branchName = branch || (await octokit.rest.repos.get({ owner, repo })).data.default_branch
+      const { data: ref } = await octokit.rest.git.getRef({ owner, repo, ref: `heads/${branchName}` })
+
+      const fullMessage = composeCommitMessage(message, coAuthors)
+      const [headline, ...rest] = fullMessage.split('\n')
+      const body = rest.join('\n').replace(/^\n+/, '') || undefined
+
+      const result = await createCommitOnBranch(octokit, {
+        owner, repo, branch: branchName,
+        expectedHeadOid: ref.object.sha,
+        headline, body,
+        additions: [{ path, contents: Buffer.from(content).toString('base64') }],
+      })
+      return { path, commitSha: result.commitSha, commitUrl: result.commitUrl }
+    } catch (error) {
+      if (error instanceof CreateCommitOnBranchError && error.reason === 'stale_data') {
+        throw error
+      }
+      const msg = error instanceof Error ? error.message : String(error)
+      console.warn(`[github-tools] Signed commit failed, using REST API: ${msg}`)
+    }
+  }
+
+  // fallback to REST API
   const encoded = Buffer.from(content).toString('base64')
   const finalMessage = composeCommitMessage(message, coAuthors)
   const { data } = await octokit.rest.repos.createOrUpdateFileContents({


### PR DESCRIPTION
GitHub REST API does not support native commit signing – using GraphQL API optimistically, falling back to the REST API if there are errors (edge cases with file types, PR size, etc.). 

Also adding some documentation on edge cases wrt user OAuth tokens vs. installation tokens and custom author/committer attribution. 