### PR TITLE
feat: support async github token providers

### DIFF
--- a/.changeset/async-github-token-provider.md
+++ b/.changeset/async-github-token-provider.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Allow GitHub token inputs to be strings or async provider functions (`GithubTokenInput`). Adds a `resolveGithubToken` helper for custom tool factories.

--- a/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
+++ b/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
@@ -90,6 +90,20 @@ const { text } = await generateText({
 ```
 ::
 
+The `token` option accepts a `GithubTokenInput`: either a token string or an async provider when the token should be minted lazily for each tool execution:
+
+```ts [lazy-token.ts]
+const tools = createGithubTools({
+  token: () => getToken('github/my-connector', {
+    subject: { type: 'app' },
+    scopes: ['contents:read', 'pull_requests:read'],
+  }),
+  preset: 'code-review',
+})
+```
+
+The provider is invoked at each tool execution, so short-lived tokens stay fresh across a long agent run. Note that in durable workflows the resolved token string is captured in the step arguments — a retried step reuses the token it was first invoked with rather than requesting a new one.
+
 Call `getToken` per request rather than caching the string yourself — the SDK keeps an in-process cache and refreshes tokens as they approach expiry. For multi-tenant connectors (one connector installed on several GitHub organizations), pass `installationId` to target a specific installation.
 
 ### Why Connect over a PAT

--- a/apps/docs/content/docs/4.api/2.reference.md
+++ b/apps/docs/content/docs/4.api/2.reference.md
@@ -46,7 +46,7 @@ Returns a record of AI SDK tools you can pass to `generateText` or `streamText`.
 
 ```ts [types.ts]
 type GithubToolsOptions = {
-  token?: string
+  token?: GithubTokenInput
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   overrides?: Partial<Record<string, ToolOverrides>>
   preset?: GithubToolPreset | GithubToolPreset[]
@@ -54,6 +54,8 @@ type GithubToolsOptions = {
   committer?: CommitIdentity
   coAuthors?: CommitIdentity[]
 }
+
+type GithubTokenInput = string | (() => Promise<string>)
 
 type CommitIdentity = {
   name: string
@@ -156,7 +158,7 @@ Returns a `ToolLoopAgent` with GitHub tools and system instructions pre-configur
 ```ts [types.ts]
 type GithubAgentOptions = {
   model: string
-  token?: string
+  token?: GithubTokenInput
   preset?: GithubToolPreset | GithubToolPreset[]
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   system?: string
@@ -241,7 +243,7 @@ export default createGithubTools({
 
 ```ts [types-eve.ts]
 type EveGithubToolsOptions = {
-  token?: string
+  token?: GithubTokenInput
   preset?: GithubToolPreset | GithubToolPreset[]
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, EveApprovalValue>>
   overrides?: EveToolOverrides
@@ -260,14 +262,18 @@ type EveApprovalValue =
 
 Also exports individual eve tool factories (`listPullRequests()`, `createIssue()`, …) for one-tool-per-file layouts. Approval supports `once`, predicates, and eve helper passthrough — unlike the Workflow subpath, approval **is enforced** at runtime.
 
+## `resolveGithubToken(token?)`
+
+Resolves a `GithubTokenInput` (token string, async provider, or the `process.env.GITHUB_TOKEN` fallback) to a token string. Throws when no token is available.
+
 ## `createOctokit(token?)`
 
 Returns a configured [`@octokit/rest`](https://github.com/octokit/rest.js) instance. Use this when you need lower-level GitHub API access or want to build custom tool factories:
 
 ```ts [custom-tool.ts]
-import { createOctokit } from '@github-tools/sdk'
+import { createOctokit, resolveGithubToken } from '@github-tools/sdk'
 
-const octokit = createOctokit()
+const octokit = createOctokit(await resolveGithubToken())
 const { data } = await octokit.repos.get({ owner: 'HugoRCD', repo: 'github-tools' })
 ```
 

--- a/examples/eve-agent/.env.example
+++ b/examples/eve-agent/.env.example
@@ -1,1 +1,3 @@
-GITHUB_TOKEN=ghp_...
+# Vercel Connect OIDC token — required for the GitHub connector.
+# From this directory: vercel link && vercel env pull
+VERCEL_OIDC_TOKEN=

--- a/examples/eve-agent/README.md
+++ b/examples/eve-agent/README.md
@@ -1,14 +1,25 @@
 # GitHub eve Agent
 
-Minimal [eve](https://eve.dev) agent using `@github-tools/sdk/eve` with the `code-review` preset.
+Minimal [eve](https://eve.dev) agent using `@github-tools/sdk/eve` with the `maintainer` preset.
+
+> **Temporary:** this example uses [Vercel Connect](https://vercel.com/docs/connect) (`github/test-github-tools`) instead of a `GITHUB_TOKEN` PAT. Revert `agent/tools/github.ts` to drop the `token` provider when you're done testing.
 
 ## Setup
 
+### 1. Link the Connect connector
+
+The connector `github/test-github-tools` must be linked to your Vercel project and installed on the GitHub org/repos you want the agent to access.
+
+### 2. Pull the OIDC token for local dev
+
 ```bash
 pnpm install
-cp .env.example .env
-# set GITHUB_TOKEN in .env
+cd examples/eve-agent
+vercel link    # select the github-tools-docs project (or your linked project)
+vercel env pull
 ```
+
+This writes `VERCEL_OIDC_TOKEN` into `.env.local`. Re-run `vercel env pull` when the token expires.
 
 Requires `ai` v7 (peer of `eve` v0.19+) and Node 24+.
 
@@ -27,7 +38,7 @@ From the monorepo root:
 pnpm dev:eve-agent
 ```
 
-Open the dev TUI and ask it to review a pull request on a repo your token can access.
+Open the dev TUI and ask it to review a pull request on a repo your connector can access.
 
 ## Project structure
 
@@ -35,7 +46,7 @@ Open the dev TUI and ask it to review a pull request on a repo your token can ac
 agent/
   agent.ts              # eve agent config
   instructions.md       # system prompt
-  tools/github.ts       # all GitHub tools via createGithubTools()
+  tools/github.ts       # GitHub tools via createGithubTools() + Vercel Connect
 ```
 
 ## Customize
@@ -45,6 +56,10 @@ Swap the preset or configure approval:
 ```ts
 export default createGithubTools({
   preset: ['code-review', 'issue-triage'],
+  token: () => getToken('github/test-github-tools', {
+    subject: { type: 'app' },
+    scopes: ['contents:read', 'pull_requests:read'],
+  }),
   requireApproval: {
     mergePullRequest: true,
     addPullRequestComment: 'once',

--- a/examples/eve-agent/agent/tools/github.ts
+++ b/examples/eve-agent/agent/tools/github.ts
@@ -1,5 +1,27 @@
+import { getToken } from '@vercel/connect'
 import { createGithubTools } from '@github-tools/sdk/eve'
+
+// TEMP: Vercel Connect instead of GITHUB_TOKEN — connector "test-github-tools" on github-tools-docs
+const CONNECTOR_UID = 'github/test-github-tools'
+
+/** Scopes for the maintainer preset — https://github-tools.com/guide/tokens-and-auth */
+const MAINTAINER_SCOPES = [
+  'contents:read',
+  'contents:write',
+  'pull_requests:read',
+  'pull_requests:write',
+  'issues:read',
+  'issues:write',
+  'actions:read',
+  'actions:write',
+  'administration:read',
+  'administration:write',
+] as const
 
 export default createGithubTools({
   preset: 'maintainer',
+  token: () => getToken(CONNECTOR_UID, {
+    subject: { type: 'app' },
+    scopes: [...MAINTAINER_SCOPES],
+  }),
 })

--- a/examples/eve-agent/package.json
+++ b/examples/eve-agent/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@github-tools/sdk": "workspace:*",
+    "@vercel/connect": "^0.3.2",
     "ai": "^7.0.0",
     "eve": "^0.19.0",
     "zod": "^4.3.6"

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -400,10 +400,12 @@ Returns an object of tools, ready to spread into `tools` of any AI SDK call.
 
 ```ts
 type GithubToolsOptions = {
-  token?: string // defaults to process.env.GITHUB_TOKEN
+  token?: GithubTokenInput // defaults to process.env.GITHUB_TOKEN
   requireApproval?: boolean | Partial<Record<GithubWriteToolName, boolean>>
   preset?: GithubToolPreset | GithubToolPreset[]
 }
+
+type GithubTokenInput = string | (() => Promise<string>)
 
 type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'ci-ops' | 'maintainer'
 ```
@@ -451,7 +453,7 @@ const stream = reviewer.stream({ prompt: 'Review PR #42 on vercel/ai' })
 | Option | Description |
 |---|---|
 | `model` | Language model — string (`'anthropic/claude-sonnet-4.6'`) or provider instance |
-| `token` | GitHub personal access token |
+| `token` | GitHub token string or async provider |
 | `preset` | Optional preset or array of presets to scope tools |
 | `requireApproval` | Approval config (same as `createGithubTools`) |
 | `instructions` | Replaces the built-in system prompt entirely |
@@ -510,6 +512,10 @@ async function agentTurn(prompt: string) {
 > See [`examples/pr-review-agent`](../../examples/pr-review-agent) for a complete PR review agent built with Chat SDK and Vercel Workflow.
 
 All presets (`code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `maintainer`) work with `createDurableGithubAgent`. Options mirror `createGithubAgent` with additional pass-through for `WorkflowAgentOptions` fields like `experimental_telemetry`, `onStepEnd`, `onEnd`, and `prepareStep`. Write tools honor `requireApproval` via `needsApproval`.
+
+### `resolveGithubToken(token?)`
+
+Resolves a `GithubTokenInput` (token string, async provider, or `process.env.GITHUB_TOKEN`) to a token string. Throws when no token is available.
 
 ### `createOctokit(token)`
 

--- a/packages/github-tools/src/core/token.test.ts
+++ b/packages/github-tools/src/core/token.test.ts
@@ -1,22 +1,44 @@
 import { describe, expect, it } from 'vitest'
-import { resolveGithubToken } from './token'
+import { createGithubTokenResolver, resolveGithubToken } from './token'
 
-describe('resolveGithubToken', () => {
-  it('uses the provided token', () => {
-    expect(resolveGithubToken('ghp_explicit')).toBe('ghp_explicit')
+describe('createGithubTokenResolver', () => {
+  it('normalizes a token string into an async resolver', async () => {
+    const resolveToken = createGithubTokenResolver('ghp_explicit')
+    await expect(resolveToken()).resolves.toBe('ghp_explicit')
   })
 
-  it('falls back to process.env.GITHUB_TOKEN', () => {
+  it('uses an async token provider', async () => {
+    const resolveToken = createGithubTokenResolver(async () => 'ghp_dynamic')
+    await expect(resolveToken()).resolves.toBe('ghp_dynamic')
+  })
+
+  it('throws when an async token provider resolves empty', async () => {
+    const resolveToken = createGithubTokenResolver(async () => '')
+    await expect(resolveToken()).rejects.toThrow('GitHub token is required')
+  })
+
+  it('falls back to process.env.GITHUB_TOKEN', async () => {
     const previous = process.env.GITHUB_TOKEN
     process.env.GITHUB_TOKEN = 'ghp_env'
-    expect(resolveGithubToken()).toBe('ghp_env')
+    const resolveToken = createGithubTokenResolver()
+    await expect(resolveToken()).resolves.toBe('ghp_env')
     process.env.GITHUB_TOKEN = previous
   })
 
-  it('throws when no token is available', () => {
+  it('throws immediately when no token is available', () => {
     const previous = process.env.GITHUB_TOKEN
     delete process.env.GITHUB_TOKEN
-    expect(() => resolveGithubToken()).toThrow('GitHub token is required')
+    expect(() => createGithubTokenResolver()).toThrow('GitHub token is required')
     process.env.GITHUB_TOKEN = previous
+  })
+})
+
+describe('resolveGithubToken', () => {
+  it('resolves a token string', async () => {
+    await expect(resolveGithubToken('ghp_explicit')).resolves.toBe('ghp_explicit')
+  })
+
+  it('resolves an async token provider', async () => {
+    await expect(resolveGithubToken(async () => 'ghp_dynamic')).resolves.toBe('ghp_dynamic')
   })
 })

--- a/packages/github-tools/src/core/token.ts
+++ b/packages/github-tools/src/core/token.ts
@@ -1,7 +1,34 @@
-export function resolveGithubToken(token?: string): string {
+export type GithubTokenInput = string | (() => Promise<string>)
+export type GithubTokenResolver = () => Promise<string>
+
+const TOKEN_REQUIRED_ERROR = 'GitHub token is required. Pass it as `token` or set the GITHUB_TOKEN environment variable.'
+
+/**
+ * Normalizes a token string, async token provider, or `process.env.GITHUB_TOKEN`
+ * into a `() => Promise<string>` resolver.
+ *
+ * Throws immediately for static inputs when no token is available. Provider
+ * functions are validated lazily, each time the resolver is invoked.
+ */
+export function createGithubTokenResolver(token?: GithubTokenInput): GithubTokenResolver {
+  if (typeof token === 'function') {
+    return async () => {
+      const resolvedToken = await token()
+      if (!resolvedToken) {
+        throw new Error(TOKEN_REQUIRED_ERROR)
+      }
+      return resolvedToken
+    }
+  }
+
   const resolvedToken = token || process.env.GITHUB_TOKEN
   if (!resolvedToken) {
-    throw new Error('GitHub token is required. Pass it as `token` or set the GITHUB_TOKEN environment variable.')
+    throw new Error(TOKEN_REQUIRED_ERROR)
   }
-  return resolvedToken
+  return async () => resolvedToken
+}
+
+/** Resolves a {@link GithubTokenInput} to a token string. */
+export function resolveGithubToken(token?: GithubTokenInput): Promise<string> {
+  return createGithubTokenResolver(token)()
 }

--- a/packages/github-tools/src/core/tool-types.ts
+++ b/packages/github-tools/src/core/tool-types.ts
@@ -1,5 +1,6 @@
 import type { ApprovalConfig } from './approval'
 import type { CombinedPresetToolNames, GithubToolPreset, PresetToolName } from './presets'
+import type { GithubTokenInput } from './token'
 import type { GithubToolName } from './tool-names'
 import type { CommitIdentity, GithubTool, ToolOverrides } from '../types'
 
@@ -8,8 +9,8 @@ export type AllGithubTools = Record<GithubToolName, GithubTool>
 
 /** Base options shared by all {@link createGithubTools} overloads. */
 export type GithubToolsBaseOptions = {
-  /** GitHub personal access token. Falls back to `process.env.GITHUB_TOKEN` when omitted. */
-  token?: string
+  /** GitHub token string or async provider. Falls back to `process.env.GITHUB_TOKEN` when omitted. */
+  token?: GithubTokenInput
   /** Control whether write operations require user approval. @see {@link ApprovalConfig} */
   requireApproval?: ApprovalConfig
   /** Per-tool overrides for description, title, needsApproval, and related AI SDK tool fields. */

--- a/packages/github-tools/src/eve/build.ts
+++ b/packages/github-tools/src/eve/build.ts
@@ -1,6 +1,6 @@
 import type { ToolDefinition } from 'eve/tools'
 import { resolvePresetTools, type CombinedPresetToolNames, type GithubToolPreset, type PresetToolName } from '../core/presets'
-import { resolveGithubToken } from '../core/token'
+import { createGithubTokenResolver } from '../core/token'
 import { mapEveApprovalValue, resolveEveApproval } from './approval'
 import { getEveTools } from './load-eve'
 import { ALL_GITHUB_TOOL_NAMES, createToolRegistry, type GithubToolName, type ToolBuildContext } from './registry'
@@ -31,9 +31,8 @@ export function buildEveToolDefinition(
   options: BuildOptions = {},
 ): ToolDefinition {
   const { defineTool } = getEveTools()
-  const token = resolveGithubToken(options.token)
   const ctx: ToolBuildContext = {
-    token,
+    token: createGithubTokenResolver(options.token),
     author: options.author,
     committer: options.committer,
     coAuthors: options.coAuthors,
@@ -59,9 +58,8 @@ export function buildEveToolDefinition(
 
 export function buildEveToolMap(options: EveGithubToolsOptions = {}): EveToolMap {
   const { defineTool } = getEveTools()
-  const token = resolveGithubToken(options.token)
   const ctx: ToolBuildContext = {
-    token,
+    token: createGithubTokenResolver(options.token),
     author: options.author,
     committer: options.committer,
     coAuthors: options.coAuthors,

--- a/packages/github-tools/src/eve/registry.ts
+++ b/packages/github-tools/src/eve/registry.ts
@@ -13,13 +13,14 @@ import * as pullRequests from '../core/pull-requests'
 import * as repository from '../core/repository'
 import * as search from '../core/search'
 import * as workflows from '../core/workflows'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { GithubWriteToolName } from '../core/write-tools'
 import type { GithubToolName } from '../core/tool-names'
 export type { GithubToolName } from '../core/tool-names'
 export { ALL_GITHUB_TOOL_NAMES } from '../core/tool-names'
 
 export type ToolBuildContext = {
-  token: string
+  token: GithubTokenInput
   author?: CommitIdentity
   committer?: CommitIdentity
   coAuthors?: CommitIdentity[]
@@ -39,7 +40,7 @@ function withToken<T extends Record<string, unknown>>(
   ctx: ToolBuildContext,
   extra?: Record<string, unknown>,
 ) {
-  return (input: Record<string, unknown>) => core({ token: ctx.token, ...extra, ...input } as T & { token: string })
+  return async (input: Record<string, unknown>) => core({ token: await resolveGithubToken(ctx.token), ...extra, ...input } as T & { token: string })
 }
 
 function modelOutputAdapter(
@@ -331,4 +332,3 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
     },
   ]
 }
-

--- a/packages/github-tools/src/eve/steps.ts
+++ b/packages/github-tools/src/eve/steps.ts
@@ -1,3 +1,4 @@
+import { resolveGithubToken } from '../core/token'
 import { createToolRegistry, type GithubToolName, type ToolBuildContext } from './registry'
 
 async function executeGithubToolStep(
@@ -13,10 +14,12 @@ async function executeGithubToolStep(
   return entry.execute(input)
 }
 
-export function runGithubToolStep(
+export async function runGithubToolStep(
   name: GithubToolName,
   input: Record<string, unknown>,
   ctx: ToolBuildContext,
 ) {
-  return executeGithubToolStep(name, input, ctx)
+  // Resolve the token before entering the step so only a serializable string crosses the boundary.
+  const token = await resolveGithubToken(ctx.token)
+  return executeGithubToolStep(name, input, { ...ctx, token })
 }

--- a/packages/github-tools/src/eve/types.ts
+++ b/packages/github-tools/src/eve/types.ts
@@ -1,6 +1,7 @@
 import type { Approval, ToolModelOutput } from 'eve/tools'
 import type { z } from 'zod'
 import type { GithubToolPreset } from '../core/presets'
+import type { GithubTokenInput } from '../core/token'
 import type { GithubToolName } from '../core/tool-names'
 import type { GithubWriteToolName } from '../core/write-tools'
 import type { CommitIdentity } from '../types'
@@ -32,8 +33,8 @@ export type EveToolOverrides = Partial<Record<GithubToolName, {
 }>>
 
 export type EveGithubToolsOptions = {
-  /** Defaults to `process.env.GITHUB_TOKEN`. */
-  token?: string
+  /** GitHub token string or async provider. Defaults to `process.env.GITHUB_TOKEN`. */
+  token?: GithubTokenInput
   /**
    * Restrict tools to a predefined preset.
    *

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -10,7 +10,7 @@ import { resolveAiSdkApproval } from './core/approval'
 import { resolvePresetTools, type CombinedPresetToolNames, type GithubToolPreset, type PresetToolName } from './core/presets'
 import { type GithubToolName } from './core/tool-names'
 import { type AllGithubTools, type GithubToolsBaseOptions } from './core/tool-types'
-import { resolveGithubToken } from './core/token'
+import { createGithubTokenResolver } from './core/token'
 import type { GithubWriteToolName } from './core/write-tools'
 
 export type { GithubWriteToolName } from './core/write-tools'
@@ -88,53 +88,53 @@ export function createGithubTools({
   committer,
   coAuthors,
 }: GithubToolsOptions = {}): AllGithubTools | Pick<AllGithubTools, GithubToolName> {
-  const resolvedToken = resolveGithubToken(token)
+  const resolveToken = createGithubTokenResolver(token)
   const approval = (name: GithubWriteToolName) => ({ needsApproval: resolveAiSdkApproval(name, requireApproval) })
   const allowed = preset ? resolvePresetTools(preset) : null
 
   const allTools = {
-    getRepository: getRepository(resolvedToken),
-    listBranches: listBranches(resolvedToken),
-    getFileContent: getFileContent(resolvedToken),
-    listPullRequests: listPullRequests(resolvedToken),
-    getPullRequest: getPullRequest(resolvedToken),
-    listIssues: listIssues(resolvedToken),
-    getIssue: getIssue(resolvedToken),
-    searchCode: searchCode(resolvedToken),
-    searchRepositories: searchRepositories(resolvedToken),
-    listCommits: listCommits(resolvedToken),
-    getCommit: getCommit(resolvedToken),
-    getBlame: getBlame(resolvedToken),
-    createBranch: createBranch(resolvedToken, approval('createBranch')),
-    forkRepository: forkRepository(resolvedToken, approval('forkRepository')),
-    createRepository: createRepository(resolvedToken, approval('createRepository')),
-    createOrUpdateFile: createOrUpdateFile(resolvedToken, { ...approval('createOrUpdateFile'), author, committer, coAuthors }),
-    createPullRequest: createPullRequest(resolvedToken, approval('createPullRequest')),
-    mergePullRequest: mergePullRequest(resolvedToken, { ...approval('mergePullRequest'), coAuthors }),
-    addPullRequestComment: addPullRequestComment(resolvedToken, approval('addPullRequestComment')),
-    listPullRequestFiles: listPullRequestFiles(resolvedToken),
-    listPullRequestReviews: listPullRequestReviews(resolvedToken),
-    createPullRequestReview: createPullRequestReview(resolvedToken, approval('createPullRequestReview')),
-    createIssue: createIssue(resolvedToken, approval('createIssue')),
-    addIssueComment: addIssueComment(resolvedToken, approval('addIssueComment')),
-    closeIssue: closeIssue(resolvedToken, approval('closeIssue')),
-    listLabels: listLabels(resolvedToken),
-    addLabels: addLabels(resolvedToken, approval('addLabels')),
-    removeLabel: removeLabel(resolvedToken, approval('removeLabel')),
-    listGists: listGists(resolvedToken),
-    getGist: getGist(resolvedToken),
-    listGistComments: listGistComments(resolvedToken),
-    createGist: createGist(resolvedToken, approval('createGist')),
-    updateGist: updateGist(resolvedToken, approval('updateGist')),
-    deleteGist: deleteGist(resolvedToken, approval('deleteGist')),
-    createGistComment: createGistComment(resolvedToken, approval('createGistComment')),
-    listWorkflows: listWorkflows(resolvedToken),
-    listWorkflowRuns: listWorkflowRuns(resolvedToken),
-    getWorkflowRun: getWorkflowRun(resolvedToken),
-    listWorkflowJobs: listWorkflowJobs(resolvedToken),
-    triggerWorkflow: triggerWorkflow(resolvedToken, approval('triggerWorkflow')),
-    cancelWorkflowRun: cancelWorkflowRun(resolvedToken, approval('cancelWorkflowRun')),
-    rerunWorkflowRun: rerunWorkflowRun(resolvedToken, approval('rerunWorkflowRun')),
+    getRepository: getRepository(resolveToken),
+    listBranches: listBranches(resolveToken),
+    getFileContent: getFileContent(resolveToken),
+    listPullRequests: listPullRequests(resolveToken),
+    getPullRequest: getPullRequest(resolveToken),
+    listIssues: listIssues(resolveToken),
+    getIssue: getIssue(resolveToken),
+    searchCode: searchCode(resolveToken),
+    searchRepositories: searchRepositories(resolveToken),
+    listCommits: listCommits(resolveToken),
+    getCommit: getCommit(resolveToken),
+    getBlame: getBlame(resolveToken),
+    createBranch: createBranch(resolveToken, approval('createBranch')),
+    forkRepository: forkRepository(resolveToken, approval('forkRepository')),
+    createRepository: createRepository(resolveToken, approval('createRepository')),
+    createOrUpdateFile: createOrUpdateFile(resolveToken, { ...approval('createOrUpdateFile'), author, committer, coAuthors }),
+    createPullRequest: createPullRequest(resolveToken, approval('createPullRequest')),
+    mergePullRequest: mergePullRequest(resolveToken, { ...approval('mergePullRequest'), coAuthors }),
+    addPullRequestComment: addPullRequestComment(resolveToken, approval('addPullRequestComment')),
+    listPullRequestFiles: listPullRequestFiles(resolveToken),
+    listPullRequestReviews: listPullRequestReviews(resolveToken),
+    createPullRequestReview: createPullRequestReview(resolveToken, approval('createPullRequestReview')),
+    createIssue: createIssue(resolveToken, approval('createIssue')),
+    addIssueComment: addIssueComment(resolveToken, approval('addIssueComment')),
+    closeIssue: closeIssue(resolveToken, approval('closeIssue')),
+    listLabels: listLabels(resolveToken),
+    addLabels: addLabels(resolveToken, approval('addLabels')),
+    removeLabel: removeLabel(resolveToken, approval('removeLabel')),
+    listGists: listGists(resolveToken),
+    getGist: getGist(resolveToken),
+    listGistComments: listGistComments(resolveToken),
+    createGist: createGist(resolveToken, approval('createGist')),
+    updateGist: updateGist(resolveToken, approval('updateGist')),
+    deleteGist: deleteGist(resolveToken, approval('deleteGist')),
+    createGistComment: createGistComment(resolveToken, approval('createGistComment')),
+    listWorkflows: listWorkflows(resolveToken),
+    listWorkflowRuns: listWorkflowRuns(resolveToken),
+    getWorkflowRun: getWorkflowRun(resolveToken),
+    listWorkflowJobs: listWorkflowJobs(resolveToken),
+    triggerWorkflow: triggerWorkflow(resolveToken, approval('triggerWorkflow')),
+    cancelWorkflowRun: cancelWorkflowRun(resolveToken, approval('cancelWorkflowRun')),
+    rerunWorkflowRun: rerunWorkflowRun(resolveToken, approval('rerunWorkflowRun')),
   } satisfies AllGithubTools
 
   if (overrides) {
@@ -165,5 +165,7 @@ export { listCommits, getCommit, getBlame } from './tools/commits'
 export { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 export { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
 export type { CommitIdentity, CommitToolOptions, GithubTool, Octokit, ToolOptions, ToolOverrides } from './types'
+export type { GithubTokenInput } from './core/token'
+export { resolveGithubToken } from './core/token'
 export { createGithubAgent } from './agents'
 export type { CreateGithubAgentOptions } from './agents'

--- a/packages/github-tools/src/tools/commits.ts
+++ b/packages/github-tools/src/tools/commits.ts
@@ -1,4 +1,5 @@
 import { tool } from 'ai'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { GithubTool } from '../types'
 import {
   listCommitsInputSchema,
@@ -19,11 +20,11 @@ async function listCommitsStep(args: Parameters<typeof listCommitsCore>[0]) {
 }
 
 /** List commits for a GitHub repository. Filter by file path to see commits that touched a file. */
-export const listCommits = (token: string): GithubTool =>
+export const listCommits = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listCommitsDescription,
     inputSchema: listCommitsInputSchema,
-    execute: async args => listCommitsStep({ token, ...args }),
+    execute: async args => listCommitsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function getCommitStep(args: Parameters<typeof getCommitCore>[0]) {
@@ -32,12 +33,12 @@ async function getCommitStep(args: Parameters<typeof getCommitCore>[0]) {
 }
 
 /** Get detailed information about a specific commit, including files changed with additions and deletions. */
-export const getCommit = (token: string): GithubTool =>
+export const getCommit = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getCommitDescription,
     inputSchema: getCommitInputSchema,
     toModelOutput: getCommitToModelOutput,
-    execute: async args => getCommitStep({ token, ...args }),
+    execute: async args => getCommitStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function getBlameStep(args: Parameters<typeof getBlameCore>[0]) {
@@ -46,9 +47,9 @@ async function getBlameStep(args: Parameters<typeof getBlameCore>[0]) {
 }
 
 /** Line-level git blame for a file at a commit-like ref (branch, tag, or SHA). */
-export const getBlame = (token: string): GithubTool =>
+export const getBlame = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getBlameDescription,
     inputSchema: getBlameInputSchema,
-    execute: async args => getBlameStep({ token, ...args }),
+    execute: async args => getBlameStep({ token: await resolveGithubToken(token), ...args }),
   })

--- a/packages/github-tools/src/tools/gists.ts
+++ b/packages/github-tools/src/tools/gists.ts
@@ -22,6 +22,7 @@ import {
   createGistCommentDescription,
   createGistCommentCore,
 } from '../core/gists'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { ToolOptions, GithubTool } from '../types'
 
 async function listGistsStep(args: Parameters<typeof listGistsCore>[0]) {
@@ -30,11 +31,11 @@ async function listGistsStep(args: Parameters<typeof listGistsCore>[0]) {
 }
 
 /** List gists for the authenticated user or a specific user. */
-export const listGists = (token: string): GithubTool =>
+export const listGists = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listGistsDescription,
     inputSchema: listGistsInputSchema,
-    execute: async args => listGistsStep({ token, ...args }),
+    execute: async args => listGistsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function getGistStep(args: Parameters<typeof getGistCore>[0]) {
@@ -43,11 +44,11 @@ async function getGistStep(args: Parameters<typeof getGistCore>[0]) {
 }
 
 /** Get a gist by ID, including file contents. */
-export const getGist = (token: string): GithubTool =>
+export const getGist = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getGistDescription,
     inputSchema: getGistInputSchema,
-    execute: async args => getGistStep({ token, ...args }),
+    execute: async args => getGistStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listGistCommentsStep(args: Parameters<typeof listGistCommentsCore>[0]) {
@@ -56,11 +57,11 @@ async function listGistCommentsStep(args: Parameters<typeof listGistCommentsCore
 }
 
 /** List comments on a gist. */
-export const listGistComments = (token: string): GithubTool =>
+export const listGistComments = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listGistCommentsDescription,
     inputSchema: listGistCommentsInputSchema,
-    execute: async args => listGistCommentsStep({ token, ...args }),
+    execute: async args => listGistCommentsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createGistStep(args: Parameters<typeof createGistCore>[0]) {
@@ -69,12 +70,12 @@ async function createGistStep(args: Parameters<typeof createGistCore>[0]) {
 }
 
 /** Create a new gist with one or more files. Requires approval by default. */
-export const createGist = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createGist = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createGistDescription,
     needsApproval,
     inputSchema: createGistInputSchema,
-    execute: async args => createGistStep({ token, ...args }),
+    execute: async args => createGistStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function updateGistStep(args: Parameters<typeof updateGistCore>[0]) {
@@ -83,12 +84,12 @@ async function updateGistStep(args: Parameters<typeof updateGistCore>[0]) {
 }
 
 /** Update an existing gist. Requires approval by default. */
-export const updateGist = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const updateGist = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: updateGistDescription,
     needsApproval,
     inputSchema: updateGistInputSchema,
-    execute: async args => updateGistStep({ token, ...args }),
+    execute: async args => updateGistStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function deleteGistStep(args: Parameters<typeof deleteGistCore>[0]) {
@@ -97,12 +98,12 @@ async function deleteGistStep(args: Parameters<typeof deleteGistCore>[0]) {
 }
 
 /** Delete a gist permanently. Requires approval by default. */
-export const deleteGist = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const deleteGist = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: deleteGistDescription,
     needsApproval,
     inputSchema: deleteGistInputSchema,
-    execute: async args => deleteGistStep({ token, ...args }),
+    execute: async args => deleteGistStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createGistCommentStep(args: Parameters<typeof createGistCommentCore>[0]) {
@@ -111,10 +112,10 @@ async function createGistCommentStep(args: Parameters<typeof createGistCommentCo
 }
 
 /** Add a comment to a gist. Requires approval by default. */
-export const createGistComment = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createGistComment = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createGistCommentDescription,
     needsApproval,
     inputSchema: createGistCommentInputSchema,
-    execute: async args => createGistCommentStep({ token, ...args }),
+    execute: async args => createGistCommentStep({ token: await resolveGithubToken(token), ...args }),
   })

--- a/packages/github-tools/src/tools/issues.ts
+++ b/packages/github-tools/src/tools/issues.ts
@@ -25,6 +25,7 @@ import {
   removeLabelDescription,
   removeLabelCore,
 } from '../core/issues'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { ToolOptions, GithubTool } from '../types'
 
 async function listIssuesStep(args: Parameters<typeof listIssuesCore>[0]) {
@@ -33,11 +34,11 @@ async function listIssuesStep(args: Parameters<typeof listIssuesCore>[0]) {
 }
 
 /** List issues for a GitHub repository (excludes pull requests). */
-export const listIssues = (token: string): GithubTool =>
+export const listIssues = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listIssuesDescription,
     inputSchema: listIssuesInputSchema,
-    execute: async args => listIssuesStep({ token, ...args }),
+    execute: async args => listIssuesStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function getIssueStep(args: Parameters<typeof getIssueCore>[0]) {
@@ -46,11 +47,11 @@ async function getIssueStep(args: Parameters<typeof getIssueCore>[0]) {
 }
 
 /** Get detailed information about a specific issue. */
-export const getIssue = (token: string): GithubTool =>
+export const getIssue = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getIssueDescription,
     inputSchema: getIssueInputSchema,
-    execute: async args => getIssueStep({ token, ...args }),
+    execute: async args => getIssueStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createIssueStep(args: Parameters<typeof createIssueCore>[0]) {
@@ -59,12 +60,12 @@ async function createIssueStep(args: Parameters<typeof createIssueCore>[0]) {
 }
 
 /** Create a new issue in a GitHub repository. Requires approval by default. */
-export const createIssue = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createIssue = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createIssueDescription,
     needsApproval,
     inputSchema: createIssueInputSchema,
-    execute: async args => createIssueStep({ token, ...args }),
+    execute: async args => createIssueStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function addIssueCommentStep(args: Parameters<typeof addIssueCommentCore>[0]) {
@@ -73,12 +74,12 @@ async function addIssueCommentStep(args: Parameters<typeof addIssueCommentCore>[
 }
 
 /** Add a comment to a GitHub issue. Requires approval by default. */
-export const addIssueComment = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const addIssueComment = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: addIssueCommentDescription,
     needsApproval,
     inputSchema: addIssueCommentInputSchema,
-    execute: async args => addIssueCommentStep({ token, ...args }),
+    execute: async args => addIssueCommentStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function closeIssueStep(args: Parameters<typeof closeIssueCore>[0]) {
@@ -87,12 +88,12 @@ async function closeIssueStep(args: Parameters<typeof closeIssueCore>[0]) {
 }
 
 /** Close an open GitHub issue. Requires approval by default. */
-export const closeIssue = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const closeIssue = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: closeIssueDescription,
     needsApproval,
     inputSchema: closeIssueInputSchema,
-    execute: async args => closeIssueStep({ token, ...args }),
+    execute: async args => closeIssueStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listLabelsStep(args: Parameters<typeof listLabelsCore>[0]) {
@@ -101,11 +102,11 @@ async function listLabelsStep(args: Parameters<typeof listLabelsCore>[0]) {
 }
 
 /** List labels available in a GitHub repository. */
-export const listLabels = (token: string): GithubTool =>
+export const listLabels = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listLabelsDescription,
     inputSchema: listLabelsInputSchema,
-    execute: async args => listLabelsStep({ token, ...args }),
+    execute: async args => listLabelsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function addLabelsStep(args: Parameters<typeof addLabelsCore>[0]) {
@@ -114,12 +115,12 @@ async function addLabelsStep(args: Parameters<typeof addLabelsCore>[0]) {
 }
 
 /** Add labels to an issue or pull request. Requires approval by default. */
-export const addLabels = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const addLabels = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: addLabelsDescription,
     needsApproval,
     inputSchema: addLabelsInputSchema,
-    execute: async args => addLabelsStep({ token, ...args }),
+    execute: async args => addLabelsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function removeLabelStep(args: Parameters<typeof removeLabelCore>[0]) {
@@ -128,10 +129,10 @@ async function removeLabelStep(args: Parameters<typeof removeLabelCore>[0]) {
 }
 
 /** Remove a label from an issue or pull request. Requires approval by default. */
-export const removeLabel = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const removeLabel = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: removeLabelDescription,
     needsApproval,
     inputSchema: removeLabelInputSchema,
-    execute: async args => removeLabelStep({ token, ...args }),
+    execute: async args => removeLabelStep({ token: await resolveGithubToken(token), ...args }),
   })

--- a/packages/github-tools/src/tools/pull-requests.ts
+++ b/packages/github-tools/src/tools/pull-requests.ts
@@ -26,6 +26,7 @@ import {
   createPullRequestReviewCore,
 } from '../core/pull-requests'
 import { listPullRequestFilesToModelOutput } from '../core/model-output'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { CommitIdentity, ToolOptions, GithubTool } from '../types'
 
 export type MergeToolOptions = ToolOptions & {
@@ -38,11 +39,11 @@ async function listPullRequestsStep(args: Parameters<typeof listPullRequestsCore
 }
 
 /** List pull requests for a GitHub repository. */
-export const listPullRequests = (token: string): GithubTool =>
+export const listPullRequests = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listPullRequestsDescription,
     inputSchema: listPullRequestsInputSchema,
-    execute: async args => listPullRequestsStep({ token, ...args }),
+    execute: async args => listPullRequestsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function getPullRequestStep(args: Parameters<typeof getPullRequestCore>[0]) {
@@ -51,11 +52,11 @@ async function getPullRequestStep(args: Parameters<typeof getPullRequestCore>[0]
 }
 
 /** Get detailed information about a specific pull request. */
-export const getPullRequest = (token: string): GithubTool =>
+export const getPullRequest = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getPullRequestDescription,
     inputSchema: getPullRequestInputSchema,
-    execute: async args => getPullRequestStep({ token, ...args }),
+    execute: async args => getPullRequestStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createPullRequestStep(args: Parameters<typeof createPullRequestCore>[0]) {
@@ -64,12 +65,12 @@ async function createPullRequestStep(args: Parameters<typeof createPullRequestCo
 }
 
 /** Create a new pull request in a GitHub repository. Requires approval by default. */
-export const createPullRequest = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createPullRequest = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createPullRequestDescription,
     needsApproval,
     inputSchema: createPullRequestInputSchema,
-    execute: async args => createPullRequestStep({ token, ...args }),
+    execute: async args => createPullRequestStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function mergePullRequestStep(args: Parameters<typeof mergePullRequestCore>[0]) {
@@ -78,12 +79,12 @@ async function mergePullRequestStep(args: Parameters<typeof mergePullRequestCore
 }
 
 /** Merge a pull request. Requires approval by default. */
-export const mergePullRequest = (token: string, { needsApproval = true, coAuthors }: MergeToolOptions = {}): GithubTool =>
+export const mergePullRequest = (token: GithubTokenInput, { needsApproval = true, coAuthors }: MergeToolOptions = {}): GithubTool =>
   tool({
     description: mergePullRequestDescription,
     needsApproval,
     inputSchema: mergePullRequestInputSchema,
-    execute: async args => mergePullRequestStep({ token, coAuthors, ...args }),
+    execute: async args => mergePullRequestStep({ token: await resolveGithubToken(token), coAuthors, ...args }),
   })
 
 async function addPullRequestCommentStep(args: Parameters<typeof addPullRequestCommentCore>[0]) {
@@ -92,12 +93,12 @@ async function addPullRequestCommentStep(args: Parameters<typeof addPullRequestC
 }
 
 /** Add a comment to a pull request. Requires approval by default. */
-export const addPullRequestComment = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const addPullRequestComment = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: addPullRequestCommentDescription,
     needsApproval,
     inputSchema: addPullRequestCommentInputSchema,
-    execute: async args => addPullRequestCommentStep({ token, ...args }),
+    execute: async args => addPullRequestCommentStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listPullRequestFilesStep(args: Parameters<typeof listPullRequestFilesCore>[0]) {
@@ -106,12 +107,12 @@ async function listPullRequestFilesStep(args: Parameters<typeof listPullRequestF
 }
 
 /** List files changed in a pull request, including diff status and patch content. */
-export const listPullRequestFiles = (token: string): GithubTool =>
+export const listPullRequestFiles = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listPullRequestFilesDescription,
     inputSchema: listPullRequestFilesInputSchema,
     toModelOutput: listPullRequestFilesToModelOutput,
-    execute: async args => listPullRequestFilesStep({ token, ...args }),
+    execute: async args => listPullRequestFilesStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listPullRequestReviewsStep(args: Parameters<typeof listPullRequestReviewsCore>[0]) {
@@ -120,11 +121,11 @@ async function listPullRequestReviewsStep(args: Parameters<typeof listPullReques
 }
 
 /** List reviews on a pull request (approvals, change requests, and comments). */
-export const listPullRequestReviews = (token: string): GithubTool =>
+export const listPullRequestReviews = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listPullRequestReviewsDescription,
     inputSchema: listPullRequestReviewsInputSchema,
-    execute: async args => listPullRequestReviewsStep({ token, ...args }),
+    execute: async args => listPullRequestReviewsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createPullRequestReviewStep(args: Parameters<typeof createPullRequestReviewCore>[0]) {
@@ -133,10 +134,10 @@ async function createPullRequestReviewStep(args: Parameters<typeof createPullReq
 }
 
 /** Submit a pull request review with optional inline comments. Requires approval by default. */
-export const createPullRequestReview = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createPullRequestReview = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createPullRequestReviewDescription,
     needsApproval,
     inputSchema: createPullRequestReviewInputSchema,
-    execute: async args => createPullRequestReviewStep({ token, ...args }),
+    execute: async args => createPullRequestReviewStep({ token: await resolveGithubToken(token), ...args }),
   })

--- a/packages/github-tools/src/tools/repository.ts
+++ b/packages/github-tools/src/tools/repository.ts
@@ -24,6 +24,7 @@ import {
   composeCommitMessage,
 } from '../core/repository'
 import { getFileContentToModelOutput } from '../core/model-output'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { CommitToolOptions, ToolOptions, GithubTool } from '../types'
 
 export { composeCommitMessage }
@@ -34,11 +35,11 @@ async function getRepositoryStep(args: Parameters<typeof getRepositoryCore>[0]) 
 }
 
 /** Get information about a GitHub repository including description, stars, forks, language, and default branch. */
-export const getRepository = (token: string): GithubTool =>
+export const getRepository = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getRepositoryDescription,
     inputSchema: getRepositoryInputSchema,
-    execute: async args => getRepositoryStep({ token, ...args }),
+    execute: async args => getRepositoryStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listBranchesStep(args: Parameters<typeof listBranchesCore>[0]) {
@@ -47,11 +48,11 @@ async function listBranchesStep(args: Parameters<typeof listBranchesCore>[0]) {
 }
 
 /** List branches in a GitHub repository. */
-export const listBranches = (token: string): GithubTool =>
+export const listBranches = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listBranchesDescription,
     inputSchema: listBranchesInputSchema,
-    execute: async args => listBranchesStep({ token, ...args }),
+    execute: async args => listBranchesStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function getFileContentStep(args: Parameters<typeof getFileContentCore>[0]) {
@@ -60,12 +61,12 @@ async function getFileContentStep(args: Parameters<typeof getFileContentCore>[0]
 }
 
 /** Get the content of a file from a GitHub repository. */
-export const getFileContent = (token: string): GithubTool =>
+export const getFileContent = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getFileContentDescription,
     inputSchema: getFileContentInputSchema,
     toModelOutput: getFileContentToModelOutput,
-    execute: async args => getFileContentStep({ token, ...args }),
+    execute: async args => getFileContentStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createBranchStep(args: Parameters<typeof createBranchCore>[0]) {
@@ -74,12 +75,12 @@ async function createBranchStep(args: Parameters<typeof createBranchCore>[0]) {
 }
 
 /** Create a new branch in a GitHub repository from an existing branch or commit SHA. Requires approval by default. */
-export const createBranch = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createBranch = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createBranchDescription,
     needsApproval,
     inputSchema: createBranchInputSchema,
-    execute: async args => createBranchStep({ token, ...args }),
+    execute: async args => createBranchStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function forkRepositoryStep(args: Parameters<typeof forkRepositoryCore>[0]) {
@@ -88,12 +89,12 @@ async function forkRepositoryStep(args: Parameters<typeof forkRepositoryCore>[0]
 }
 
 /** Fork a GitHub repository to the authenticated user account or a specified organization. Requires approval by default. */
-export const forkRepository = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const forkRepository = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: forkRepositoryDescription,
     needsApproval,
     inputSchema: forkRepositoryInputSchema,
-    execute: async args => forkRepositoryStep({ token, ...args }),
+    execute: async args => forkRepositoryStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createRepositoryStep(args: Parameters<typeof createRepositoryCore>[0]) {
@@ -102,12 +103,12 @@ async function createRepositoryStep(args: Parameters<typeof createRepositoryCore
 }
 
 /** Create a new GitHub repository for the authenticated user or a specified organization. Requires approval by default. */
-export const createRepository = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const createRepository = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: createRepositoryDescription,
     needsApproval,
     inputSchema: createRepositoryInputSchema,
-    execute: async args => createRepositoryStep({ token, ...args }),
+    execute: async args => createRepositoryStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createOrUpdateFileStep(args: Parameters<typeof createOrUpdateFileCore>[0]) {
@@ -117,12 +118,12 @@ async function createOrUpdateFileStep(args: Parameters<typeof createOrUpdateFile
 
 /** Create or update a file in a GitHub repository. Provide the SHA when updating an existing file. Requires approval by default. */
 export const createOrUpdateFile = (
-  token: string,
+  token: GithubTokenInput,
   { needsApproval = true, author, committer, coAuthors }: CommitToolOptions = {},
 ): GithubTool =>
   tool({
     description: createOrUpdateFileDescription,
     needsApproval,
     inputSchema: createOrUpdateFileInputSchema,
-    execute: async args => createOrUpdateFileStep({ token, author, committer, coAuthors, ...args }),
+    execute: async args => createOrUpdateFileStep({ token: await resolveGithubToken(token), author, committer, coAuthors, ...args }),
   })

--- a/packages/github-tools/src/tools/search.ts
+++ b/packages/github-tools/src/tools/search.ts
@@ -1,4 +1,5 @@
 import { tool } from 'ai'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { GithubTool } from '../types'
 import {
   searchCodeInputSchema,
@@ -15,11 +16,11 @@ async function searchCodeStep(args: Parameters<typeof searchCodeCore>[0]) {
 }
 
 /** Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search. */
-export const searchCode = (token: string): GithubTool =>
+export const searchCode = (token: GithubTokenInput): GithubTool =>
   tool({
     description: searchCodeDescription,
     inputSchema: searchCodeInputSchema,
-    execute: async args => searchCodeStep({ token, ...args }),
+    execute: async args => searchCodeStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function searchRepositoriesStep(args: Parameters<typeof searchRepositoriesCore>[0]) {
@@ -28,9 +29,9 @@ async function searchRepositoriesStep(args: Parameters<typeof searchRepositories
 }
 
 /** Search for GitHub repositories by keyword, topic, language, or other qualifiers. */
-export const searchRepositories = (token: string): GithubTool =>
+export const searchRepositories = (token: GithubTokenInput): GithubTool =>
   tool({
     description: searchRepositoriesDescription,
     inputSchema: searchRepositoriesInputSchema,
-    execute: async args => searchRepositoriesStep({ token, ...args }),
+    execute: async args => searchRepositoriesStep({ token: await resolveGithubToken(token), ...args }),
   })

--- a/packages/github-tools/src/tools/workflows.ts
+++ b/packages/github-tools/src/tools/workflows.ts
@@ -22,6 +22,7 @@ import {
   rerunWorkflowRunDescription,
   rerunWorkflowRunCore,
 } from '../core/workflows'
+import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { ToolOptions, GithubTool } from '../types'
 
 async function listWorkflowsStep(args: Parameters<typeof listWorkflowsCore>[0]) {
@@ -30,11 +31,11 @@ async function listWorkflowsStep(args: Parameters<typeof listWorkflowsCore>[0]) 
 }
 
 /** List GitHub Actions workflows in a repository. */
-export const listWorkflows = (token: string): GithubTool =>
+export const listWorkflows = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listWorkflowsDescription,
     inputSchema: listWorkflowsInputSchema,
-    execute: async args => listWorkflowsStep({ token, ...args }),
+    execute: async args => listWorkflowsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listWorkflowRunsStep(args: Parameters<typeof listWorkflowRunsCore>[0]) {
@@ -43,11 +44,11 @@ async function listWorkflowRunsStep(args: Parameters<typeof listWorkflowRunsCore
 }
 
 /** List workflow runs for a repository, optionally filtered by workflow, branch, status, or event. */
-export const listWorkflowRuns = (token: string): GithubTool =>
+export const listWorkflowRuns = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listWorkflowRunsDescription,
     inputSchema: listWorkflowRunsInputSchema,
-    execute: async args => listWorkflowRunsStep({ token, ...args }),
+    execute: async args => listWorkflowRunsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function getWorkflowRunStep(args: Parameters<typeof getWorkflowRunCore>[0]) {
@@ -56,11 +57,11 @@ async function getWorkflowRunStep(args: Parameters<typeof getWorkflowRunCore>[0]
 }
 
 /** Get details of a specific workflow run including status, timing, and trigger info. */
-export const getWorkflowRun = (token: string): GithubTool =>
+export const getWorkflowRun = (token: GithubTokenInput): GithubTool =>
   tool({
     description: getWorkflowRunDescription,
     inputSchema: getWorkflowRunInputSchema,
-    execute: async args => getWorkflowRunStep({ token, ...args }),
+    execute: async args => getWorkflowRunStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listWorkflowJobsStep(args: Parameters<typeof listWorkflowJobsCore>[0]) {
@@ -69,11 +70,11 @@ async function listWorkflowJobsStep(args: Parameters<typeof listWorkflowJobsCore
 }
 
 /** List jobs for a workflow run, including step-level status and timing. */
-export const listWorkflowJobs = (token: string): GithubTool =>
+export const listWorkflowJobs = (token: GithubTokenInput): GithubTool =>
   tool({
     description: listWorkflowJobsDescription,
     inputSchema: listWorkflowJobsInputSchema,
-    execute: async args => listWorkflowJobsStep({ token, ...args }),
+    execute: async args => listWorkflowJobsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function triggerWorkflowStep(args: Parameters<typeof triggerWorkflowCore>[0]) {
@@ -82,12 +83,12 @@ async function triggerWorkflowStep(args: Parameters<typeof triggerWorkflowCore>[
 }
 
 /** Trigger a workflow via workflow_dispatch event. Requires approval by default. */
-export const triggerWorkflow = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const triggerWorkflow = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: triggerWorkflowDescription,
     needsApproval,
     inputSchema: triggerWorkflowInputSchema,
-    execute: async args => triggerWorkflowStep({ token, ...args }),
+    execute: async args => triggerWorkflowStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function cancelWorkflowRunStep(args: Parameters<typeof cancelWorkflowRunCore>[0]) {
@@ -96,12 +97,12 @@ async function cancelWorkflowRunStep(args: Parameters<typeof cancelWorkflowRunCo
 }
 
 /** Cancel an in-progress workflow run. Requires approval by default. */
-export const cancelWorkflowRun = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const cancelWorkflowRun = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: cancelWorkflowRunDescription,
     needsApproval,
     inputSchema: cancelWorkflowRunInputSchema,
-    execute: async args => cancelWorkflowRunStep({ token, ...args }),
+    execute: async args => cancelWorkflowRunStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function rerunWorkflowRunStep(args: Parameters<typeof rerunWorkflowRunCore>[0]) {
@@ -110,10 +111,10 @@ async function rerunWorkflowRunStep(args: Parameters<typeof rerunWorkflowRunCore
 }
 
 /** Re-run a workflow run, optionally only the failed jobs. Requires approval by default. */
-export const rerunWorkflowRun = (token: string, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+export const rerunWorkflowRun = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
   tool({
     description: rerunWorkflowRunDescription,
     needsApproval,
     inputSchema: rerunWorkflowRunInputSchema,
-    execute: async args => rerunWorkflowRunStep({ token, ...args }),
+    execute: async args => rerunWorkflowRunStep({ token: await resolveGithubToken(token), ...args }),
   })

--- a/packages/github-tools/src/workflow.ts
+++ b/packages/github-tools/src/workflow.ts
@@ -22,6 +22,7 @@ import type { CombinedPresetToolNames, GithubToolPreset, PresetToolName } from '
 import type { GithubToolName } from './core/tool-names'
 import type { ApprovalConfig } from './index'
 import type { CommitIdentity } from './types'
+import type { GithubTokenInput } from './core/token'
 import type { Context } from '@ai-sdk/provider-utils'
 
 /**
@@ -116,10 +117,10 @@ export type CreateDurableGithubAgentOptions =
   Omit<WorkflowAgentOptions, 'model' | 'tools' | 'instructions'> & {
     model: string | LanguageModel
     /**
-     * GitHub personal access token.
+     * GitHub personal access token or async token provider.
      * Falls back to `process.env.GITHUB_TOKEN` when omitted.
      */
-    token?: string
+    token?: GithubTokenInput
     /**
      * Restrict tools and system prompt to a predefined preset.
      *
@@ -224,6 +225,6 @@ export function createDurableGithubAgent({
 }
 
 export { createGithubTools, createGithubAgent } from './index'
-export type { CommitIdentity, CommitToolOptions, GithubTools, GithubToolsOptions, GithubToolPreset, GithubToolName, GithubWriteToolName, ApprovalConfig, ToolOverrides, AllGithubTools, PresetToolName, CombinedPresetToolNames, GithubToolsForPreset, PickGithubTools } from './index'
-export { PRESET_TOOLS, GITHUB_TOOL_NAMES, GITHUB_WRITE_TOOLS } from './index'
+export type { CommitIdentity, CommitToolOptions, GithubTools, GithubToolsOptions, GithubToolPreset, GithubToolName, GithubWriteToolName, ApprovalConfig, ToolOverrides, AllGithubTools, PresetToolName, CombinedPresetToolNames, GithubToolsForPreset, PickGithubTools, GithubTokenInput } from './index'
+export { PRESET_TOOLS, GITHUB_TOOL_NAMES, GITHUB_WRITE_TOOLS, resolveGithubToken } from './index'
 export type { CreateGithubAgentOptions } from './agents'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.31.0(@types/node@25.6.0)
       turbo:
         specifier: latest
-        version: 2.10.3
+        version: 2.10.4
 
   apps/chat:
     dependencies:
@@ -181,6 +181,9 @@ importers:
       '@github-tools/sdk':
         specifier: workspace:*
         version: link:../../packages/github-tools
+      '@vercel/connect':
+        specifier: ^0.3.2
+        version: 0.3.2(@ai-sdk/mcp@1.0.58(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(eve@0.19.0(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.15(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(microsandbox@0.6.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)))
       ai:
         specifier: ^7.0.0
         version: 7.0.15(zod@4.4.3)
@@ -199,28 +202,28 @@ importers:
     dependencies:
       '@chat-adapter/github':
         specifier: latest
-        version: 4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+        version: 4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
       '@chat-adapter/state-memory':
         specifier: latest
-        version: 4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+        version: 4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
       '@github-tools/sdk':
         specifier: workspace:*
         version: link:../../packages/github-tools
       '@workflow/ai':
         specifier: latest
-        version: 4.1.2(@opentelemetry/api@1.9.0)(ai@6.0.175(zod@4.4.3))(workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3))
+        version: 4.2.0(@opentelemetry/api@1.9.0)(ai@6.0.175(zod@4.4.3))(workflow@4.6.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3))
       ai:
         specifier: ^6.0.175
         version: 6.0.175(zod@4.4.3)
       chat:
         specifier: latest
-        version: 4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+        version: 4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
       evlog:
         specifier: latest
         version: 2.20.0(baf9dfdaf59b56c95f6f0af7706c3836)
       workflow:
         specifier: latest
-        version: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
+        version: 4.6.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -713,16 +716,16 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@chat-adapter/github@4.32.0':
-    resolution: {integrity: sha512-0HHSI2rd7XXE3rt37uUS+zWbTK6JSl1mAUtQk5hm1SBtyP23BV4B4pDCdR/X5Eo9e0i9sMNYR7CNwfab1+7g3Q==}
+  '@chat-adapter/github@4.33.0':
+    resolution: {integrity: sha512-42FlshypGNSke+PoNhl2qRG8SUdilimivCPGW+jQfAqDz4/DDuM5qdMoy93p1TnJ5GqIg8LxJLDT+eNwgQJxEQ==}
     engines: {node: '>=20'}
 
-  '@chat-adapter/shared@4.32.0':
-    resolution: {integrity: sha512-ANXYe2dbSmr9A+yUAnV8TfFht4GM6f3zR5LnAYtQdNnRI9CJfXIUXuhRaVBe5RD8IEgGXyGi4BKj5qdjBtUumA==}
+  '@chat-adapter/shared@4.33.0':
+    resolution: {integrity: sha512-PIafG7ySashbaGBBBnpDtufgXYiAEf8LIp2nu6iTXYe97KBgCK5qwFksONxEcvOkpMvLsn2Tx/Ui2dGLA0Xe6g==}
     engines: {node: '>=20'}
 
-  '@chat-adapter/state-memory@4.32.0':
-    resolution: {integrity: sha512-fN91ZzjRUUhgeVReukvrDkaaQXC+x0jETR+77vg67y95g1LnUaqSFBz+WOyYLaTT7i7JGz9aEMlBNt6uYu66dg==}
+  '@chat-adapter/state-memory@4.33.0':
+    resolution: {integrity: sha512-qCFAN4GRpdWdDAnbjTkC0nQIHBsfqcloEfbLZuuC8/yPeJHfp/O7LzOGU1HAPvrhDz6KZg5Kvy4XAc8YDwirPw==}
     engines: {node: '>=20'}
 
   '@clack/core@1.3.0':
@@ -4730,33 +4733,33 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@turbo/darwin-64@2.10.3':
-    resolution: {integrity: sha512-guuiO2kKc7yUQFU2jhWyM/BrYGD/brqb0+JvJIXTQ/QI1NlWfHZ1id50kkkOWqxmBiDc8DgW2orfY85pQIc7gw==}
+  '@turbo/darwin-64@2.10.4':
+    resolution: {integrity: sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.3':
-    resolution: {integrity: sha512-UglEDl/r1/h5Vw6oS6cEE29Jugz2sDLxHCSupNznKatj1fDMRXFqYKFcbvm8RTFhtYPI45NxkrPNo9BqNychBg==}
+  '@turbo/darwin-arm64@2.10.4':
+    resolution: {integrity: sha512-VQ1Yxs5zkPT+2z7t1P4mvn6JmcKLkOCAsPuK9XbOvuVj0DlTlETfIXNisX0771v/vTWHOQqiwoGi+TtAUq8efw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.3':
-    resolution: {integrity: sha512-KuQxaPWD7OBmwEZqO0sgijwcuXR5eMWbo7BEt2m1D2Q3RylJDj7WMcJ0Btv2VJA0QC+khzAaTAm1yWowJ0CWAw==}
+  '@turbo/linux-64@2.10.4':
+    resolution: {integrity: sha512-IzV1QovmwX7mfGnVinmE++2IB8tbeo38weltiuH5zNqwCTBjLs/DytyRKx+bmnhHdXIq9SheR8p0Nip/LBUPHg==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.10.3':
-    resolution: {integrity: sha512-DPkIKQ+6p0sho3Cx/e/A3F+AKgXQJA+z//cHsTcyyM1YWRGSYA0UTP8NUpb4iS2tVBSniGwmjRUr73hpq8kcDg==}
+  '@turbo/linux-arm64@2.10.4':
+    resolution: {integrity: sha512-rfujSQkP5aYiRn0PgTM7F00WkJCP/bKDVZbOx3WmrZwa/vHA0bplhCl328kpX7VI9HH2vI90ISGwuSVgJgoqTw==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.10.3':
-    resolution: {integrity: sha512-8NvFAze9D4PsosZAnK3aGqHz2vLzREz9lNIxLgfE0jRchq2sZQE190cwFm7WX17yg3ftPvwCvWH3rhLbG1UHCQ==}
+  '@turbo/windows-64@2.10.4':
+    resolution: {integrity: sha512-NnspP7Wd5fa3Wwnqv9bKfhegqZzuHBgbPxdZU/idTLQcazx/vgKu95JlCx2YHY0hdvKCnPcARrDwM+KEUmaO7A==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.3':
-    resolution: {integrity: sha512-AqjqV5cHbFa0YRaQ+Dyw6lSm6as4h/Uf8LcZ7VN8i+Odr23ShFD5SUvVAR1d3rZqibFVs9c0VdtXdfQfkdcs3A==}
+  '@turbo/windows-arm64@2.10.4':
+    resolution: {integrity: sha512-Iv02YgOpaEShc2OkG7mgCJ2pEw1RUKiKbs0h8W5wAf4jZ5vpmraTEjuGTgHRuOORQnC1GN3KHo5WB+hu1abRMA==}
     cpu: [arm64]
     os: [win32]
 
@@ -5236,6 +5239,36 @@ packages:
   '@vercel/cli-auth@0.0.1':
     resolution: {integrity: sha512-CnqiuMlZ4pjs2LCPYiR6aLKPPd3Xb8SBI1Y7eotXKgpx6qgrGNY+E7EIyUt5ErGHJGIrCZyGG5WEo4bHtVmz2Q==}
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@1.0.0':
+    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+
+  '@vercel/connect@0.3.2':
+    resolution: {integrity: sha512-l3EX/W5WTW2i5sUfl+2LiXJ1fXpjtTifMAaM2BLgkEzMbW8UR999g1F++6MTWHZWDbbufZdE+YqsIG5WNz+5Nw==}
+    peerDependencies:
+      '@ai-sdk/mcp': ^1 || ^2
+      '@auth/core': '>=0.37.0'
+      '@chat-adapter/slack': ^4.0.0
+      ai: ^6 || ^7.0.0-beta.0
+      better-auth: '>=1.5.0'
+      eve: '>=0.13.7'
+    peerDependenciesMeta:
+      '@ai-sdk/mcp':
+        optional: true
+      '@auth/core':
+        optional: true
+      '@chat-adapter/slack':
+        optional: true
+      ai:
+        optional: true
+      better-auth:
+        optional: true
+      eve:
+        optional: true
+
   '@vercel/functions@3.5.0':
     resolution: {integrity: sha512-+RokZ+4gkYyOsKBuJ29cQ8iSZG123LLJbZfPry20kkTgrN9U0277La4feP4DnWVo3sGoYa4plCEKY9XKUYoX9g==}
     engines: {node: '>= 20'}
@@ -5256,6 +5289,10 @@ packages:
 
   '@vercel/oidc@3.4.0':
     resolution: {integrity: sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.8.0':
+    resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
     engines: {node: '>= 20'}
 
   '@vercel/queue@0.3.1':
@@ -5519,18 +5556,46 @@ packages:
       '@opentelemetry/api':
         optional: true
 
+  '@workflow/ai@4.2.0':
+    resolution: {integrity: sha512-FrV05mZxw7wXFVE6mr1EYkTLahC6yGVpzb5Hn9xfU/899u/CQRjyxMr5Y6ozbg8oVElS97K11n1qmByARV6RqA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      ai: ^6
+      workflow: ^4.6.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@workflow/astro@4.0.10':
     resolution: {integrity: sha512-uGoA1xHmi8hiadiloqO+xb2GYmQCxltNFJWC99bTnGV4V5lvAgXq01TDESQIReE1ZlA+PuPPtv3jtWk8mCOZRQ==}
 
+  '@workflow/astro@4.0.11':
+    resolution: {integrity: sha512-Kf2c+af4prF/KHXfGGenzu3r5RdlsXSNw+O5qVAly/O6iDy+av7HMfJFS2P3eIzPVxJkBFfQxKf2+xgyxWZzeA==}
+
   '@workflow/builders@4.1.0':
     resolution: {integrity: sha512-9Y8jchPlFR0Iz2wELXA3u/K8lq4vhdSuSLDu0fL5sQfmXrjJe0mK08zjyyA4mRwB8In9ysUrZSlK4/qEnbRbzw==}
+
+  '@workflow/builders@4.1.1':
+    resolution: {integrity: sha512-pGPXtmP7PeFAEmyQX789GHCqllrUnYyfyK5TdggxCu9FOKQHXl6Xmy8na5LJMQd/aDvKEA2qQIuFDGkFXwURWQ==}
 
   '@workflow/cli@4.2.10':
     resolution: {integrity: sha512-3k4q3bbo6y7KyzRoxAIPEwwBzQ32piTIWn9WeAVIcO+lOFn2t3sOfhhdGF4INJZtcmlcK/CpGd/MQU010xkU4w==}
     hasBin: true
 
+  '@workflow/cli@4.3.0':
+    resolution: {integrity: sha512-2gZRQxTuCeNYM8kkxRCy4nKG8SonRZVYuQRJ3i6CTyi3vmfS7ycn2BZ3vmY2gIlkZoFmD2/YblDJFgPrbLtahg==}
+    hasBin: true
+
   '@workflow/core@4.5.0':
     resolution: {integrity: sha512-O4Cpk24wbHVFD4rYgwwHVhnn8oRgY2xEX3tip5q5FNhSXCF+MBPnLJMVU5hCzjRYFcfQ8OZMv0jcCxqUFehgFg==}
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@workflow/core@4.6.0':
+    resolution: {integrity: sha512-4cZP28Yxbzwy1QtLTxqSKvuTBkRxgpAMejcPtwCFUZC3YVIZAult7NlP1IB5tYsMSzsANi26K4tK1L17Z9TgBA==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -5549,8 +5614,25 @@ packages:
       '@swc/cli': '>=0.4.0'
       '@swc/core': '>=1.5.0'
 
+  '@workflow/nest@4.0.12':
+    resolution: {integrity: sha512-liF5TKYUpszFdOZsfHS04pbna9R2ghR+0kASqj8qowvy65VxM/lE6WvxgZFcTQ+cVrFl9lHd6ajdYt6EgVicKw==}
+    hasBin: true
+    peerDependencies:
+      '@nestjs/common': '>=10.0.0'
+      '@nestjs/core': '>=10.0.0'
+      '@swc/cli': '>=0.4.0'
+      '@swc/core': '>=1.5.0'
+
   '@workflow/next@4.0.11':
     resolution: {integrity: sha512-y9VcnfIUV1cwlSFuul4pOyxskGwMcJRxXdYR560Dw/JV5NZwqdCgCtWahOVTU3+hN2NFRKWUEoZ1p0OVCnlAJQ==}
+    peerDependencies:
+      next: '>13'
+    peerDependenciesMeta:
+      next:
+        optional: true
+
+  '@workflow/next@4.1.0':
+    resolution: {integrity: sha512-CnT6X827EKtABg6xOqm2/uDk/gv1Q476LmkeBwj6MDeRi00ZYvzPSGjUm9VY1ydO4HxtysNh1OyJ1kfI7u9NCw==}
     peerDependencies:
       next: '>13'
     peerDependenciesMeta:
@@ -5560,11 +5642,20 @@ packages:
   '@workflow/nitro@4.1.1':
     resolution: {integrity: sha512-HO8Og8OwnnTWU93/KrqlldktiUjhU7TXk3lC8b0WEKhajGd8HVLvXDEb+4DIp3JoaNo8j5L+4dpBxPhwfcIiFg==}
 
+  '@workflow/nitro@4.1.2':
+    resolution: {integrity: sha512-6ipZc220wnVTr9vynXaBybHiNMOBuyKAh+xYcg6OSd0aycl88wJAyCf0c1xaExzdzs3S2ruoXEWdFML3oeWpuA==}
+
   '@workflow/nuxt@4.0.11':
     resolution: {integrity: sha512-CXfsux7T0GpOwxzf/0UxZjrpA5XC7QhiwGh0umNnn37CAqDGYETGy4QZtKluEVKB/rZElssNjkJk1b0ufBAgOw==}
 
+  '@workflow/nuxt@4.0.12':
+    resolution: {integrity: sha512-vVqZysV5fwHINMBv6oKkMZmNXnc4Y7lXr+kDfYIr7SHMmWQKs7xIU5a3bIwLPm4y2oo9iw6hWgWv0yDdj2O/LQ==}
+
   '@workflow/rollup@4.0.10':
     resolution: {integrity: sha512-gRKQv/pYOsCCXHSyg27a5mf054ucaWT3nBq+YU15LpwlOvGf2Z68k5H7D2oZYyAtwHa3v4vp6tTdEBvhzsIBQw==}
+
+  '@workflow/rollup@4.0.11':
+    resolution: {integrity: sha512-x8/z7+jGZhNSdC1aIroXXeqTyDhcjZSnvK4iZ/hQNonkUaRt0/sLTliACARQKNEK3FKh4G9oKyASj/TH5PQ1cg==}
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
@@ -5581,8 +5672,16 @@ packages:
   '@workflow/sveltekit@4.0.10':
     resolution: {integrity: sha512-O9sGC1AK69B/WpVpHCC/4KWJPe4LStBRq7ICQ+5uctGXxnDaLMkonF3IOk/nJa/FEtPRibBTLdJYoBKJYk8UpA==}
 
+  '@workflow/sveltekit@4.0.11':
+    resolution: {integrity: sha512-FhRfc52pYYi4GIZzBrJLisFikPmjPZ/64vnBmLISbtMPivHqg+8PeMGGonHOLd7lukBsX5pJb3ak9d1XYXPPWA==}
+
   '@workflow/swc-plugin@4.1.1':
     resolution: {integrity: sha512-Bi1K/z7Fjxzf5DY9BCBZHMd6Y4SvuCPOAyslydcDD9m38Suz3xCcfrEDvXo8R5mnEnTuLIB4GEJyB54CkMuuiQ==}
+    peerDependencies:
+      '@swc/core': 1.15.3
+
+  '@workflow/swc-plugin@4.1.2':
+    resolution: {integrity: sha512-oSd+fSXtcrHMJ82OwEqyfhYpqr1EsSQY5IEpntkKSlzzkdTFV4hcAj0vlafgIfI3WfhqxrXUoHfp/S1XE49jcA==}
     peerDependencies:
       '@swc/core': 1.15.3
 
@@ -5597,11 +5696,25 @@ packages:
   '@workflow/vite@4.0.10':
     resolution: {integrity: sha512-8Bw9vbUlWFXdAgHx7484fQFtNSPBVuiQq5IFRc+5Pfj5GY4R0jT2ivkNsQ59d+h1vMYUxXTIVfdukgYt3EISOA==}
 
+  '@workflow/vite@4.0.11':
+    resolution: {integrity: sha512-qaQfuwAy0+W/gDGoMWTYfamuNjo5D5iTEdV03oSRZE7wyfmmX6xoA/YdeBFSIt8sbbJxHlz08smRIM5SmELtXg==}
+
   '@workflow/web@4.1.11':
     resolution: {integrity: sha512-0IsUJ4BpViEg4LH2jijgP/yfddFcbQS/l3VShx/YwvsLirC57h8FN+r+XcUZeUn3B7yyY69OBBB6pl+5bmGQMg==}
 
+  '@workflow/web@4.1.12':
+    resolution: {integrity: sha512-dGd4ohEtALY22yxjRR0GLTMG5vDTlqS1sJvKGX1KnDKN9QkJhUhmjDE+2RygOtt1tB7ezShU0WhPcR/h7ypluw==}
+
   '@workflow/world-local@4.2.0':
     resolution: {integrity: sha512-gsJSl9PeenbF8TECSsaev+6/LQAW3AIL/WMxpAQzQOgFocOAGAsch669fHeY2TuwJBchretVw7V6HN0pyTvLeQ==}
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@workflow/world-local@4.2.1':
+    resolution: {integrity: sha512-o5tQQQbi3Ox222QjYAfk0cwz4+/yAbAlwhIpu84WBtH66g1TnUAo/D9S/w0t/j2ZaGdzbdoaYOF597J1LYrxiw==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -5616,10 +5729,21 @@ packages:
       '@opentelemetry/api':
         optional: true
 
+  '@workflow/world-vercel@4.5.0':
+    resolution: {integrity: sha512-FfE4CLE9HimRZrn+drjT5WgM2NbXsiM4Vh4AKXJRTnMrgdFNBeyi5WSOnzmVYHkMtpGfbxN8J/E8vuDrADdZzg==}
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@workflow/world@4.2.0':
     resolution: {integrity: sha512-g7XHJXqZG/zfgcL6EQ7RjjAR5pXCYAwBu38Y3zk5meYKdkQbm3KFtSkeAS4NKbhR+5vw1lmoe4XW6YcydGOgbQ==}
     peerDependencies:
       zod: 4.3.6
+
+  '@workflow/world@4.2.1':
+    resolution: {integrity: sha512-ApVQclR6RZdvdcO/SQCG8Rnx+KiTTMNL4m8GC6rHee1jIO/bEAfUrHaw4k2SvhAHb9WG/d7nenTIXzMm+hXzbw==}
 
   '@xhmikosr/archive-type@8.0.1':
     resolution: {integrity: sha512-toXuiWChyfOpEiCPsIw6HGHaNji5LVkvB6EREL548vGWr+hGaehwxG4LzN20vm9aGFXwnA/Jty8yW2/SmV+1zQ==}
@@ -6126,8 +6250,8 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
-  chat@4.32.0:
-    resolution: {integrity: sha512-0NlJcCLycTy8kytRsZEnW4Gzomm+SNh1Yg7y9GVYB5fTjyhOxCcnzqrythgXNn2dvv7VeihDIISpNU0WZdOKKg==}
+  chat@4.33.0:
+    resolution: {integrity: sha512-qaQyr6Nm7gLEPkYpfjlZzCxKKjvDyRe3GoVA5++RrzW9po5fe3ddH4l9JkGaFsTvSiRGAzuz12WJj/BB5+A6Hw==}
     engines: {node: '>=20'}
     peerDependencies:
       ai: ^6.0.182
@@ -7003,10 +7127,6 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.21.0:
-    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -7375,6 +7495,10 @@ packages:
         optional: true
       vite:
         optional: true
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
@@ -7940,6 +8064,10 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -8220,6 +8348,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
@@ -8727,6 +8858,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
@@ -8956,6 +9091,10 @@ packages:
     resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
     engines: {node: '>=14.16'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -9137,6 +9276,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
@@ -10395,6 +10538,10 @@ packages:
   strip-dirs@3.0.0:
     resolution: {integrity: sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
@@ -10719,8 +10866,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.10.3:
-    resolution: {integrity: sha512-uZIqzfgtWbyqu1Tqwdd0giRnPGgL0ejbcdF8eZLJhtTTVSrOgArZGzYeXTD6XNcc7ANgdhqex11Y9bHBeyiQLQ==}
+  turbo@2.10.4:
+    resolution: {integrity: sha512-GQpduILaKjoaGljw097ScsSyKTtZSY7cZ3bJktzfTkPMyCf3ShKLuXK2IaOEN2Plziml+ArR7WJ1m+V4VbnaKQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -10817,6 +10964,10 @@ packages:
 
   undici@7.26.0:
     resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -11528,6 +11679,15 @@ packages:
 
   workflow@4.5.0:
     resolution: {integrity: sha512-EV9jIngHHWV9sZQXtehL/kMTYPEB7dxXjxsxBHleSpJ65XltuNAOBq1lOi4F3KHiRE7zD3G0o2N18sAV/4CDQw==}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  workflow@4.6.0:
+    resolution: {integrity: sha512-HF5/pjK6eR7fcrhyD3xN/rKvans6r93w2tUvNe0WDxkE9fcsqpezGg2neuG9GvEcCl9PBGfblTo7GYvIDoUqXQ==}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': '1'
@@ -12311,28 +12471,28 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@chat-adapter/github@4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/github@4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+      '@chat-adapter/shared': 4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
       '@octokit/auth-app': 8.2.0
       '@octokit/rest': 22.0.1
-      chat: 4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+      chat: 4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/shared@4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/shared@4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      chat: 4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+      chat: 4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - zod
 
-  '@chat-adapter/state-memory@4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)':
+  '@chat-adapter/state-memory@4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      chat: 4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
+      chat: 4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -12383,7 +12543,7 @@ snapshots:
       '@nuxt/kit': 4.4.8(magicast@0.5.2)
       chokidar: 5.0.0
       pathe: 2.0.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -12395,7 +12555,7 @@ snapshots:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       chokidar: 5.0.0
       pathe: 2.0.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13511,7 +13671,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.5
       srvx: 0.11.15
       std-env: 4.1.0
       tinyclip: 0.1.12
@@ -13549,7 +13709,7 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.5
       srvx: 0.11.15
       std-env: 4.1.0
       tinyclip: 0.1.12
@@ -13775,11 +13935,11 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
-      semver: 7.7.4
+      semver: 7.8.5
       simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.8(magicast@0.5.2))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.3.0(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
@@ -13816,11 +13976,11 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
-      semver: 7.7.4
+      semver: 7.8.5
       simple-git: 3.36.0
       sirv: 3.0.2
       structured-clone-es: 2.0.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.8(magicast@0.5.2))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.3.0(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
@@ -14105,7 +14265,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.7.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -14248,7 +14408,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.8.0
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
@@ -14318,7 +14478,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
-      devalue: 5.8.0
+      devalue: 5.8.1
       errx: 0.1.0
       escape-string-regexp: 5.0.0
       exsolve: 1.1.0
@@ -16328,7 +16488,7 @@ snapshots:
   '@tailwindcss/node@4.2.4':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.21.0
+      enhanced-resolve: 5.21.6
       jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
@@ -16773,22 +16933,22 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@turbo/darwin-64@2.10.3':
+  '@turbo/darwin-64@2.10.4':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.3':
+  '@turbo/darwin-arm64@2.10.4':
     optional: true
 
-  '@turbo/linux-64@2.10.3':
+  '@turbo/linux-64@2.10.4':
     optional: true
 
-  '@turbo/linux-arm64@2.10.3':
+  '@turbo/linux-arm64@2.10.4':
     optional: true
 
-  '@turbo/windows-64@2.10.3':
+  '@turbo/windows-64@2.10.4':
     optional: true
 
-  '@turbo/windows-arm64@2.10.3':
+  '@turbo/windows-arm64@2.10.4':
     optional: true
 
   '@turf/boolean-point-in-polygon@7.3.5':
@@ -17351,6 +17511,23 @@ snapshots:
       xdg-app-paths: 5.1.0
       zod: 4.1.11
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.1.0
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.0':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/connect@0.3.2(@ai-sdk/mcp@1.0.58(zod@4.4.3))(ai@7.0.15(zod@4.4.3))(eve@0.19.0(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.15(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(microsandbox@0.6.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+    optionalDependencies:
+      '@ai-sdk/mcp': 1.0.58(zod@4.4.3)
+      ai: 7.0.15(zod@4.4.3)
+      eve: 0.19.0(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.15(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(microsandbox@0.6.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+
   '@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49)':
     dependencies:
       '@vercel/oidc': 3.4.0
@@ -17379,6 +17556,12 @@ snapshots:
   '@vercel/oidc@3.2.0': {}
 
   '@vercel/oidc@3.4.0': {}
+
+  '@vercel/oidc@3.8.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
 
   '@vercel/queue@0.3.1':
     dependencies:
@@ -17689,21 +17872,6 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@workflow/ai@4.1.2(@opentelemetry/api@1.9.0)(ai@6.0.175(zod@4.4.3))(workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3))':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@workflow/serde': 4.1.1
-      ai: 6.0.175(zod@4.4.3)
-      workflow: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
-      zod: 4.3.6
-    optionalDependencies:
-      '@ai-sdk/anthropic': 3.0.75(zod@4.3.6)
-      '@ai-sdk/gateway': 3.0.143(zod@4.3.6)
-      '@ai-sdk/google': 3.0.68(zod@4.3.6)
-      '@ai-sdk/openai': 3.0.62(zod@4.3.6)
-      '@ai-sdk/xai': 3.0.88(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
-
   '@workflow/ai@4.1.2(@opentelemetry/api@1.9.0)(ai@7.0.15(zod@4.4.3))(workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3))':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -17734,6 +17902,21 @@ snapshots:
       '@ai-sdk/xai': 3.0.88(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
 
+  '@workflow/ai@4.2.0(@opentelemetry/api@1.9.0)(ai@6.0.175(zod@4.4.3))(workflow@4.6.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3))':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@workflow/serde': 4.1.2
+      ai: 6.0.175(zod@4.4.3)
+      workflow: 4.6.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
+      zod: 4.3.6
+    optionalDependencies:
+      '@ai-sdk/anthropic': 3.0.75(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.143(zod@4.3.6)
+      '@ai-sdk/google': 3.0.68(zod@4.3.6)
+      '@ai-sdk/openai': 3.0.62(zod@4.3.6)
+      '@ai-sdk/xai': 3.0.88(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+
   '@workflow/astro@4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
@@ -17748,12 +17931,45 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
+  '@workflow/astro@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/vite': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      exsolve: 1.1.0
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
   '@workflow/builders@4.1.0(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
       '@workflow/core': 4.5.0(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.4
       '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/utils': 4.1.3
+      builtin-modules: 5.0.0
+      chalk: 5.6.2
+      enhanced-resolve: 5.19.0
+      esbuild: 0.28.1
+      find-up: 7.0.0
+      json5: 2.2.3
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
+  '@workflow/builders@4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.0)
+      '@workflow/errors': 4.1.4
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
       '@workflow/utils': 4.1.3
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -17804,6 +18020,43 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
+  '@workflow/cli@4.3.0(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@oclif/core': 4.11.4
+      '@oclif/plugin-help': 6.2.37
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@vercel/cli-auth': 0.0.1
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.0)
+      '@workflow/errors': 4.1.4
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/utils': 4.1.3
+      '@workflow/web': 4.1.12
+      '@workflow/world': 4.2.1
+      '@workflow/world-local': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.5.0(@opentelemetry/api@1.9.0)
+      boxen: 8.0.1
+      builtin-modules: 5.0.0
+      chalk: 5.6.2
+      chokidar: 4.0.3
+      date-fns: 4.1.0
+      dotenv: 17.4.2
+      easy-table: 1.2.0
+      enhanced-resolve: 5.19.0
+      esbuild: 0.28.1
+      find-up: 7.0.0
+      mixpart: 0.0.4
+      open: 10.2.0
+      ora: 8.2.0
+      terminal-link: 5.0.0
+      tinyglobby: 0.2.17
+      xdg-app-paths: 5.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
   '@workflow/core@4.5.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
@@ -17817,6 +18070,32 @@ snapshots:
       '@workflow/world': 4.2.0(zod@4.3.6)
       '@workflow/world-local': 4.2.0(@opentelemetry/api@1.9.0)
       '@workflow/world-vercel': 4.4.1(@opentelemetry/api@1.9.0)
+      debug: 4.4.3(supports-color@8.1.1)
+      devalue: 5.8.1
+      ms: 2.1.3
+      nanoid: 5.1.6
+      seedrandom: 3.0.5
+      semver: 7.7.4
+      ulid: 3.0.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@workflow/core@4.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.49
+      '@jridgewell/trace-mapping': 0.3.31
+      '@standard-schema/spec': 1.0.0
+      '@types/ms': 2.1.0
+      '@vercel/functions': 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49)
+      '@workflow/errors': 4.1.4
+      '@workflow/serde': 4.1.2
+      '@workflow/utils': 4.1.3
+      '@workflow/world': 4.2.1
+      '@workflow/world-local': 4.2.1(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.5.0(@opentelemetry/api@1.9.0)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.8.1
       ms: 2.1.3
@@ -17849,12 +18128,39 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
+  '@workflow/nest@4.0.12(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)':
+    dependencies:
+      '@nestjs/common': 11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
   '@workflow/next@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
       '@workflow/builders': 4.1.0(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/core': 4.5.0(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      semver: 7.7.4
+      watchpack: 2.5.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
+  '@workflow/next@4.1.0(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.0)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
       semver: 7.7.4
       watchpack: 2.5.1
     transitivePeerDependencies:
@@ -17878,10 +18184,36 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
+  '@workflow/nitro@4.1.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/vite': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/web': 4.1.12
+      exsolve: 1.0.8
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
   '@workflow/nuxt@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)':
     dependencies:
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
       '@workflow/nitro': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - magicast
+      - supports-color
+
+  '@workflow/nuxt@4.0.12(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)':
+    dependencies:
+      '@nuxt/kit': 4.4.7(magicast@0.5.3)
+      '@workflow/nitro': 4.1.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -17893,6 +18225,17 @@ snapshots:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
       '@workflow/builders': 4.1.0(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      exsolve: 1.0.7
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
+  '@workflow/rollup@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
       exsolve: 1.0.7
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -17922,7 +18265,26 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
+  '@workflow/sveltekit@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))
+      '@workflow/vite': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      exsolve: 1.1.0
+      fs-extra: 11.3.5
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
   '@workflow/swc-plugin@4.1.1(@swc/core@1.15.3(@swc/helpers@0.5.21))':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.21)
+
+  '@workflow/swc-plugin@4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.21))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
 
@@ -17942,7 +18304,21 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
+  '@workflow/vite@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
+    dependencies:
+      '@workflow/builders': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+
   '@workflow/web@4.1.11':
+    dependencies:
+      express: 5.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@workflow/web@4.1.12':
     dependencies:
       express: 5.2.1
     transitivePeerDependencies:
@@ -17961,6 +18337,19 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@workflow/world-local@4.2.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@vercel/queue': 0.3.1
+      '@workflow/errors': 4.1.4
+      '@workflow/utils': 4.1.3
+      '@workflow/world': 4.2.1
+      async-sema: 3.1.1
+      ulid: 3.0.2
+      undici: 7.28.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@workflow/world-vercel@4.4.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@vercel/oidc': 3.2.0
@@ -17973,7 +18362,24 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@workflow/world-vercel@4.5.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@vercel/queue': 0.3.1
+      '@workflow/errors': 4.1.4
+      '@workflow/world': 4.2.1
+      cbor-x: 1.6.0
+      undici: 7.28.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@workflow/world@4.2.0(zod@4.3.6)':
+    dependencies:
+      ulid: 3.0.2
+      zod: 4.3.6
+
+  '@workflow/world@4.2.1':
     dependencies:
       ulid: 3.0.2
       zod: 4.3.6
@@ -18559,7 +18965,7 @@ snapshots:
 
   chardet@2.1.1: {}
 
-  chat@4.32.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3):
+  chat@4.33.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -19446,11 +19852,6 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
-  enhanced-resolve@5.21.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
@@ -20008,6 +20409,18 @@ snapshots:
       nitropack: 2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.135.0)(rolldown@1.1.4)(srvx@0.11.21)
       ofetch: 2.0.0-alpha.3
       vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
 
   execa@8.0.1:
     dependencies:
@@ -20761,6 +21174,8 @@ snapshots:
 
   human-id@4.1.3: {}
 
+  human-signals@2.1.0: {}
+
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
@@ -21022,6 +21437,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.7.0: {}
+
+  jose@5.10.0: {}
 
   jose@6.2.3: {}
 
@@ -21749,6 +22166,8 @@ snapshots:
 
   mime@4.1.0: {}
 
+  mimic-fn@2.1.0: {}
+
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
@@ -22379,6 +22798,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-url@8.1.1: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
 
   npm-run-path@5.3.0:
     dependencies:
@@ -23029,6 +23452,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -23411,7 +23838,7 @@ snapshots:
   pkg-types@2.3.1:
     dependencies:
       confbox: 0.2.4
-      exsolve: 1.0.8
+      exsolve: 1.1.0
       pathe: 2.0.3
 
   pluralize@8.0.0: {}
@@ -24641,6 +25068,8 @@ snapshots:
       inspect-with-kind: 1.0.5
       is-plain-obj: 1.1.0
 
+  strip-final-newline@2.0.0: {}
+
   strip-final-newline@3.0.0: {}
 
   strip-final-newline@4.0.0: {}
@@ -24960,14 +25389,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.10.3:
+  turbo@2.10.4:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.3
-      '@turbo/darwin-arm64': 2.10.3
-      '@turbo/linux-64': 2.10.3
-      '@turbo/linux-arm64': 2.10.3
-      '@turbo/windows-64': 2.10.3
-      '@turbo/windows-arm64': 2.10.3
+      '@turbo/darwin-64': 2.10.4
+      '@turbo/darwin-arm64': 2.10.4
+      '@turbo/linux-64': 2.10.4
+      '@turbo/linux-arm64': 2.10.4
+      '@turbo/windows-64': 2.10.4
+      '@turbo/windows-arm64': 2.10.4
 
   type-check@0.4.0:
     dependencies:
@@ -25059,6 +25488,8 @@ snapshots:
 
   undici@7.26.0: {}
 
+  undici@7.28.0: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -25130,7 +25561,7 @@ snapshots:
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
     optionalDependencies:
@@ -25149,7 +25580,7 @@ snapshots:
       pkg-types: 2.3.1
       scule: 1.3.0
       strip-literal: 3.1.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
     optionalDependencies:
@@ -25755,7 +26186,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
       scule: 1.3.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
       vue: 3.5.34(typescript@6.0.3)
@@ -25778,7 +26209,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
       scule: 1.3.0
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
       vue: 3.5.34(typescript@6.0.3)
@@ -25882,6 +26313,34 @@ snapshots:
       '@workflow/nuxt': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)
       '@workflow/rollup': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/sveltekit': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/typescript-plugin': 4.0.3(typescript@6.0.3)
+      '@workflow/utils': 4.1.3
+      ms: 2.1.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - '@nestjs/common'
+      - '@nestjs/core'
+      - '@swc/cli'
+      - '@swc/core'
+      - '@swc/helpers'
+      - magicast
+      - next
+      - supports-color
+      - typescript
+
+  workflow@4.6.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3):
+    dependencies:
+      '@workflow/astro': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/cli': 4.3.0(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.6.0(@opentelemetry/api@1.9.0)
+      '@workflow/errors': 4.1.4
+      '@workflow/nest': 4.0.12(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
+      '@workflow/next': 4.1.0(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/nitro': 4.1.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/nuxt': 4.0.12(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)
+      '@workflow/rollup': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/sveltekit': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/typescript-plugin': 4.0.3(typescript@6.0.3)
       '@workflow/utils': 4.1.3
       ms: 2.1.3


### PR DESCRIPTION
## Summary

- Allow `token` to be a string or async provider (`GithubTokenInput`), resolved lazily at each tool execution — unblocks Vercel Connect and other short-lived token mechanisms
- Keep `createOctokit` and the `core/*` layer backward compatible (no breaking changes on low-level APIs)
- Add `resolveGithubToken` helper, docs, minor changeset, and a temporary Vercel Connect example in `examples/eve-agent`
- Supersedes #41 with a cleaner implementation; credits original approach

Co-authored-by: @trevorharwell <trevor.harwell@evisions.com>