### PR TITLE
feat: support async github token providers

### DIFF
--- a/.changeset/async-github-token-provider.md
+++ b/.changeset/async-github-token-provider.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": patch
+---
+
+Allow GitHub token inputs to be strings or async provider functions.

--- a/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
+++ b/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
@@ -90,6 +90,18 @@ const { text } = await generateText({
 ```
 ::
 
+The `token` option accepts a `GithubTokenInput`: either a token string or an async provider when the token should be minted lazily for each tool execution:
+
+```ts [lazy-token.ts]
+const tools = createGithubTools({
+  token: () => getToken('github/my-connector', {
+    subject: { type: 'app' },
+    scopes: ['contents:read', 'pull_requests:read'],
+  }),
+  preset: 'code-review',
+})
+```
+
 Call `getToken` per request rather than caching the string yourself — the SDK keeps an in-process cache and refreshes tokens as they approach expiry. For multi-tenant connectors (one connector installed on several GitHub organizations), pass `installationId` to target a specific installation.
 
 ### Why Connect over a PAT

--- a/apps/docs/content/docs/4.api/2.reference.md
+++ b/apps/docs/content/docs/4.api/2.reference.md
@@ -46,7 +46,7 @@ Returns a record of AI SDK tools you can pass to `generateText` or `streamText`.
 
 ```ts [types.ts]
 type GithubToolsOptions = {
-  token?: string
+  token?: GithubTokenInput
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   overrides?: Partial<Record<string, ToolOverrides>>
   preset?: GithubToolPreset | GithubToolPreset[]
@@ -54,6 +54,8 @@ type GithubToolsOptions = {
   committer?: CommitIdentity
   coAuthors?: CommitIdentity[]
 }
+
+type GithubTokenInput = string | (() => Promise<string>)
 
 type CommitIdentity = {
   name: string
@@ -156,7 +158,7 @@ Returns a `ToolLoopAgent` with GitHub tools and system instructions pre-configur
 ```ts [types.ts]
 type GithubAgentOptions = {
   model: string
-  token?: string
+  token?: GithubTokenInput
   preset?: GithubToolPreset | GithubToolPreset[]
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   system?: string
@@ -241,7 +243,7 @@ export default createGithubTools({
 
 ```ts [types-eve.ts]
 type EveGithubToolsOptions = {
-  token?: string
+  token?: GithubTokenInput
   preset?: GithubToolPreset | GithubToolPreset[]
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, EveApprovalValue>>
   overrides?: EveToolOverrides
@@ -260,14 +262,19 @@ type EveApprovalValue =
 
 Also exports individual eve tool factories (`listPullRequests()`, `createIssue()`, …) for one-tool-per-file layouts. Approval supports `once`, predicates, and eve helper passthrough — unlike the Workflow subpath, approval **is enforced** at runtime.
 
-## `createOctokit(token?)`
+## `createGithubTokenResolver(token?)`
+
+Normalizes a `GithubTokenInput` string, async token provider, or `process.env.GITHUB_TOKEN` fallback into a `() => Promise<string>` resolver. Throws immediately when no token input is passed and `GITHUB_TOKEN` is unset.
+
+## `createOctokit(resolveToken)`
 
 Returns a configured [`@octokit/rest`](https://github.com/octokit/rest.js) instance. Use this when you need lower-level GitHub API access or want to build custom tool factories:
 
 ```ts [custom-tool.ts]
-import { createOctokit } from '@github-tools/sdk'
+import { createGithubTokenResolver, createOctokit } from '@github-tools/sdk'
 
-const octokit = createOctokit()
+const resolveToken = createGithubTokenResolver()
+const octokit = await createOctokit(resolveToken)
 const { data } = await octokit.repos.get({ owner: 'HugoRCD', repo: 'github-tools' })
 ```
 

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -400,10 +400,12 @@ Returns an object of tools, ready to spread into `tools` of any AI SDK call.
 
 ```ts
 type GithubToolsOptions = {
-  token?: string // defaults to process.env.GITHUB_TOKEN
+  token?: GithubTokenInput // defaults to process.env.GITHUB_TOKEN
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   preset?: GithubToolPreset | GithubToolPreset[]
 }
+
+type GithubTokenInput = string | (() => Promise<string>)
 
 type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'ci-ops' | 'maintainer'
 ```
@@ -451,7 +453,7 @@ const stream = reviewer.stream({ prompt: 'Review PR #42 on vercel/ai' })
 | Option | Description |
 |---|---|
 | `model` | Language model — string (`'anthropic/claude-sonnet-4.6'`) or provider instance |
-| `token` | GitHub personal access token |
+| `token` | GitHub token string or async provider |
 | `preset` | Optional preset or array of presets to scope tools |
 | `requireApproval` | Approval config (same as `createGithubTools`) |
 | `instructions` | Replaces the built-in system prompt entirely |
@@ -511,7 +513,11 @@ async function agentTurn(prompt: string) {
 
 All presets (`code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `maintainer`) work with `createDurableGithubAgent`. Options mirror `createGithubAgent` with additional pass-through for `WorkflowAgentOptions` fields like `experimental_telemetry`, `onStepEnd`, `onEnd`, and `prepareStep`. Write tools honor `requireApproval` via `needsApproval`.
 
-### `createOctokit(token)`
+### `createGithubTokenResolver(token?)`
+
+Normalizes a token string, async token provider, or `process.env.GITHUB_TOKEN` into a `() => Promise<string>` resolver. Throws immediately when no token input is passed and `GITHUB_TOKEN` is unset.
+
+### `createOctokit(resolveToken)`
 
 Returns a configured [`octokit`](https://github.com/octokit/octokit.js) instance. Useful for building custom tools.
 

--- a/packages/github-tools/src/client.test.ts
+++ b/packages/github-tools/src/client.test.ts
@@ -4,7 +4,7 @@ import { GITHUB_API_VERSION, createOctokit } from './client'
 describe('createOctokit', () => {
   it('sets X-GitHub-Api-Version on REST requests', async () => {
     const seen: string[] = []
-    const octokit = createOctokit('ghp_test')
+    const octokit = await createOctokit(async () => 'ghp_test')
 
     octokit.request = octokit.request.defaults({
       request: {

--- a/packages/github-tools/src/client.ts
+++ b/packages/github-tools/src/client.ts
@@ -1,10 +1,11 @@
 import { Octokit } from 'octokit'
+import type { GithubTokenResolver } from './core/token'
 
 /** @see https://docs.github.com/en/rest/about-the-rest-api/api-versions */
 export const GITHUB_API_VERSION = '2026-03-10'
 
-export function createOctokit(token: string): Octokit {
-  const octokit = new Octokit({ auth: token })
+export async function createOctokit(resolveToken: GithubTokenResolver): Promise<Octokit> {
+  const octokit = new Octokit({ auth: await resolveToken() })
 
   octokit.hook.before('request', (options) => {
     options.headers = {

--- a/packages/github-tools/src/core/commits.ts
+++ b/packages/github-tools/src/core/commits.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
+import type { GithubTokenResolver } from './token'
 
 export const BLAME_QUERY = `
   query ($owner: String!, $name: String!, $expression: String!, $path: String!) {
@@ -75,8 +76,8 @@ export const listCommitsInputSchema = z.object({
 export const listCommitsDescription =
   'List commits for a GitHub repository. Filter by file path to see commits that touched a file. For line-by-line attribution at a given ref, use getBlame instead.'
 
-export async function listCommitsCore({ token, owner, repo, path, sha, author, since, until, perPage }: { token: string, owner: string, repo: string, path?: string, sha?: string, author?: string, since?: string, until?: string, perPage: number }) {
-  const octokit = createOctokit(token)
+export async function listCommitsCore({ resolveToken, owner, repo, path, sha, author, since, until, perPage }: { resolveToken: GithubTokenResolver, owner: string, repo: string, path?: string, sha?: string, author?: string, since?: string, until?: string, perPage: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.repos.listCommits({
     owner,
     repo,
@@ -105,8 +106,8 @@ export const getCommitInputSchema = z.object({
 
 export const getCommitDescription = 'Get detailed information about a specific commit, including the list of files changed with additions and deletions'
 
-export async function getCommitCore({ token, owner, repo, ref }: { token: string, owner: string, repo: string, ref: string }) {
-  const octokit = createOctokit(token)
+export async function getCommitCore({ resolveToken, owner, repo, ref }: { resolveToken: GithubTokenResolver, owner: string, repo: string, ref: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.repos.getCommit({ owner, repo, ref })
   return {
     sha: data.sha,
@@ -161,8 +162,8 @@ export const getBlameInputSchema = z.object({
 export const getBlameDescription =
   'Line-level git blame for a file at a commit-like ref (branch, tag, or SHA). Returns contiguous ranges mapping lines to the commits that last modified them — use this to see who introduced a line and when (GitHub GraphQL API).'
 
-export async function getBlameCore({ token, owner, repo, path, ref, line, lineStart, lineEnd }: { token: string, owner: string, repo: string, path: string, ref?: string, line?: number, lineStart?: number, lineEnd?: number }) {
-  const octokit = createOctokit(token)
+export async function getBlameCore({ resolveToken, owner, repo, path, ref, line, lineStart, lineEnd }: { resolveToken: GithubTokenResolver, owner: string, repo: string, path: string, ref?: string, line?: number, lineStart?: number, lineEnd?: number }) {
+  const octokit = await createOctokit(resolveToken)
   let expression = ref
   if (!expression) {
     const { data } = await octokit.rest.repos.get({ owner, repo })

--- a/packages/github-tools/src/core/gists.ts
+++ b/packages/github-tools/src/core/gists.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
+import type { GithubTokenResolver } from './token'
 
 export const listGistsInputSchema = z.object({
   username: z.string().optional().describe('GitHub username — omit to list your own gists'),
@@ -9,8 +10,8 @@ export const listGistsInputSchema = z.object({
 
 export const listGistsDescription = 'List gists for the authenticated user or a specific user'
 
-export async function listGistsCore({ token, username, perPage, page }: { token: string, username?: string, perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listGistsCore({ resolveToken, username, perPage, page }: { resolveToken: GithubTokenResolver, username?: string, perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = username
     ? await octokit.rest.gists.listForUser({ username, per_page: perPage, page })
     : await octokit.rest.gists.list({ per_page: perPage, page })
@@ -33,8 +34,8 @@ export const getGistInputSchema = z.object({
 
 export const getGistDescription = 'Get a gist by ID, including file contents'
 
-export async function getGistCore({ token, gistId }: { token: string, gistId: string }) {
-  const octokit = createOctokit(token)
+export async function getGistCore({ resolveToken, gistId }: { resolveToken: GithubTokenResolver, gistId: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.gists.get({ gist_id: gistId })
   return {
     id: data.id,
@@ -62,8 +63,8 @@ export const listGistCommentsInputSchema = z.object({
 
 export const listGistCommentsDescription = 'List comments on a gist'
 
-export async function listGistCommentsCore({ token, gistId, perPage, page }: { token: string, gistId: string, perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listGistCommentsCore({ resolveToken, gistId, perPage, page }: { resolveToken: GithubTokenResolver, gistId: string, perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.gists.listComments({ gist_id: gistId, per_page: perPage, page })
   return data.map(comment => ({
     id: comment.id,
@@ -85,8 +86,8 @@ export const createGistInputSchema = z.object({
 export const createGistDescription = 'Create a new gist with one or more files'
 
 /** Not idempotent — each call creates a new gist. */
-export async function createGistCore({ token, description, files, isPublic }: { token: string, description?: string, files: Record<string, { content: string }>, isPublic: boolean }) {
-  const octokit = createOctokit(token)
+export async function createGistCore({ resolveToken, description, files, isPublic }: { resolveToken: GithubTokenResolver, description?: string, files: Record<string, { content: string }>, isPublic: boolean }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.gists.create({
     description,
     files,
@@ -113,8 +114,8 @@ export const updateGistInputSchema = z.object({
 export const updateGistDescription = 'Update an existing gist — edit description, update files, or remove files'
 
 /** Not idempotent — each call applies a new revision. */
-export async function updateGistCore({ token, gistId, description, files, filesToDelete }: { token: string, gistId: string, description?: string, files?: Record<string, { content: string }>, filesToDelete?: string[] }) {
-  const octokit = createOctokit(token)
+export async function updateGistCore({ resolveToken, gistId, description, files, filesToDelete }: { resolveToken: GithubTokenResolver, gistId: string, description?: string, files?: Record<string, { content: string }>, filesToDelete?: string[] }) {
+  const octokit = await createOctokit(resolveToken)
   const fileUpdates: Record<string, { content: string } | null> = {}
   if (files) Object.assign(fileUpdates, files)
   if (filesToDelete) {
@@ -140,8 +141,8 @@ export const deleteGistInputSchema = z.object({
 export const deleteGistDescription = 'Delete a gist permanently'
 
 /** Not idempotent — deleting an already-deleted gist returns 404 from GitHub. */
-export async function deleteGistCore({ token, gistId }: { token: string, gistId: string }) {
-  const octokit = createOctokit(token)
+export async function deleteGistCore({ resolveToken, gistId }: { resolveToken: GithubTokenResolver, gistId: string }) {
+  const octokit = await createOctokit(resolveToken)
   await octokit.rest.gists.delete({ gist_id: gistId })
   return { deleted: true, gistId }
 }
@@ -154,8 +155,8 @@ export const createGistCommentInputSchema = z.object({
 export const createGistCommentDescription = 'Add a comment to a gist'
 
 /** Not idempotent — each call adds another comment. */
-export async function createGistCommentCore({ token, gistId, body }: { token: string, gistId: string, body: string }) {
-  const octokit = createOctokit(token)
+export async function createGistCommentCore({ resolveToken, gistId, body }: { resolveToken: GithubTokenResolver, gistId: string, body: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.gists.createComment({ gist_id: gistId, body })
   return {
     id: data.id,

--- a/packages/github-tools/src/core/issues.ts
+++ b/packages/github-tools/src/core/issues.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
+import type { GithubTokenResolver } from './token'
 
 export const listIssuesInputSchema = z.object({
   owner: z.string().describe('Repository owner'),
@@ -11,8 +12,8 @@ export const listIssuesInputSchema = z.object({
 
 export const listIssuesDescription = 'List issues for a GitHub repository (excludes pull requests)'
 
-export async function listIssuesCore({ token, owner, repo, state, labels, perPage }: { token: string, owner: string, repo: string, state: 'open' | 'closed' | 'all', labels?: string, perPage: number }) {
-  const octokit = createOctokit(token)
+export async function listIssuesCore({ resolveToken, owner, repo, state, labels, perPage }: { resolveToken: GithubTokenResolver, owner: string, repo: string, state: 'open' | 'closed' | 'all', labels?: string, perPage: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.issues.listForRepo({
     owner,
     repo,
@@ -42,8 +43,8 @@ export const getIssueInputSchema = z.object({
 
 export const getIssueDescription = 'Get detailed information about a specific issue'
 
-export async function getIssueCore({ token, owner, repo, issueNumber }: { token: string, owner: string, repo: string, issueNumber: number }) {
-  const octokit = createOctokit(token)
+export async function getIssueCore({ resolveToken, owner, repo, issueNumber }: { resolveToken: GithubTokenResolver, owner: string, repo: string, issueNumber: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.issues.get({ owner, repo, issue_number: issueNumber })
   return {
     number: data.number,
@@ -73,8 +74,8 @@ export const createIssueInputSchema = z.object({
 export const createIssueDescription = 'Create a new issue in a GitHub repository'
 
 /** Not idempotent — each call creates a new issue. */
-export async function createIssueCore({ token, owner, repo, title, body, labels, assignees }: { token: string, owner: string, repo: string, title: string, body?: string, labels?: string[], assignees?: string[] }) {
-  const octokit = createOctokit(token)
+export async function createIssueCore({ resolveToken, owner, repo, title, body, labels, assignees }: { resolveToken: GithubTokenResolver, owner: string, repo: string, title: string, body?: string, labels?: string[], assignees?: string[] }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.issues.create({ owner, repo, title, body, labels, assignees })
   return {
     number: data.number,
@@ -95,8 +96,8 @@ export const addIssueCommentInputSchema = z.object({
 export const addIssueCommentDescription = 'Add a comment to a GitHub issue'
 
 /** Not idempotent — each call adds another comment. */
-export async function addIssueCommentCore({ token, owner, repo, issueNumber, body }: { token: string, owner: string, repo: string, issueNumber: number, body: string }) {
-  const octokit = createOctokit(token)
+export async function addIssueCommentCore({ resolveToken, owner, repo, issueNumber, body }: { resolveToken: GithubTokenResolver, owner: string, repo: string, issueNumber: number, body: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body })
   return {
     id: data.id,
@@ -117,8 +118,8 @@ export const closeIssueInputSchema = z.object({
 export const closeIssueDescription = 'Close an open GitHub issue'
 
 /** Idempotent when the issue is already closed. */
-export async function closeIssueCore({ token, owner, repo, issueNumber, stateReason }: { token: string, owner: string, repo: string, issueNumber: number, stateReason: 'completed' | 'not_planned' }) {
-  const octokit = createOctokit(token)
+export async function closeIssueCore({ resolveToken, owner, repo, issueNumber, stateReason }: { resolveToken: GithubTokenResolver, owner: string, repo: string, issueNumber: number, stateReason: 'completed' | 'not_planned' }) {
+  const octokit = await createOctokit(resolveToken)
   const { data: existing } = await octokit.rest.issues.get({ owner, repo, issue_number: issueNumber })
   if (existing.state === 'closed') {
     return {
@@ -155,8 +156,8 @@ export const listLabelsInputSchema = z.object({
 
 export const listLabelsDescription = 'List labels available in a GitHub repository'
 
-export async function listLabelsCore({ token, owner, repo, perPage, page }: { token: string, owner: string, repo: string, perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listLabelsCore({ resolveToken, owner, repo, perPage, page }: { resolveToken: GithubTokenResolver, owner: string, repo: string, perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.issues.listLabelsForRepo({ owner, repo, per_page: perPage, page })
   return data.map(label => ({
     name: label.name,
@@ -175,8 +176,8 @@ export const addLabelsInputSchema = z.object({
 export const addLabelsDescription = 'Add labels to an issue or pull request'
 
 /** Not idempotent — re-adding labels is a no-op on GitHub but still mutates. */
-export async function addLabelsCore({ token, owner, repo, issueNumber, labels }: { token: string, owner: string, repo: string, issueNumber: number, labels: string[] }) {
-  const octokit = createOctokit(token)
+export async function addLabelsCore({ resolveToken, owner, repo, issueNumber, labels }: { resolveToken: GithubTokenResolver, owner: string, repo: string, issueNumber: number, labels: string[] }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels })
   return data.map(label => ({
     name: label.name,
@@ -195,8 +196,8 @@ export const removeLabelInputSchema = z.object({
 export const removeLabelDescription = 'Remove a label from an issue or pull request'
 
 /** Not idempotent — removing a missing label returns 404 from GitHub. */
-export async function removeLabelCore({ token, owner, repo, issueNumber, label }: { token: string, owner: string, repo: string, issueNumber: number, label: string }) {
-  const octokit = createOctokit(token)
+export async function removeLabelCore({ resolveToken, owner, repo, issueNumber, label }: { resolveToken: GithubTokenResolver, owner: string, repo: string, issueNumber: number, label: string }) {
+  const octokit = await createOctokit(resolveToken)
   await octokit.rest.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: label })
   return { removed: true, label, issueNumber }
 }

--- a/packages/github-tools/src/core/pull-requests.ts
+++ b/packages/github-tools/src/core/pull-requests.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
+import type { GithubTokenResolver } from './token'
 import type { CommitIdentity } from '../types'
 import { composeCommitMessage } from './repository'
 
@@ -12,8 +13,8 @@ export const listPullRequestsInputSchema = z.object({
 
 export const listPullRequestsDescription = 'List pull requests for a GitHub repository'
 
-export async function listPullRequestsCore({ token, owner, repo, state, perPage }: { token: string, owner: string, repo: string, state: 'open' | 'closed' | 'all', perPage: number }) {
-  const octokit = createOctokit(token)
+export async function listPullRequestsCore({ resolveToken, owner, repo, state, perPage }: { resolveToken: GithubTokenResolver, owner: string, repo: string, state: 'open' | 'closed' | 'all', perPage: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.pulls.list({ owner, repo, state, per_page: perPage })
   return data.map(pr => ({
     number: pr.number,
@@ -37,8 +38,8 @@ export const getPullRequestInputSchema = z.object({
 
 export const getPullRequestDescription = 'Get detailed information about a specific pull request'
 
-export async function getPullRequestCore({ token, owner, repo, pullNumber }: { token: string, owner: string, repo: string, pullNumber: number }) {
-  const octokit = createOctokit(token)
+export async function getPullRequestCore({ resolveToken, owner, repo, pullNumber }: { resolveToken: GithubTokenResolver, owner: string, repo: string, pullNumber: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.pulls.get({ owner, repo, pull_number: pullNumber })
   return {
     number: data.number,
@@ -74,8 +75,8 @@ export const createPullRequestInputSchema = z.object({
 export const createPullRequestDescription = 'Create a new pull request in a GitHub repository'
 
 /** Not idempotent — each call creates a new pull request. */
-export async function createPullRequestCore({ token, owner, repo, title, body, head, base, draft }: { token: string, owner: string, repo: string, title: string, body?: string, head: string, base: string, draft: boolean }) {
-  const octokit = createOctokit(token)
+export async function createPullRequestCore({ resolveToken, owner, repo, title, body, head, base, draft }: { resolveToken: GithubTokenResolver, owner: string, repo: string, title: string, body?: string, head: string, base: string, draft: boolean }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.pulls.create({ owner, repo, title, body, head, base, draft })
   return {
     number: data.number,
@@ -101,7 +102,7 @@ export const mergePullRequestDescription = 'Merge a pull request'
 
 /** Not idempotent — merging an already-merged PR returns an error from GitHub. */
 export async function mergePullRequestCore({
-  token,
+  resolveToken,
   owner,
   repo,
   pullNumber,
@@ -110,7 +111,7 @@ export async function mergePullRequestCore({
   mergeMethod,
   coAuthors,
 }: {
-  token: string
+  resolveToken: GithubTokenResolver
   owner: string
   repo: string
   pullNumber: number
@@ -119,7 +120,7 @@ export async function mergePullRequestCore({
   mergeMethod: 'merge' | 'squash' | 'rebase'
   coAuthors?: CommitIdentity[]
 }) {
-  const octokit = createOctokit(token)
+  const octokit = await createOctokit(resolveToken)
   const finalMessage = composeCommitMessage(commitMessage ?? '', coAuthors) || undefined
   const { data } = await octokit.rest.pulls.merge({
     owner,
@@ -146,8 +147,8 @@ export const addPullRequestCommentInputSchema = z.object({
 export const addPullRequestCommentDescription = 'Add a comment to a pull request'
 
 /** Not idempotent — each call adds another comment. */
-export async function addPullRequestCommentCore({ token, owner, repo, pullNumber, body }: { token: string, owner: string, repo: string, pullNumber: number, body: string }) {
-  const octokit = createOctokit(token)
+export async function addPullRequestCommentCore({ resolveToken, owner, repo, pullNumber, body }: { resolveToken: GithubTokenResolver, owner: string, repo: string, pullNumber: number, body: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.issues.createComment({ owner, repo, issue_number: pullNumber, body })
   return {
     id: data.id,
@@ -168,8 +169,8 @@ export const listPullRequestFilesInputSchema = z.object({
 
 export const listPullRequestFilesDescription = 'List files changed in a pull request, including diff status and patch content'
 
-export async function listPullRequestFilesCore({ token, owner, repo, pullNumber, perPage, page }: { token: string, owner: string, repo: string, pullNumber: number, perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listPullRequestFilesCore({ resolveToken, owner, repo, pullNumber, perPage, page }: { resolveToken: GithubTokenResolver, owner: string, repo: string, pullNumber: number, perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.pulls.listFiles({ owner, repo, pull_number: pullNumber, per_page: perPage, page })
   return data.map(file => ({
     filename: file.filename,
@@ -191,8 +192,8 @@ export const listPullRequestReviewsInputSchema = z.object({
 
 export const listPullRequestReviewsDescription = 'List reviews on a pull request (approvals, change requests, and comments)'
 
-export async function listPullRequestReviewsCore({ token, owner, repo, pullNumber, perPage, page }: { token: string, owner: string, repo: string, pullNumber: number, perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listPullRequestReviewsCore({ resolveToken, owner, repo, pullNumber, perPage, page }: { resolveToken: GithubTokenResolver, owner: string, repo: string, pullNumber: number, perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.pulls.listReviews({ owner, repo, pull_number: pullNumber, per_page: perPage, page })
   return data.map(review => ({
     id: review.id,
@@ -221,8 +222,8 @@ export const createPullRequestReviewInputSchema = z.object({
 export const createPullRequestReviewDescription = 'Submit a pull request review — approve, request changes, or comment with optional inline comments on specific lines'
 
 /** Not idempotent — each call submits a new review. */
-export async function createPullRequestReviewCore({ token, owner, repo, pullNumber, body, event, comments }: { token: string, owner: string, repo: string, pullNumber: number, body?: string, event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT', comments?: Array<{ path: string, body: string, line?: number, side?: 'LEFT' | 'RIGHT' }> }) {
-  const octokit = createOctokit(token)
+export async function createPullRequestReviewCore({ resolveToken, owner, repo, pullNumber, body, event, comments }: { resolveToken: GithubTokenResolver, owner: string, repo: string, pullNumber: number, body?: string, event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT', comments?: Array<{ path: string, body: string, line?: number, side?: 'LEFT' | 'RIGHT' }> }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.pulls.createReview({
     owner,
     repo,

--- a/packages/github-tools/src/core/repository.ts
+++ b/packages/github-tools/src/core/repository.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
+import type { GithubTokenResolver } from './token'
 import type { CommitIdentity, Octokit } from '../types'
 import { gitBlobSha } from './git-blob-sha'
 
@@ -66,8 +67,8 @@ export const getRepositoryInputSchema = z.object({
 
 export const getRepositoryDescription = 'Get information about a GitHub repository including description, stars, forks, language, and default branch'
 
-export async function getRepositoryCore({ token, owner, repo }: { token: string, owner: string, repo: string }) {
-  const octokit = createOctokit(token)
+export async function getRepositoryCore({ resolveToken, owner, repo }: { resolveToken: GithubTokenResolver, owner: string, repo: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.repos.get({ owner, repo })
   return {
     name: data.name,
@@ -93,8 +94,8 @@ export const listBranchesInputSchema = z.object({
 
 export const listBranchesDescription = 'List branches in a GitHub repository'
 
-export async function listBranchesCore({ token, owner, repo, perPage }: { token: string, owner: string, repo: string, perPage: number }) {
-  const octokit = createOctokit(token)
+export async function listBranchesCore({ resolveToken, owner, repo, perPage }: { resolveToken: GithubTokenResolver, owner: string, repo: string, perPage: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.repos.listBranches({ owner, repo, per_page: perPage })
   return data.map(branch => ({
     name: branch.name,
@@ -112,8 +113,8 @@ export const getFileContentInputSchema = z.object({
 
 export const getFileContentDescription = 'Get the content of a file from a GitHub repository'
 
-export async function getFileContentCore({ token, owner, repo, path, ref }: { token: string, owner: string, repo: string, path: string, ref?: string }) {
-  const octokit = createOctokit(token)
+export async function getFileContentCore({ resolveToken, owner, repo, path, ref }: { resolveToken: GithubTokenResolver, owner: string, repo: string, path: string, ref?: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.repos.getContent({ owner, repo, path, ref })
   if (Array.isArray(data)) {
     return { type: 'directory' as const, entries: data.map(e => ({ name: e.name, type: e.type, path: e.path })) }
@@ -141,8 +142,8 @@ export const createBranchInputSchema = z.object({
 export const createBranchDescription = 'Create a new branch in a GitHub repository from an existing branch or commit SHA'
 
 /** Idempotent when the branch already exists at the target SHA. Not idempotent otherwise. */
-export async function createBranchCore({ token, owner, repo, branch, from }: { token: string, owner: string, repo: string, branch: string, from?: string }) {
-  const octokit = createOctokit(token)
+export async function createBranchCore({ resolveToken, owner, repo, branch, from }: { resolveToken: GithubTokenResolver, owner: string, repo: string, branch: string, from?: string }) {
+  const octokit = await createOctokit(resolveToken)
   let sha = from
   if (!sha || !sha.match(/^[0-9a-f]{40}$/i)) {
     const { data: ref } = await octokit.rest.git.getRef({
@@ -189,8 +190,8 @@ export const forkRepositoryInputSchema = z.object({
 export const forkRepositoryDescription = 'Fork a GitHub repository to the authenticated user account or a specified organization'
 
 /** Not idempotent — each call may create another fork attempt. */
-export async function forkRepositoryCore({ token, owner, repo, organization, name }: { token: string, owner: string, repo: string, organization?: string, name?: string }) {
-  const octokit = createOctokit(token)
+export async function forkRepositoryCore({ resolveToken, owner, repo, organization, name }: { resolveToken: GithubTokenResolver, owner: string, repo: string, organization?: string, name?: string }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.repos.createFork({
     owner,
     repo,
@@ -222,8 +223,8 @@ export const createRepositoryInputSchema = z.object({
 export const createRepositoryDescription = 'Create a new GitHub repository for the authenticated user or a specified organization'
 
 /** Not idempotent — each call creates a new repository. */
-export async function createRepositoryCore({ token, name, description, isPrivate, autoInit, gitignoreTemplate, licenseTemplate, org }: { token: string, name: string, description?: string, isPrivate: boolean, autoInit: boolean, gitignoreTemplate?: string, licenseTemplate?: string, org?: string }) {
-  const octokit = createOctokit(token)
+export async function createRepositoryCore({ resolveToken, name, description, isPrivate, autoInit, gitignoreTemplate, licenseTemplate, org }: { resolveToken: GithubTokenResolver, name: string, description?: string, isPrivate: boolean, autoInit: boolean, gitignoreTemplate?: string, licenseTemplate?: string, org?: string }) {
+  const octokit = await createOctokit(resolveToken)
   const params = {
     name,
     description,
@@ -264,7 +265,7 @@ export const createOrUpdateFileDescription = 'Create or update a file in a GitHu
 
 /** Idempotent when updating with sha and content is unchanged. Not idempotent for new commits. */
 export async function createOrUpdateFileCore({
-  token,
+  resolveToken,
   owner,
   repo,
   path,
@@ -276,7 +277,7 @@ export async function createOrUpdateFileCore({
   committer,
   coAuthors,
 }: {
-  token: string
+  resolveToken: GithubTokenResolver
   owner: string
   repo: string
   path: string
@@ -288,7 +289,7 @@ export async function createOrUpdateFileCore({
   committer?: CommitIdentity
   coAuthors?: CommitIdentity[]
 }) {
-  const octokit = createOctokit(token)
+  const octokit = await createOctokit(resolveToken)
 
   if (sha) {
     const branchName = branch || (await octokit.rest.repos.get({ owner, repo })).data.default_branch

--- a/packages/github-tools/src/core/search.ts
+++ b/packages/github-tools/src/core/search.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
+import type { GithubTokenResolver } from './token'
 
 export const searchCodeInputSchema = z.object({
   query: z.string().describe('Search query. Supports GitHub search qualifiers, e.g. "useState repo:facebook/react"'),
@@ -8,8 +9,8 @@ export const searchCodeInputSchema = z.object({
 
 export const searchCodeDescription = 'Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search.'
 
-export async function searchCodeCore({ token, query, perPage }: { token: string, query: string, perPage: number }) {
-  const octokit = createOctokit(token)
+export async function searchCodeCore({ resolveToken, query, perPage }: { resolveToken: GithubTokenResolver, query: string, perPage: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.search.code({ q: query, per_page: perPage })
   return {
     totalCount: data.total_count,
@@ -32,8 +33,8 @@ export const searchRepositoriesInputSchema = z.object({
 
 export const searchRepositoriesDescription = 'Search for GitHub repositories by keyword, topic, language, or other qualifiers'
 
-export async function searchRepositoriesCore({ token, query, perPage, sort, order }: { token: string, query: string, perPage: number, sort?: 'stars' | 'forks' | 'help-wanted-issues' | 'updated', order: 'asc' | 'desc' }) {
-  const octokit = createOctokit(token)
+export async function searchRepositoriesCore({ resolveToken, query, perPage, sort, order }: { resolveToken: GithubTokenResolver, query: string, perPage: number, sort?: 'stars' | 'forks' | 'help-wanted-issues' | 'updated', order: 'asc' | 'desc' }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.search.repos({ q: query, per_page: perPage, sort, order })
   return {
     totalCount: data.total_count,

--- a/packages/github-tools/src/core/token.test.ts
+++ b/packages/github-tools/src/core/token.test.ts
@@ -1,22 +1,39 @@
 import { describe, expect, it } from 'vitest'
-import { resolveGithubToken } from './token'
+import { createGithubTokenResolver } from './token'
 
-describe('resolveGithubToken', () => {
-  it('uses the provided token', () => {
-    expect(resolveGithubToken('ghp_explicit')).toBe('ghp_explicit')
+describe('createGithubTokenResolver', () => {
+  it('normalizes input to an async resolver', async () => {
+    const resolveToken = createGithubTokenResolver('ghp_normalized')
+    await expect(resolveToken()).resolves.toBe('ghp_normalized')
   })
 
-  it('falls back to process.env.GITHUB_TOKEN', () => {
+  it('uses the provided token', async () => {
+    const resolveToken = createGithubTokenResolver('ghp_explicit')
+    await expect(resolveToken()).resolves.toBe('ghp_explicit')
+  })
+
+  it('uses an async token provider', async () => {
+    const resolveToken = createGithubTokenResolver(async () => 'ghp_dynamic')
+    await expect(resolveToken()).resolves.toBe('ghp_dynamic')
+  })
+
+  it('throws when an async token provider resolves empty', async () => {
+    const resolveToken = createGithubTokenResolver(async () => '')
+    await expect(resolveToken()).rejects.toThrow('GitHub token is required')
+  })
+
+  it('falls back to process.env.GITHUB_TOKEN', async () => {
     const previous = process.env.GITHUB_TOKEN
     process.env.GITHUB_TOKEN = 'ghp_env'
-    expect(resolveGithubToken()).toBe('ghp_env')
+    const resolveToken = createGithubTokenResolver()
+    await expect(resolveToken()).resolves.toBe('ghp_env')
     process.env.GITHUB_TOKEN = previous
   })
 
-  it('throws when no token is available', () => {
+  it('throws immediately when no token is available', () => {
     const previous = process.env.GITHUB_TOKEN
     delete process.env.GITHUB_TOKEN
-    expect(() => resolveGithubToken()).toThrow('GitHub token is required')
+    expect(() => createGithubTokenResolver()).toThrow('GitHub token is required')
     process.env.GITHUB_TOKEN = previous
   })
 })

--- a/packages/github-tools/src/core/token.ts
+++ b/packages/github-tools/src/core/token.ts
@@ -1,7 +1,29 @@
-export function resolveGithubToken(token?: string): string {
-  const resolvedToken = token || process.env.GITHUB_TOKEN
-  if (!resolvedToken) {
-    throw new Error('GitHub token is required. Pass it as `token` or set the GITHUB_TOKEN environment variable.')
+export type GithubTokenInput = string | (() => Promise<string>)
+export type GithubTokenResolver = () => Promise<string>
+export type GithubTokenStepArgs<T extends { resolveToken: GithubTokenResolver }> = Omit<T, 'resolveToken'> & { token: string }
+
+export function createGithubTokenStepResolver(token: string): GithubTokenResolver {
+  return async () => token
+}
+
+export function createGithubTokenResolver(token?: GithubTokenInput): GithubTokenResolver {
+  if (typeof token !== 'function') {
+    const resolvedToken = token || process.env.GITHUB_TOKEN
+
+    if (!resolvedToken) {
+      throw new Error('GitHub token is required. Pass it as `token` or set the GITHUB_TOKEN environment variable.')
+    }
+
+    return async () => resolvedToken
   }
-  return resolvedToken
+
+  return async () => {
+    const resolvedToken = await token()
+
+    if (!resolvedToken) {
+      throw new Error('GitHub token is required. Pass it as `token` or set the GITHUB_TOKEN environment variable.')
+    }
+
+    return resolvedToken
+  }
 }

--- a/packages/github-tools/src/core/tool-types.ts
+++ b/packages/github-tools/src/core/tool-types.ts
@@ -1,5 +1,6 @@
 import type { ApprovalConfig } from './approval'
 import type { CombinedPresetToolNames, GithubToolPreset, PresetToolName } from './presets'
+import type { GithubTokenInput } from './token'
 import type { GithubToolName } from './tool-names'
 import type { CommitIdentity, GithubTool, ToolOverrides } from '../types'
 
@@ -8,8 +9,8 @@ export type AllGithubTools = Record<GithubToolName, GithubTool>
 
 /** Base options shared by all {@link createGithubTools} overloads. */
 export type GithubToolsBaseOptions = {
-  /** GitHub personal access token. Falls back to `process.env.GITHUB_TOKEN` when omitted. */
-  token?: string
+  /** GitHub token string or async provider. Falls back to `process.env.GITHUB_TOKEN` when omitted. */
+  token?: GithubTokenInput
   /** Control whether write operations require user approval. @see {@link ApprovalConfig} */
   requireApproval?: ApprovalConfig
   /** Per-tool overrides for description, title, needsApproval, and related AI SDK tool fields. */

--- a/packages/github-tools/src/core/workflows.ts
+++ b/packages/github-tools/src/core/workflows.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
+import type { GithubTokenResolver } from './token'
 
 export const listWorkflowsInputSchema = z.object({
   owner: z.string().describe('Repository owner'),
@@ -10,8 +11,8 @@ export const listWorkflowsInputSchema = z.object({
 
 export const listWorkflowsDescription = 'List GitHub Actions workflows in a repository'
 
-export async function listWorkflowsCore({ token, owner, repo, perPage, page }: { token: string, owner: string, repo: string, perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listWorkflowsCore({ resolveToken, owner, repo, perPage, page }: { resolveToken: GithubTokenResolver, owner: string, repo: string, perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.actions.listRepoWorkflows({ owner, repo, per_page: perPage, page })
   return {
     totalCount: data.total_count,
@@ -42,8 +43,8 @@ export const listWorkflowRunsInputSchema = z.object({
 
 export const listWorkflowRunsDescription = 'List workflow runs for a repository, optionally filtered by workflow, branch, status, or event'
 
-export async function listWorkflowRunsCore({ token, owner, repo, workflowId, branch, event, status, perPage, page }: { token: string, owner: string, repo: string, workflowId?: string | number, branch?: string, event?: string, status?: WorkflowRunStatus, perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listWorkflowRunsCore({ resolveToken, owner, repo, workflowId, branch, event, status, perPage, page }: { resolveToken: GithubTokenResolver, owner: string, repo: string, workflowId?: string | number, branch?: string, event?: string, status?: WorkflowRunStatus, perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = workflowId
     ? await octokit.rest.actions.listWorkflowRuns({ owner, repo, workflow_id: workflowId, per_page: perPage, page, ...branch && { branch }, ...event && { event }, ...status && { status } })
     : await octokit.rest.actions.listWorkflowRunsForRepo({ owner, repo, per_page: perPage, page, ...branch && { branch }, ...event && { event }, ...status && { status } })
@@ -75,8 +76,8 @@ export const getWorkflowRunInputSchema = z.object({
 
 export const getWorkflowRunDescription = 'Get details of a specific workflow run including status, timing, and trigger info'
 
-export async function getWorkflowRunCore({ token, owner, repo, runId }: { token: string, owner: string, repo: string, runId: number }) {
-  const octokit = createOctokit(token)
+export async function getWorkflowRunCore({ resolveToken, owner, repo, runId }: { resolveToken: GithubTokenResolver, owner: string, repo: string, runId: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.actions.getWorkflowRun({ owner, repo, run_id: runId })
   return {
     id: data.id,
@@ -107,8 +108,8 @@ export const listWorkflowJobsInputSchema = z.object({
 
 export const listWorkflowJobsDescription = 'List jobs for a workflow run, including step-level status and timing'
 
-export async function listWorkflowJobsCore({ token, owner, repo, runId, filter, perPage, page }: { token: string, owner: string, repo: string, runId: number, filter: 'latest' | 'all', perPage: number, page: number }) {
-  const octokit = createOctokit(token)
+export async function listWorkflowJobsCore({ resolveToken, owner, repo, runId, filter, perPage, page }: { resolveToken: GithubTokenResolver, owner: string, repo: string, runId: number, filter: 'latest' | 'all', perPage: number, page: number }) {
+  const octokit = await createOctokit(resolveToken)
   const { data } = await octokit.rest.actions.listJobsForWorkflowRun({ owner, repo, run_id: runId, filter, per_page: perPage, page })
   return {
     totalCount: data.total_count,
@@ -144,8 +145,8 @@ export const triggerWorkflowInputSchema = z.object({
 export const triggerWorkflowDescription = 'Trigger a workflow via workflow_dispatch event'
 
 /** Not idempotent — each call starts a new workflow run. */
-export async function triggerWorkflowCore({ token, owner, repo, workflowId, ref, inputs }: { token: string, owner: string, repo: string, workflowId: string | number, ref: string, inputs?: Record<string, string> }) {
-  const octokit = createOctokit(token)
+export async function triggerWorkflowCore({ resolveToken, owner, repo, workflowId, ref, inputs }: { resolveToken: GithubTokenResolver, owner: string, repo: string, workflowId: string | number, ref: string, inputs?: Record<string, string> }) {
+  const octokit = await createOctokit(resolveToken)
   await octokit.rest.actions.createWorkflowDispatch({
     owner,
     repo,
@@ -165,8 +166,8 @@ export const cancelWorkflowRunInputSchema = z.object({
 export const cancelWorkflowRunDescription = 'Cancel an in-progress workflow run'
 
 /** Not idempotent — cancelling an already-finished run is a no-op on GitHub but still mutates. */
-export async function cancelWorkflowRunCore({ token, owner, repo, runId }: { token: string, owner: string, repo: string, runId: number }) {
-  const octokit = createOctokit(token)
+export async function cancelWorkflowRunCore({ resolveToken, owner, repo, runId }: { resolveToken: GithubTokenResolver, owner: string, repo: string, runId: number }) {
+  const octokit = await createOctokit(resolveToken)
   await octokit.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId })
   return { cancelled: true, runId }
 }
@@ -181,8 +182,8 @@ export const rerunWorkflowRunInputSchema = z.object({
 export const rerunWorkflowRunDescription = 'Re-run a workflow run, optionally only the failed jobs'
 
 /** Not idempotent — each call starts another run attempt. */
-export async function rerunWorkflowRunCore({ token, owner, repo, runId, onlyFailedJobs }: { token: string, owner: string, repo: string, runId: number, onlyFailedJobs: boolean }) {
-  const octokit = createOctokit(token)
+export async function rerunWorkflowRunCore({ resolveToken, owner, repo, runId, onlyFailedJobs }: { resolveToken: GithubTokenResolver, owner: string, repo: string, runId: number, onlyFailedJobs: boolean }) {
+  const octokit = await createOctokit(resolveToken)
   if (onlyFailedJobs) {
     await octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: runId })
   } else {

--- a/packages/github-tools/src/eve/build.test.ts
+++ b/packages/github-tools/src/eve/build.test.ts
@@ -50,12 +50,14 @@ describe('createGithubTools eve integration', () => {
       content: 'hello',
     }, {} as never)
 
-    expect(coreSpy).toHaveBeenCalledWith(expect.objectContaining({
-      token: 'ghp_test',
+    const [coreArgs] = coreSpy.mock.calls[0]!
+    expect(coreArgs).toEqual(expect.objectContaining({
+      resolveToken: expect.any(Function),
       author: { name: 'Author', email: 'author@example.com' },
       committer: { name: 'Committer', email: 'committer@example.com' },
       coAuthors,
     }))
+    await expect(coreArgs.resolveToken()).resolves.toBe('ghp_test')
 
     coreSpy.mockRestore()
   })

--- a/packages/github-tools/src/eve/build.ts
+++ b/packages/github-tools/src/eve/build.ts
@@ -1,6 +1,6 @@
 import type { ToolDefinition } from 'eve/tools'
 import { resolvePresetTools, type CombinedPresetToolNames, type GithubToolPreset, type PresetToolName } from '../core/presets'
-import { resolveGithubToken } from '../core/token'
+import { createGithubTokenResolver } from '../core/token'
 import { mapEveApprovalValue, resolveEveApproval } from './approval'
 import { getEveTools } from './load-eve'
 import { ALL_GITHUB_TOOL_NAMES, createToolRegistry, type GithubToolName, type ToolBuildContext } from './registry'
@@ -31,9 +31,9 @@ export function buildEveToolDefinition(
   options: BuildOptions = {},
 ): ToolDefinition {
   const { defineTool } = getEveTools()
-  const token = resolveGithubToken(options.token)
+  const resolveToken = createGithubTokenResolver(options.token)
   const ctx: ToolBuildContext = {
-    token,
+    resolveToken,
     author: options.author,
     committer: options.committer,
     coAuthors: options.coAuthors,
@@ -59,9 +59,9 @@ export function buildEveToolDefinition(
 
 export function buildEveToolMap(options: EveGithubToolsOptions = {}): EveToolMap {
   const { defineTool } = getEveTools()
-  const token = resolveGithubToken(options.token)
+  const resolveToken = createGithubTokenResolver(options.token)
   const ctx: ToolBuildContext = {
-    token,
+    resolveToken,
     author: options.author,
     committer: options.committer,
     coAuthors: options.coAuthors,

--- a/packages/github-tools/src/eve/registry.ts
+++ b/packages/github-tools/src/eve/registry.ts
@@ -13,13 +13,14 @@ import * as pullRequests from '../core/pull-requests'
 import * as repository from '../core/repository'
 import * as search from '../core/search'
 import * as workflows from '../core/workflows'
+import type { GithubTokenResolver } from '../core/token'
 import type { GithubWriteToolName } from '../core/write-tools'
 import type { GithubToolName } from '../core/tool-names'
 export type { GithubToolName } from '../core/tool-names'
 export { ALL_GITHUB_TOOL_NAMES } from '../core/tool-names'
 
 export type ToolBuildContext = {
-  token: string
+  resolveToken: GithubTokenResolver
   author?: CommitIdentity
   committer?: CommitIdentity
   coAuthors?: CommitIdentity[]
@@ -35,11 +36,11 @@ type ToolRegistryEntry = {
 }
 
 function withToken<T extends Record<string, unknown>>(
-  core: (args: T & { token: string }) => Promise<unknown>,
+  core: (args: T & { resolveToken: GithubTokenResolver }) => Promise<unknown>,
   ctx: ToolBuildContext,
   extra?: Record<string, unknown>,
 ) {
-  return (input: Record<string, unknown>) => core({ token: ctx.token, ...extra, ...input } as T & { token: string })
+  return (input: Record<string, unknown>) => core({ resolveToken: ctx.resolveToken, ...extra, ...input } as T & { resolveToken: GithubTokenResolver })
 }
 
 function modelOutputAdapter(
@@ -331,4 +332,3 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
     },
   ]
 }
-

--- a/packages/github-tools/src/eve/types.ts
+++ b/packages/github-tools/src/eve/types.ts
@@ -1,6 +1,7 @@
 import type { Approval, ToolModelOutput } from 'eve/tools'
 import type { z } from 'zod'
 import type { GithubToolPreset } from '../core/presets'
+import type { GithubTokenInput } from '../core/token'
 import type { GithubToolName } from '../core/tool-names'
 import type { GithubWriteToolName } from '../core/write-tools'
 import type { CommitIdentity } from '../types'
@@ -32,8 +33,8 @@ export type EveToolOverrides = Partial<Record<GithubToolName, {
 }>>
 
 export type EveGithubToolsOptions = {
-  /** Defaults to `process.env.GITHUB_TOKEN`. */
-  token?: string
+  /** GitHub token string or async provider. Defaults to `process.env.GITHUB_TOKEN`. */
+  token?: GithubTokenInput
   /**
    * Restrict tools to a predefined preset.
    *

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -10,7 +10,7 @@ import { resolveAiSdkApproval } from './core/approval'
 import { resolvePresetTools, type CombinedPresetToolNames, type GithubToolPreset, type PresetToolName } from './core/presets'
 import { type GithubToolName } from './core/tool-names'
 import { type AllGithubTools, type GithubToolsBaseOptions } from './core/tool-types'
-import { resolveGithubToken } from './core/token'
+import { createGithubTokenResolver } from './core/token'
 import type { GithubWriteToolName } from './core/write-tools'
 
 export type { GithubWriteToolName } from './core/write-tools'
@@ -88,53 +88,53 @@ export function createGithubTools({
   committer,
   coAuthors,
 }: GithubToolsOptions = {}): AllGithubTools | Pick<AllGithubTools, GithubToolName> {
-  const resolvedToken = resolveGithubToken(token)
+  const resolveToken = createGithubTokenResolver(token)
   const approval = (name: GithubWriteToolName) => ({ needsApproval: resolveAiSdkApproval(name, requireApproval) })
   const allowed = preset ? resolvePresetTools(preset) : null
 
   const allTools = {
-    getRepository: getRepository(resolvedToken),
-    listBranches: listBranches(resolvedToken),
-    getFileContent: getFileContent(resolvedToken),
-    listPullRequests: listPullRequests(resolvedToken),
-    getPullRequest: getPullRequest(resolvedToken),
-    listIssues: listIssues(resolvedToken),
-    getIssue: getIssue(resolvedToken),
-    searchCode: searchCode(resolvedToken),
-    searchRepositories: searchRepositories(resolvedToken),
-    listCommits: listCommits(resolvedToken),
-    getCommit: getCommit(resolvedToken),
-    getBlame: getBlame(resolvedToken),
-    createBranch: createBranch(resolvedToken, approval('createBranch')),
-    forkRepository: forkRepository(resolvedToken, approval('forkRepository')),
-    createRepository: createRepository(resolvedToken, approval('createRepository')),
-    createOrUpdateFile: createOrUpdateFile(resolvedToken, { ...approval('createOrUpdateFile'), author, committer, coAuthors }),
-    createPullRequest: createPullRequest(resolvedToken, approval('createPullRequest')),
-    mergePullRequest: mergePullRequest(resolvedToken, { ...approval('mergePullRequest'), coAuthors }),
-    addPullRequestComment: addPullRequestComment(resolvedToken, approval('addPullRequestComment')),
-    listPullRequestFiles: listPullRequestFiles(resolvedToken),
-    listPullRequestReviews: listPullRequestReviews(resolvedToken),
-    createPullRequestReview: createPullRequestReview(resolvedToken, approval('createPullRequestReview')),
-    createIssue: createIssue(resolvedToken, approval('createIssue')),
-    addIssueComment: addIssueComment(resolvedToken, approval('addIssueComment')),
-    closeIssue: closeIssue(resolvedToken, approval('closeIssue')),
-    listLabels: listLabels(resolvedToken),
-    addLabels: addLabels(resolvedToken, approval('addLabels')),
-    removeLabel: removeLabel(resolvedToken, approval('removeLabel')),
-    listGists: listGists(resolvedToken),
-    getGist: getGist(resolvedToken),
-    listGistComments: listGistComments(resolvedToken),
-    createGist: createGist(resolvedToken, approval('createGist')),
-    updateGist: updateGist(resolvedToken, approval('updateGist')),
-    deleteGist: deleteGist(resolvedToken, approval('deleteGist')),
-    createGistComment: createGistComment(resolvedToken, approval('createGistComment')),
-    listWorkflows: listWorkflows(resolvedToken),
-    listWorkflowRuns: listWorkflowRuns(resolvedToken),
-    getWorkflowRun: getWorkflowRun(resolvedToken),
-    listWorkflowJobs: listWorkflowJobs(resolvedToken),
-    triggerWorkflow: triggerWorkflow(resolvedToken, approval('triggerWorkflow')),
-    cancelWorkflowRun: cancelWorkflowRun(resolvedToken, approval('cancelWorkflowRun')),
-    rerunWorkflowRun: rerunWorkflowRun(resolvedToken, approval('rerunWorkflowRun')),
+    getRepository: getRepository(resolveToken),
+    listBranches: listBranches(resolveToken),
+    getFileContent: getFileContent(resolveToken),
+    listPullRequests: listPullRequests(resolveToken),
+    getPullRequest: getPullRequest(resolveToken),
+    listIssues: listIssues(resolveToken),
+    getIssue: getIssue(resolveToken),
+    searchCode: searchCode(resolveToken),
+    searchRepositories: searchRepositories(resolveToken),
+    listCommits: listCommits(resolveToken),
+    getCommit: getCommit(resolveToken),
+    getBlame: getBlame(resolveToken),
+    createBranch: createBranch(resolveToken, approval('createBranch')),
+    forkRepository: forkRepository(resolveToken, approval('forkRepository')),
+    createRepository: createRepository(resolveToken, approval('createRepository')),
+    createOrUpdateFile: createOrUpdateFile(resolveToken, { ...approval('createOrUpdateFile'), author, committer, coAuthors }),
+    createPullRequest: createPullRequest(resolveToken, approval('createPullRequest')),
+    mergePullRequest: mergePullRequest(resolveToken, { ...approval('mergePullRequest'), coAuthors }),
+    addPullRequestComment: addPullRequestComment(resolveToken, approval('addPullRequestComment')),
+    listPullRequestFiles: listPullRequestFiles(resolveToken),
+    listPullRequestReviews: listPullRequestReviews(resolveToken),
+    createPullRequestReview: createPullRequestReview(resolveToken, approval('createPullRequestReview')),
+    createIssue: createIssue(resolveToken, approval('createIssue')),
+    addIssueComment: addIssueComment(resolveToken, approval('addIssueComment')),
+    closeIssue: closeIssue(resolveToken, approval('closeIssue')),
+    listLabels: listLabels(resolveToken),
+    addLabels: addLabels(resolveToken, approval('addLabels')),
+    removeLabel: removeLabel(resolveToken, approval('removeLabel')),
+    listGists: listGists(resolveToken),
+    getGist: getGist(resolveToken),
+    listGistComments: listGistComments(resolveToken),
+    createGist: createGist(resolveToken, approval('createGist')),
+    updateGist: updateGist(resolveToken, approval('updateGist')),
+    deleteGist: deleteGist(resolveToken, approval('deleteGist')),
+    createGistComment: createGistComment(resolveToken, approval('createGistComment')),
+    listWorkflows: listWorkflows(resolveToken),
+    listWorkflowRuns: listWorkflowRuns(resolveToken),
+    getWorkflowRun: getWorkflowRun(resolveToken),
+    listWorkflowJobs: listWorkflowJobs(resolveToken),
+    triggerWorkflow: triggerWorkflow(resolveToken, approval('triggerWorkflow')),
+    cancelWorkflowRun: cancelWorkflowRun(resolveToken, approval('cancelWorkflowRun')),
+    rerunWorkflowRun: rerunWorkflowRun(resolveToken, approval('rerunWorkflowRun')),
   } satisfies AllGithubTools
 
   if (overrides) {
@@ -165,5 +165,7 @@ export { listCommits, getCommit, getBlame } from './tools/commits'
 export { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 export { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
 export type { CommitIdentity, CommitToolOptions, GithubTool, Octokit, ToolOptions, ToolOverrides } from './types'
+export type { GithubTokenInput, GithubTokenResolver } from './core/token'
+export { createGithubTokenResolver } from './core/token'
 export { createGithubAgent } from './agents'
 export type { CreateGithubAgentOptions } from './agents'

--- a/packages/github-tools/src/tools/commits.ts
+++ b/packages/github-tools/src/tools/commits.ts
@@ -1,4 +1,5 @@
 import { tool } from 'ai'
+import { createGithubTokenStepResolver, type GithubTokenResolver, type GithubTokenStepArgs } from '../core/token'
 import type { GithubTool } from '../types'
 import {
   listCommitsInputSchema,
@@ -13,42 +14,42 @@ import {
 } from '../core/commits'
 import { getCommitToModelOutput } from '../core/model-output'
 
-async function listCommitsStep(args: Parameters<typeof listCommitsCore>[0]) {
+async function listCommitsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listCommitsCore>[0]>) {
   "use step"
-  return listCommitsCore(args)
+  return listCommitsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List commits for a GitHub repository. Filter by file path to see commits that touched a file. */
-export const listCommits = (token: string): GithubTool =>
+export const listCommits = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listCommitsDescription,
     inputSchema: listCommitsInputSchema,
-    execute: async args => listCommitsStep({ token, ...args }),
+    execute: async args => listCommitsStep({ token: await resolveToken(), ...args }),
   })
 
-async function getCommitStep(args: Parameters<typeof getCommitCore>[0]) {
+async function getCommitStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getCommitCore>[0]>) {
   "use step"
-  return getCommitCore(args)
+  return getCommitCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Get detailed information about a specific commit, including files changed with additions and deletions. */
-export const getCommit = (token: string): GithubTool =>
+export const getCommit = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getCommitDescription,
     inputSchema: getCommitInputSchema,
     toModelOutput: getCommitToModelOutput,
-    execute: async args => getCommitStep({ token, ...args }),
+    execute: async args => getCommitStep({ token: await resolveToken(), ...args }),
   })
 
-async function getBlameStep(args: Parameters<typeof getBlameCore>[0]) {
+async function getBlameStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getBlameCore>[0]>) {
   "use step"
-  return getBlameCore(args)
+  return getBlameCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Line-level git blame for a file at a commit-like ref (branch, tag, or SHA). */
-export const getBlame = (token: string): GithubTool =>
+export const getBlame = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getBlameDescription,
     inputSchema: getBlameInputSchema,
-    execute: async args => getBlameStep({ token, ...args }),
+    execute: async args => getBlameStep({ token: await resolveToken(), ...args }),
   })

--- a/packages/github-tools/src/tools/gists.ts
+++ b/packages/github-tools/src/tools/gists.ts
@@ -22,99 +22,100 @@ import {
   createGistCommentDescription,
   createGistCommentCore,
 } from '../core/gists'
-import type { ToolOptions, GithubTool } from '../types'
+import { createGithubTokenStepResolver, type GithubTokenResolver, type GithubTokenStepArgs } from '../core/token'
+import type { GithubTool, ToolOptions } from '../types'
 
-async function listGistsStep(args: Parameters<typeof listGistsCore>[0]) {
+async function listGistsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listGistsCore>[0]>) {
   "use step"
-  return listGistsCore(args)
+  return listGistsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List gists for the authenticated user or a specific user. */
-export const listGists = (token: string): GithubTool =>
+export const listGists = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listGistsDescription,
     inputSchema: listGistsInputSchema,
-    execute: async args => listGistsStep({ token, ...args }),
+    execute: async args => listGistsStep({ token: await resolveToken(), ...args }),
   })
 
-async function getGistStep(args: Parameters<typeof getGistCore>[0]) {
+async function getGistStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getGistCore>[0]>) {
   "use step"
-  return getGistCore(args)
+  return getGistCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Get a gist by ID, including file contents. */
-export const getGist = (token: string): GithubTool =>
+export const getGist = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getGistDescription,
     inputSchema: getGistInputSchema,
-    execute: async args => getGistStep({ token, ...args }),
+    execute: async args => getGistStep({ token: await resolveToken(), ...args }),
   })
 
-async function listGistCommentsStep(args: Parameters<typeof listGistCommentsCore>[0]) {
+async function listGistCommentsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listGistCommentsCore>[0]>) {
   "use step"
-  return listGistCommentsCore(args)
+  return listGistCommentsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List comments on a gist. */
-export const listGistComments = (token: string): GithubTool =>
+export const listGistComments = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listGistCommentsDescription,
     inputSchema: listGistCommentsInputSchema,
-    execute: async args => listGistCommentsStep({ token, ...args }),
+    execute: async args => listGistCommentsStep({ token: await resolveToken(), ...args }),
   })
 
-async function createGistStep(args: Parameters<typeof createGistCore>[0]) {
+async function createGistStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createGistCore>[0]>) {
   "use step"
-  return createGistCore(args)
+  return createGistCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Create a new gist with one or more files. Requires approval by default. */
-export const createGist = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createGist = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createGistDescription,
     needsApproval,
     inputSchema: createGistInputSchema,
-    execute: async args => createGistStep({ token, ...args }),
+    execute: async args => createGistStep({ token: await resolveToken(), ...args }),
   })
 
-async function updateGistStep(args: Parameters<typeof updateGistCore>[0]) {
+async function updateGistStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof updateGistCore>[0]>) {
   "use step"
-  return updateGistCore(args)
+  return updateGistCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Update an existing gist. Requires approval by default. */
-export const updateGist = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const updateGist = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: updateGistDescription,
     needsApproval,
     inputSchema: updateGistInputSchema,
-    execute: async args => updateGistStep({ token, ...args }),
+    execute: async args => updateGistStep({ token: await resolveToken(), ...args }),
   })
 
-async function deleteGistStep(args: Parameters<typeof deleteGistCore>[0]) {
+async function deleteGistStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof deleteGistCore>[0]>) {
   "use step"
-  return deleteGistCore(args)
+  return deleteGistCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Delete a gist permanently. Requires approval by default. */
-export const deleteGist = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const deleteGist = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: deleteGistDescription,
     needsApproval,
     inputSchema: deleteGistInputSchema,
-    execute: async args => deleteGistStep({ token, ...args }),
+    execute: async args => deleteGistStep({ token: await resolveToken(), ...args }),
   })
 
-async function createGistCommentStep(args: Parameters<typeof createGistCommentCore>[0]) {
+async function createGistCommentStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createGistCommentCore>[0]>) {
   "use step"
-  return createGistCommentCore(args)
+  return createGistCommentCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Add a comment to a gist. Requires approval by default. */
-export const createGistComment = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createGistComment = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createGistCommentDescription,
     needsApproval,
     inputSchema: createGistCommentInputSchema,
-    execute: async args => createGistCommentStep({ token, ...args }),
+    execute: async args => createGistCommentStep({ token: await resolveToken(), ...args }),
   })

--- a/packages/github-tools/src/tools/issues.ts
+++ b/packages/github-tools/src/tools/issues.ts
@@ -25,113 +25,114 @@ import {
   removeLabelDescription,
   removeLabelCore,
 } from '../core/issues'
-import type { ToolOptions, GithubTool } from '../types'
+import { createGithubTokenStepResolver, type GithubTokenResolver, type GithubTokenStepArgs } from '../core/token'
+import type { GithubTool, ToolOptions } from '../types'
 
-async function listIssuesStep(args: Parameters<typeof listIssuesCore>[0]) {
+async function listIssuesStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listIssuesCore>[0]>) {
   "use step"
-  return listIssuesCore(args)
+  return listIssuesCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List issues for a GitHub repository (excludes pull requests). */
-export const listIssues = (token: string): GithubTool =>
+export const listIssues = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listIssuesDescription,
     inputSchema: listIssuesInputSchema,
-    execute: async args => listIssuesStep({ token, ...args }),
+    execute: async args => listIssuesStep({ token: await resolveToken(), ...args }),
   })
 
-async function getIssueStep(args: Parameters<typeof getIssueCore>[0]) {
+async function getIssueStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getIssueCore>[0]>) {
   "use step"
-  return getIssueCore(args)
+  return getIssueCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Get detailed information about a specific issue. */
-export const getIssue = (token: string): GithubTool =>
+export const getIssue = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getIssueDescription,
     inputSchema: getIssueInputSchema,
-    execute: async args => getIssueStep({ token, ...args }),
+    execute: async args => getIssueStep({ token: await resolveToken(), ...args }),
   })
 
-async function createIssueStep(args: Parameters<typeof createIssueCore>[0]) {
+async function createIssueStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createIssueCore>[0]>) {
   "use step"
-  return createIssueCore(args)
+  return createIssueCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Create a new issue in a GitHub repository. Requires approval by default. */
-export const createIssue = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createIssue = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createIssueDescription,
     needsApproval,
     inputSchema: createIssueInputSchema,
-    execute: async args => createIssueStep({ token, ...args }),
+    execute: async args => createIssueStep({ token: await resolveToken(), ...args }),
   })
 
-async function addIssueCommentStep(args: Parameters<typeof addIssueCommentCore>[0]) {
+async function addIssueCommentStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof addIssueCommentCore>[0]>) {
   "use step"
-  return addIssueCommentCore(args)
+  return addIssueCommentCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Add a comment to a GitHub issue. Requires approval by default. */
-export const addIssueComment = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const addIssueComment = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: addIssueCommentDescription,
     needsApproval,
     inputSchema: addIssueCommentInputSchema,
-    execute: async args => addIssueCommentStep({ token, ...args }),
+    execute: async args => addIssueCommentStep({ token: await resolveToken(), ...args }),
   })
 
-async function closeIssueStep(args: Parameters<typeof closeIssueCore>[0]) {
+async function closeIssueStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof closeIssueCore>[0]>) {
   "use step"
-  return closeIssueCore(args)
+  return closeIssueCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Close an open GitHub issue. Requires approval by default. */
-export const closeIssue = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const closeIssue = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: closeIssueDescription,
     needsApproval,
     inputSchema: closeIssueInputSchema,
-    execute: async args => closeIssueStep({ token, ...args }),
+    execute: async args => closeIssueStep({ token: await resolveToken(), ...args }),
   })
 
-async function listLabelsStep(args: Parameters<typeof listLabelsCore>[0]) {
+async function listLabelsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listLabelsCore>[0]>) {
   "use step"
-  return listLabelsCore(args)
+  return listLabelsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List labels available in a GitHub repository. */
-export const listLabels = (token: string): GithubTool =>
+export const listLabels = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listLabelsDescription,
     inputSchema: listLabelsInputSchema,
-    execute: async args => listLabelsStep({ token, ...args }),
+    execute: async args => listLabelsStep({ token: await resolveToken(), ...args }),
   })
 
-async function addLabelsStep(args: Parameters<typeof addLabelsCore>[0]) {
+async function addLabelsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof addLabelsCore>[0]>) {
   "use step"
-  return addLabelsCore(args)
+  return addLabelsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Add labels to an issue or pull request. Requires approval by default. */
-export const addLabels = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const addLabels = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: addLabelsDescription,
     needsApproval,
     inputSchema: addLabelsInputSchema,
-    execute: async args => addLabelsStep({ token, ...args }),
+    execute: async args => addLabelsStep({ token: await resolveToken(), ...args }),
   })
 
-async function removeLabelStep(args: Parameters<typeof removeLabelCore>[0]) {
+async function removeLabelStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof removeLabelCore>[0]>) {
   "use step"
-  return removeLabelCore(args)
+  return removeLabelCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Remove a label from an issue or pull request. Requires approval by default. */
-export const removeLabel = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const removeLabel = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: removeLabelDescription,
     needsApproval,
     inputSchema: removeLabelInputSchema,
-    execute: async args => removeLabelStep({ token, ...args }),
+    execute: async args => removeLabelStep({ token: await resolveToken(), ...args }),
   })

--- a/packages/github-tools/src/tools/pull-requests.ts
+++ b/packages/github-tools/src/tools/pull-requests.ts
@@ -26,117 +26,118 @@ import {
   createPullRequestReviewCore,
 } from '../core/pull-requests'
 import { listPullRequestFilesToModelOutput } from '../core/model-output'
-import type { CommitIdentity, ToolOptions, GithubTool } from '../types'
+import { createGithubTokenStepResolver, type GithubTokenResolver, type GithubTokenStepArgs } from '../core/token'
+import type { CommitIdentity, GithubTool, ToolOptions } from '../types'
 
 export type MergeToolOptions = ToolOptions & {
   coAuthors?: CommitIdentity[]
 }
 
-async function listPullRequestsStep(args: Parameters<typeof listPullRequestsCore>[0]) {
+async function listPullRequestsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listPullRequestsCore>[0]>) {
   "use step"
-  return listPullRequestsCore(args)
+  return listPullRequestsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List pull requests for a GitHub repository. */
-export const listPullRequests = (token: string): GithubTool =>
+export const listPullRequests = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listPullRequestsDescription,
     inputSchema: listPullRequestsInputSchema,
-    execute: async args => listPullRequestsStep({ token, ...args }),
+    execute: async args => listPullRequestsStep({ token: await resolveToken(), ...args }),
   })
 
-async function getPullRequestStep(args: Parameters<typeof getPullRequestCore>[0]) {
+async function getPullRequestStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getPullRequestCore>[0]>) {
   "use step"
-  return getPullRequestCore(args)
+  return getPullRequestCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Get detailed information about a specific pull request. */
-export const getPullRequest = (token: string): GithubTool =>
+export const getPullRequest = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getPullRequestDescription,
     inputSchema: getPullRequestInputSchema,
-    execute: async args => getPullRequestStep({ token, ...args }),
+    execute: async args => getPullRequestStep({ token: await resolveToken(), ...args }),
   })
 
-async function createPullRequestStep(args: Parameters<typeof createPullRequestCore>[0]) {
+async function createPullRequestStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createPullRequestCore>[0]>) {
   "use step"
-  return createPullRequestCore(args)
+  return createPullRequestCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Create a new pull request in a GitHub repository. Requires approval by default. */
-export const createPullRequest = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createPullRequest = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createPullRequestDescription,
     needsApproval,
     inputSchema: createPullRequestInputSchema,
-    execute: async args => createPullRequestStep({ token, ...args }),
+    execute: async args => createPullRequestStep({ token: await resolveToken(), ...args }),
   })
 
-async function mergePullRequestStep(args: Parameters<typeof mergePullRequestCore>[0]) {
+async function mergePullRequestStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof mergePullRequestCore>[0]>) {
   "use step"
-  return mergePullRequestCore(args)
+  return mergePullRequestCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Merge a pull request. Requires approval by default. */
-export const mergePullRequest = (token: string, { needsApproval = true, coAuthors }: MergeToolOptions = {}): GithubTool =>
+export const mergePullRequest = (resolveToken: GithubTokenResolver, { needsApproval = true, coAuthors }: MergeToolOptions = {}): GithubTool =>
   tool({
     description: mergePullRequestDescription,
     needsApproval,
     inputSchema: mergePullRequestInputSchema,
-    execute: async args => mergePullRequestStep({ token, coAuthors, ...args }),
+    execute: async args => mergePullRequestStep({ token: await resolveToken(), coAuthors, ...args }),
   })
 
-async function addPullRequestCommentStep(args: Parameters<typeof addPullRequestCommentCore>[0]) {
+async function addPullRequestCommentStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof addPullRequestCommentCore>[0]>) {
   "use step"
-  return addPullRequestCommentCore(args)
+  return addPullRequestCommentCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Add a comment to a pull request. Requires approval by default. */
-export const addPullRequestComment = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const addPullRequestComment = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: addPullRequestCommentDescription,
     needsApproval,
     inputSchema: addPullRequestCommentInputSchema,
-    execute: async args => addPullRequestCommentStep({ token, ...args }),
+    execute: async args => addPullRequestCommentStep({ token: await resolveToken(), ...args }),
   })
 
-async function listPullRequestFilesStep(args: Parameters<typeof listPullRequestFilesCore>[0]) {
+async function listPullRequestFilesStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listPullRequestFilesCore>[0]>) {
   "use step"
-  return listPullRequestFilesCore(args)
+  return listPullRequestFilesCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List files changed in a pull request, including diff status and patch content. */
-export const listPullRequestFiles = (token: string): GithubTool =>
+export const listPullRequestFiles = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listPullRequestFilesDescription,
     inputSchema: listPullRequestFilesInputSchema,
     toModelOutput: listPullRequestFilesToModelOutput,
-    execute: async args => listPullRequestFilesStep({ token, ...args }),
+    execute: async args => listPullRequestFilesStep({ token: await resolveToken(), ...args }),
   })
 
-async function listPullRequestReviewsStep(args: Parameters<typeof listPullRequestReviewsCore>[0]) {
+async function listPullRequestReviewsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listPullRequestReviewsCore>[0]>) {
   "use step"
-  return listPullRequestReviewsCore(args)
+  return listPullRequestReviewsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List reviews on a pull request (approvals, change requests, and comments). */
-export const listPullRequestReviews = (token: string): GithubTool =>
+export const listPullRequestReviews = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listPullRequestReviewsDescription,
     inputSchema: listPullRequestReviewsInputSchema,
-    execute: async args => listPullRequestReviewsStep({ token, ...args }),
+    execute: async args => listPullRequestReviewsStep({ token: await resolveToken(), ...args }),
   })
 
-async function createPullRequestReviewStep(args: Parameters<typeof createPullRequestReviewCore>[0]) {
+async function createPullRequestReviewStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createPullRequestReviewCore>[0]>) {
   "use step"
-  return createPullRequestReviewCore(args)
+  return createPullRequestReviewCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Submit a pull request review with optional inline comments. Requires approval by default. */
-export const createPullRequestReview = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createPullRequestReview = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createPullRequestReviewDescription,
     needsApproval,
     inputSchema: createPullRequestReviewInputSchema,
-    execute: async args => createPullRequestReviewStep({ token, ...args }),
+    execute: async args => createPullRequestReviewStep({ token: await resolveToken(), ...args }),
   })

--- a/packages/github-tools/src/tools/repository.ts
+++ b/packages/github-tools/src/tools/repository.ts
@@ -24,105 +24,106 @@ import {
   composeCommitMessage,
 } from '../core/repository'
 import { getFileContentToModelOutput } from '../core/model-output'
-import type { CommitToolOptions, ToolOptions, GithubTool } from '../types'
+import { createGithubTokenStepResolver, type GithubTokenResolver, type GithubTokenStepArgs } from '../core/token'
+import type { CommitToolOptions, GithubTool, ToolOptions } from '../types'
 
 export { composeCommitMessage }
 
-async function getRepositoryStep(args: Parameters<typeof getRepositoryCore>[0]) {
+async function getRepositoryStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getRepositoryCore>[0]>) {
   "use step"
-  return getRepositoryCore(args)
+  return getRepositoryCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Get information about a GitHub repository including description, stars, forks, language, and default branch. */
-export const getRepository = (token: string): GithubTool =>
+export const getRepository = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getRepositoryDescription,
     inputSchema: getRepositoryInputSchema,
-    execute: async args => getRepositoryStep({ token, ...args }),
+    execute: async args => getRepositoryStep({ token: await resolveToken(), ...args }),
   })
 
-async function listBranchesStep(args: Parameters<typeof listBranchesCore>[0]) {
+async function listBranchesStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listBranchesCore>[0]>) {
   "use step"
-  return listBranchesCore(args)
+  return listBranchesCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List branches in a GitHub repository. */
-export const listBranches = (token: string): GithubTool =>
+export const listBranches = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listBranchesDescription,
     inputSchema: listBranchesInputSchema,
-    execute: async args => listBranchesStep({ token, ...args }),
+    execute: async args => listBranchesStep({ token: await resolveToken(), ...args }),
   })
 
-async function getFileContentStep(args: Parameters<typeof getFileContentCore>[0]) {
+async function getFileContentStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getFileContentCore>[0]>) {
   "use step"
-  return getFileContentCore(args)
+  return getFileContentCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Get the content of a file from a GitHub repository. */
-export const getFileContent = (token: string): GithubTool =>
+export const getFileContent = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getFileContentDescription,
     inputSchema: getFileContentInputSchema,
     toModelOutput: getFileContentToModelOutput,
-    execute: async args => getFileContentStep({ token, ...args }),
+    execute: async args => getFileContentStep({ token: await resolveToken(), ...args }),
   })
 
-async function createBranchStep(args: Parameters<typeof createBranchCore>[0]) {
+async function createBranchStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createBranchCore>[0]>) {
   "use step"
-  return createBranchCore(args)
+  return createBranchCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Create a new branch in a GitHub repository from an existing branch or commit SHA. Requires approval by default. */
-export const createBranch = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createBranch = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createBranchDescription,
     needsApproval,
     inputSchema: createBranchInputSchema,
-    execute: async args => createBranchStep({ token, ...args }),
+    execute: async args => createBranchStep({ token: await resolveToken(), ...args }),
   })
 
-async function forkRepositoryStep(args: Parameters<typeof forkRepositoryCore>[0]) {
+async function forkRepositoryStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof forkRepositoryCore>[0]>) {
   "use step"
-  return forkRepositoryCore(args)
+  return forkRepositoryCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Fork a GitHub repository to the authenticated user account or a specified organization. Requires approval by default. */
-export const forkRepository = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const forkRepository = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: forkRepositoryDescription,
     needsApproval,
     inputSchema: forkRepositoryInputSchema,
-    execute: async args => forkRepositoryStep({ token, ...args }),
+    execute: async args => forkRepositoryStep({ token: await resolveToken(), ...args }),
   })
 
-async function createRepositoryStep(args: Parameters<typeof createRepositoryCore>[0]) {
+async function createRepositoryStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createRepositoryCore>[0]>) {
   "use step"
-  return createRepositoryCore(args)
+  return createRepositoryCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Create a new GitHub repository for the authenticated user or a specified organization. Requires approval by default. */
-export const createRepository = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createRepository = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createRepositoryDescription,
     needsApproval,
     inputSchema: createRepositoryInputSchema,
-    execute: async args => createRepositoryStep({ token, ...args }),
+    execute: async args => createRepositoryStep({ token: await resolveToken(), ...args }),
   })
 
-async function createOrUpdateFileStep(args: Parameters<typeof createOrUpdateFileCore>[0]) {
+async function createOrUpdateFileStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof createOrUpdateFileCore>[0]>) {
   "use step"
-  return createOrUpdateFileCore(args)
+  return createOrUpdateFileCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Create or update a file in a GitHub repository. Provide the SHA when updating an existing file. Requires approval by default. */
 export const createOrUpdateFile = (
-  token: string,
+  resolveToken: GithubTokenResolver,
   { needsApproval = true, author, committer, coAuthors }: CommitToolOptions = {},
 ): GithubTool =>
   tool({
     description: createOrUpdateFileDescription,
     needsApproval,
     inputSchema: createOrUpdateFileInputSchema,
-    execute: async args => createOrUpdateFileStep({ token, author, committer, coAuthors, ...args }),
+    execute: async args => createOrUpdateFileStep({ token: await resolveToken(), author, committer, coAuthors, ...args }),
   })

--- a/packages/github-tools/src/tools/search.ts
+++ b/packages/github-tools/src/tools/search.ts
@@ -1,4 +1,5 @@
 import { tool } from 'ai'
+import { createGithubTokenStepResolver, type GithubTokenResolver, type GithubTokenStepArgs } from '../core/token'
 import type { GithubTool } from '../types'
 import {
   searchCodeInputSchema,
@@ -9,28 +10,28 @@ import {
   searchRepositoriesCore,
 } from '../core/search'
 
-async function searchCodeStep(args: Parameters<typeof searchCodeCore>[0]) {
+async function searchCodeStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof searchCodeCore>[0]>) {
   "use step"
-  return searchCodeCore(args)
+  return searchCodeCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search. */
-export const searchCode = (token: string): GithubTool =>
+export const searchCode = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: searchCodeDescription,
     inputSchema: searchCodeInputSchema,
-    execute: async args => searchCodeStep({ token, ...args }),
+    execute: async args => searchCodeStep({ token: await resolveToken(), ...args }),
   })
 
-async function searchRepositoriesStep(args: Parameters<typeof searchRepositoriesCore>[0]) {
+async function searchRepositoriesStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof searchRepositoriesCore>[0]>) {
   "use step"
-  return searchRepositoriesCore(args)
+  return searchRepositoriesCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Search for GitHub repositories by keyword, topic, language, or other qualifiers. */
-export const searchRepositories = (token: string): GithubTool =>
+export const searchRepositories = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: searchRepositoriesDescription,
     inputSchema: searchRepositoriesInputSchema,
-    execute: async args => searchRepositoriesStep({ token, ...args }),
+    execute: async args => searchRepositoriesStep({ token: await resolveToken(), ...args }),
   })

--- a/packages/github-tools/src/tools/workflows.ts
+++ b/packages/github-tools/src/tools/workflows.ts
@@ -22,98 +22,99 @@ import {
   rerunWorkflowRunDescription,
   rerunWorkflowRunCore,
 } from '../core/workflows'
-import type { ToolOptions, GithubTool } from '../types'
+import { createGithubTokenStepResolver, type GithubTokenResolver, type GithubTokenStepArgs } from '../core/token'
+import type { GithubTool, ToolOptions } from '../types'
 
-async function listWorkflowsStep(args: Parameters<typeof listWorkflowsCore>[0]) {
+async function listWorkflowsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listWorkflowsCore>[0]>) {
   "use step"
-  return listWorkflowsCore(args)
+  return listWorkflowsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List GitHub Actions workflows in a repository. */
-export const listWorkflows = (token: string): GithubTool =>
+export const listWorkflows = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listWorkflowsDescription,
     inputSchema: listWorkflowsInputSchema,
-    execute: async args => listWorkflowsStep({ token, ...args }),
+    execute: async args => listWorkflowsStep({ token: await resolveToken(), ...args }),
   })
 
-async function listWorkflowRunsStep(args: Parameters<typeof listWorkflowRunsCore>[0]) {
+async function listWorkflowRunsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listWorkflowRunsCore>[0]>) {
   "use step"
-  return listWorkflowRunsCore(args)
+  return listWorkflowRunsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List workflow runs for a repository, optionally filtered by workflow, branch, status, or event. */
-export const listWorkflowRuns = (token: string): GithubTool =>
+export const listWorkflowRuns = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listWorkflowRunsDescription,
     inputSchema: listWorkflowRunsInputSchema,
-    execute: async args => listWorkflowRunsStep({ token, ...args }),
+    execute: async args => listWorkflowRunsStep({ token: await resolveToken(), ...args }),
   })
 
-async function getWorkflowRunStep(args: Parameters<typeof getWorkflowRunCore>[0]) {
+async function getWorkflowRunStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof getWorkflowRunCore>[0]>) {
   "use step"
-  return getWorkflowRunCore(args)
+  return getWorkflowRunCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Get details of a specific workflow run including status, timing, and trigger info. */
-export const getWorkflowRun = (token: string): GithubTool =>
+export const getWorkflowRun = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: getWorkflowRunDescription,
     inputSchema: getWorkflowRunInputSchema,
-    execute: async args => getWorkflowRunStep({ token, ...args }),
+    execute: async args => getWorkflowRunStep({ token: await resolveToken(), ...args }),
   })
 
-async function listWorkflowJobsStep(args: Parameters<typeof listWorkflowJobsCore>[0]) {
+async function listWorkflowJobsStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof listWorkflowJobsCore>[0]>) {
   "use step"
-  return listWorkflowJobsCore(args)
+  return listWorkflowJobsCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** List jobs for a workflow run, including step-level status and timing. */
-export const listWorkflowJobs = (token: string): GithubTool =>
+export const listWorkflowJobs = (resolveToken: GithubTokenResolver): GithubTool =>
   tool({
     description: listWorkflowJobsDescription,
     inputSchema: listWorkflowJobsInputSchema,
-    execute: async args => listWorkflowJobsStep({ token, ...args }),
+    execute: async args => listWorkflowJobsStep({ token: await resolveToken(), ...args }),
   })
 
-async function triggerWorkflowStep(args: Parameters<typeof triggerWorkflowCore>[0]) {
+async function triggerWorkflowStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof triggerWorkflowCore>[0]>) {
   "use step"
-  return triggerWorkflowCore(args)
+  return triggerWorkflowCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Trigger a workflow via workflow_dispatch event. Requires approval by default. */
-export const triggerWorkflow = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const triggerWorkflow = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: triggerWorkflowDescription,
     needsApproval,
     inputSchema: triggerWorkflowInputSchema,
-    execute: async args => triggerWorkflowStep({ token, ...args }),
+    execute: async args => triggerWorkflowStep({ token: await resolveToken(), ...args }),
   })
 
-async function cancelWorkflowRunStep(args: Parameters<typeof cancelWorkflowRunCore>[0]) {
+async function cancelWorkflowRunStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof cancelWorkflowRunCore>[0]>) {
   "use step"
-  return cancelWorkflowRunCore(args)
+  return cancelWorkflowRunCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Cancel an in-progress workflow run. Requires approval by default. */
-export const cancelWorkflowRun = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const cancelWorkflowRun = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: cancelWorkflowRunDescription,
     needsApproval,
     inputSchema: cancelWorkflowRunInputSchema,
-    execute: async args => cancelWorkflowRunStep({ token, ...args }),
+    execute: async args => cancelWorkflowRunStep({ token: await resolveToken(), ...args }),
   })
 
-async function rerunWorkflowRunStep(args: Parameters<typeof rerunWorkflowRunCore>[0]) {
+async function rerunWorkflowRunStep({ token, ...args }: GithubTokenStepArgs<Parameters<typeof rerunWorkflowRunCore>[0]>) {
   "use step"
-  return rerunWorkflowRunCore(args)
+  return rerunWorkflowRunCore({ resolveToken: createGithubTokenStepResolver(token), ...args })
 }
 
 /** Re-run a workflow run, optionally only the failed jobs. Requires approval by default. */
-export const rerunWorkflowRun = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const rerunWorkflowRun = (resolveToken: GithubTokenResolver, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: rerunWorkflowRunDescription,
     needsApproval,
     inputSchema: rerunWorkflowRunInputSchema,
-    execute: async args => rerunWorkflowRunStep({ token, ...args }),
+    execute: async args => rerunWorkflowRunStep({ token: await resolveToken(), ...args }),
   })

--- a/packages/github-tools/src/workflow.ts
+++ b/packages/github-tools/src/workflow.ts
@@ -22,6 +22,7 @@ import type { CombinedPresetToolNames, GithubToolPreset, PresetToolName } from '
 import type { GithubToolName } from './core/tool-names'
 import type { ApprovalConfig } from './index'
 import type { CommitIdentity } from './types'
+import type { GithubTokenInput } from './core/token'
 import type { Context } from '@ai-sdk/provider-utils'
 
 /**
@@ -116,10 +117,10 @@ export type CreateDurableGithubAgentOptions =
   Omit<WorkflowAgentOptions, 'model' | 'tools' | 'instructions'> & {
     model: string | LanguageModel
     /**
-     * GitHub personal access token.
+     * GitHub personal access token or async token provider.
      * Falls back to `process.env.GITHUB_TOKEN` when omitted.
      */
-    token?: string
+    token?: GithubTokenInput
     /**
      * Restrict tools and system prompt to a predefined preset.
      *
@@ -224,6 +225,6 @@ export function createDurableGithubAgent({
 }
 
 export { createGithubTools, createGithubAgent } from './index'
-export type { CommitIdentity, CommitToolOptions, GithubTools, GithubToolsOptions, GithubToolPreset, GithubToolName, GithubWriteToolName, ApprovalConfig, ToolOverrides, AllGithubTools, PresetToolName, CombinedPresetToolNames, GithubToolsForPreset, PickGithubTools } from './index'
-export { PRESET_TOOLS, GITHUB_TOOL_NAMES, GITHUB_WRITE_TOOLS } from './index'
+export type { CommitIdentity, CommitToolOptions, GithubTools, GithubToolsOptions, GithubToolPreset, GithubToolName, GithubWriteToolName, ApprovalConfig, ToolOverrides, AllGithubTools, PresetToolName, CombinedPresetToolNames, GithubToolsForPreset, PickGithubTools, GithubTokenInput, GithubTokenResolver } from './index'
+export { PRESET_TOOLS, GITHUB_TOOL_NAMES, GITHUB_WRITE_TOOLS, createGithubTokenResolver } from './index'
 export type { CreateGithubAgentOptions } from './agents'


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### 📚 Description

Allow GitHub token configuration to be either a token string or an async provider function. The input is normalized with createGithubTokenResolver into a predictable async resolveToken function, which is passed through SDK tools, Eve tool builders, workflow support, and Octokit creation.

Throws immediately when no token input or GITHUB_TOKEN environment variable is available, updates docs and README examples, adds tests, and includes a changeset.

Verification run:
- pnpm --filter @github-tools/sdk test
- pnpm --filter @github-tools/sdk typecheck
- pnpm typecheck
- pnpm lint
- pnpm build

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.