### PR TITLE
docs: add eve GitHub agent guide to external references

### DIFF
--- a/apps/docs/content/docs/2.frameworks/1.eve.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve.md
@@ -194,6 +194,7 @@ Per-session GitHub tokens via eve connections (`auth: 'eve'`) are planned, backe
 
 ## External references
 
+- [How to build a GitHub agent with eve and GitHub Tools](https://vercel.com/kb/guide/github-agent-eve)
 - [eve documentation](https://eve.dev)
 - [Dynamic capabilities](https://eve.dev/docs/guides/dynamic-capabilities) (bundled with the `eve` package)
 - [Human-in-the-loop](https://eve.dev/docs/tools/human-in-the-loop)


### PR DESCRIPTION
Adds a link to the [How to build a GitHub agent with eve and GitHub Tools](https://vercel.com/kb/guide/github-agent-eve) guide under External references on the eve frameworks page.