### PR TITLE
ci: replace pull_request_target with pull_request and pin action SHAs

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,7 @@
 name: Label PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
     branches:

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,7 +1,7 @@
 name: Validate PR title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         id: lint_pr_title
         with:
           scopes: |
@@ -47,7 +47,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         # When the previous steps fail, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -66,7 +66,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: pr-title-lint-error
           message: |


### PR DESCRIPTION
## Summary

- Replaces `pull_request_target` with `pull_request` in `label-pr.yml` and `semantic-pull-request.yml` — eliminates the elevated-privilege trigger that could be abused if a `checkout` step were ever added
- Pins `amannn/action-semantic-pull-request` to commit SHA `48f256284bd46cdaab1048c3721360e808335d50` (v6) to prevent floating-tag supply chain attacks
- Pins `marocchino/sticky-pull-request-comment` to commit SHA `773744901bac0e8cbb5a0dc842800d45e9b2b405` (v2.9.4) for the same reason

Addresses security finding **VULN-10700**. Labelling and PR title validation are both read-only operations that work identically under `pull_request`.

## Test plan
- [ ] Open a test PR — label-pr workflow runs and applies the correct label
- [ ] Open a test PR with a non-conforming title — semantic-pull-request workflow posts the expected error comment