### PR TITLE
chore: upgrade pnpm to v11 and add minimumReleaseAge

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-shamefully-hoist=true

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "@changesets/cli": "^2.31.0",
     "turbo": "latest"
   },
-  "packageManager": "pnpm@10.30.2"
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,16 @@ packages:
 shamefullyHoist: true
 
 allowBuilds:
+  '@nestjs/core': false
+  '@parcel/watcher': false
+  '@swc/core': false
   better-sqlite3: true
+  cbor-extract: false
+  esbuild: false
+  maplibre-gl: false
+  sharp: false
+  unrs-resolver: false
+  vue-demi: false
 
 minimumReleaseAge: 2880
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,16 @@ shamefullyHoist: true
 
 allowBuilds:
   better-sqlite3: true
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  # Nuxt
+  - '@nuxt/*'
+  - '@nuxtjs/*'
+  - 'nuxt'
+  - 'nuxt-*'
+  # Vercel
+  - '@vercel/*'
+  - '@ai-sdk/*'
+  - 'ai'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,7 @@ packages:
   - 'examples/*'
   - 'packages/*'
 
-onlyBuiltDependencies:
-  - better-sqlite3
+shamefullyHoist: true
+
+allowBuilds:
+  better-sqlite3: true


### PR DESCRIPTION
## Summary

Two related changes to harden the supply chain and modernize the package manager setup.

### 1. Upgrade pnpm to v11

- Bump `packageManager` to `pnpm@11.1.3`
- Migrate `onlyBuiltDependencies` → unified `allowBuilds` map (required in v11)
- Move `shamefullyHoist` from `.npmrc` → `pnpm-workspace.yaml` (in v11, `.npmrc` only holds auth/registry)
- Delete `.npmrc` (now empty)

### 2. Add `minimumReleaseAge` to harden supply chain

Sets a 2-day minimum age (2880 minutes) before any newly published dependency can resolve. Mitigates compromised-package attacks where a malicious version is pushed and pulled into installs within hours.

Trusted-source allowlist exempts the Nuxt and Vercel ecosystems:
- `@nuxt/*`, `@nuxtjs/*`, `nuxt`, `nuxt-*`
- `@vercel/*`, `@ai-sdk/*`, `ai`

## Test plan
- [ ] `pnpm install` resolves cleanly with v11 (lockfile already verified via `--lockfile-only`, 2326 entries pass supply-chain policies)
- [ ] CI passes