### PR TITLE
feat(sdk): first-class Vercel Connect integration

### DIFF
--- a/.changeset/vercel-connect-integration.md
+++ b/.changeset/vercel-connect-integration.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Add `@github-tools/sdk/connect` and `@github-tools/sdk/connect/eve` helpers for Vercel Connect — preset-derived scopes, `connectGithubToken`, and `connectGithubTools`.

--- a/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
+++ b/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
@@ -49,11 +49,13 @@ Fine-grained personal access tokens let you restrict access per repository and p
 
 | Preset | Repository access | Contents | Pull requests | Issues | Actions | Administration |
 |---|---|---|---|---|---|---|
-| `repo-explorer` | selected repos | `read` | — | — | — | — |
+| `repo-explorer` | selected repos | `read` | `read` | `read` | `read` | — |
 | `code-review` | selected repos | `read` | `read` (or `write` for comments) | — | — | — |
 | `issue-triage` | selected repos | `read` | — | `write` | — | — |
 | `ci-ops` | selected repos | `read` | — | — | `write` | — |
 | `maintainer` | selected repos | `write` | `write` | `write` | `write` | `write` (for repo creation and forking) |
+
+`repo-explorer` and `maintainer` also include gist read (and, for `maintainer`, write) tools. Gists aren't tied to a repository — GitHub only grants gist access to GitHub App *user* access tokens, never installation tokens, so give the PAT the "Gists" account permission separately, and expect gist tools to fail over Vercel Connect (see below).
 
 ## Mint tokens with Vercel Connect
 

--- a/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
+++ b/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
@@ -59,6 +59,10 @@ Fine-grained personal access tokens let you restrict access per repository and p
 
 For agents deployed on Vercel, [Vercel Connect](https://vercel.com/docs/connect) replaces long-lived PATs entirely. You attach a **GitHub connector** (a Vercel-managed GitHub App) to your project, and your server code requests a **short-lived, scoped token** at runtime — no secret to store, rotate, or leak.
 
+::callout{icon="i-lucide-plug"}
+**First-class helper** — use `@github-tools/sdk/connect` to derive scopes from your preset automatically. See the [Vercel Connect guide](/guide/vercel-connect) for `connectGithubTools` and `connectGithubToken`.
+::
+
 ::steps{level="3"}
 ### Create a GitHub connector
 
@@ -70,7 +74,20 @@ Link the connector to the Vercel project that runs your agent. On Vercel, the SD
 
 ### Request a token at runtime
 
-Install `@vercel/connect` and call `getToken` with the permissions your preset needs, then pass the result as `token`:
+Install `@vercel/connect` and call `getToken` with the permissions your preset needs, then pass the result as `token`. Prefer the [connect subpath](/guide/vercel-connect) when you want preset-derived scopes without maintaining a scope list:
+
+```ts [connect-tools.ts]
+import { connectGithubTools } from '@github-tools/sdk/connect'
+import { generateText } from 'ai'
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4.6',
+  tools: connectGithubTools('github/my-connector', { preset: 'code-review' }),
+  prompt: 'Summarize the open PRs on my-org/my-repo.',
+})
+```
+
+Manual `getToken` (full control over every parameter):
 
 ```ts [connect-token.ts]
 import { getToken } from '@vercel/connect'

--- a/apps/docs/content/docs/3.guide/6.vercel-connect.md
+++ b/apps/docs/content/docs/3.guide/6.vercel-connect.md
@@ -1,0 +1,123 @@
+---
+title: Vercel Connect
+description: Use @github-tools/sdk/connect to mint scoped GitHub tokens from a Vercel Connect connector — preset-derived scopes, zero boilerplate.
+navigation:
+  title: Vercel Connect
+path: /guide/vercel-connect
+links:
+  - label: Tokens & Auth
+    icon: i-lucide-key-round
+    to: /guide/tokens-and-auth
+    color: neutral
+    variant: subtle
+  - label: Scope with presets
+    icon: i-lucide-layers
+    to: /guide/presets
+    color: neutral
+    variant: subtle
+---
+
+For agents deployed on Vercel, [Vercel Connect](https://vercel.com/docs/connect) replaces long-lived PATs. Attach a **GitHub connector** to your project and mint **short-lived, scoped tokens** at runtime — no secret to store.
+
+The `@github-tools/sdk/connect` subpath wraps Connect with preset-derived scopes so you only think about the connector and preset.
+
+## Quick start (AI SDK)
+
+```ts [connect-tools.ts]
+import { connectGithubTools } from '@github-tools/sdk/connect'
+import { generateText } from 'ai'
+
+const tools = connectGithubTools('github/my-connector', {
+  preset: 'code-review',
+})
+
+const { text } = await generateText({
+  model: 'anthropic/claude-sonnet-4.6',
+  tools,
+  prompt: 'Summarize open PRs on my-org/my-repo.',
+})
+```
+
+Scopes are derived automatically from the preset — see the [preset → Connect scope matrix](/guide/tokens-and-auth#map-permissions-to-presets).
+
+## eve agent
+
+```ts [eve-connect.ts]
+// agent/tools/github.ts
+import { connectGithubTools } from '@github-tools/sdk/connect/eve'
+
+export default connectGithubTools('github/my-connector', {
+  preset: 'maintainer',
+})
+```
+
+See [`examples/eve-agent`](https://github.com/vercel-labs/github-tools/tree/main/examples/eve-agent) for a runnable example.
+
+## Token provider only
+
+When you need a lazy token for custom tool factories:
+
+```ts [connect-token.ts]
+import { connectGithubToken } from '@github-tools/sdk/connect'
+import { createGithubTools } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  preset: 'ci-ops',
+  token: connectGithubToken('github/my-connector'),
+})
+```
+
+## Multi-tenant and repository scoping
+
+Override Connect parameters when you need installation targeting or narrower repository access:
+
+```ts [connect-override.ts]
+import { connectGithubTools } from '@github-tools/sdk/connect'
+
+const tools = connectGithubTools('github/my-connector', {
+  preset: 'issue-triage',
+  connect: {
+    installationId: 'inst_abc',
+    repositories: ['vercel-labs/github-tools'],
+    scopes: ['issues:write'], // replaces preset-derived scopes when provided
+  },
+})
+```
+
+`subject` is always `{ type: 'app' }` — same as `connectGitHubAdapter` from `@vercel/connect`.
+
+## Setup checklist
+
+::steps{level="3"}
+### Create a GitHub connector
+
+Create a connector from the [Vercel dashboard](https://vercel.com/docs/connect) (or `vercel connect` in the CLI), then install it on the GitHub org or user account your agent needs.
+
+### Link it to your project
+
+Link the connector to the Vercel project that runs your agent. On Vercel, the SDK authenticates automatically with the deployment OIDC token. For local development, run `vercel link` then `vercel env pull`.
+
+### Install the peer dependency
+
+```sh
+pnpm add @vercel/connect
+```
+
+`@vercel/connect` is an optional peer dependency of `@github-tools/sdk` — install it only when using the `/connect` subpath.
+::
+
+## Manual `getToken` (escape hatch)
+
+If you need full control over every `ConnectTokenParams` field, call `getToken` directly and pass the result as `token`. See [Tokens & Auth](/guide/tokens-and-auth#mint-tokens-with-vercel-connect).
+
+## API reference
+
+- [`connectGithubTools`](/api/reference#connectgithubtools) — AI SDK tool set
+- [`connectGithubTools` (eve)](/api/reference#connectgithubtools--eve) — eve `defineDynamic` sentinel
+- [`connectGithubToken`](/api/reference#connectgithubtoken) — lazy token provider
+- [`connectGithubScopesForPreset`](/api/reference#connectgithubscopesforpreset) — scope helper
+
+## External references
+
+- [Vercel Connect documentation](https://vercel.com/docs/connect)
+- [Vercel Connect SDK reference](https://vercel.com/docs/connect/ts-sdk-reference)

--- a/apps/docs/content/docs/3.guide/6.vercel-connect.md
+++ b/apps/docs/content/docs/3.guide/6.vercel-connect.md
@@ -42,6 +42,19 @@ Scopes are derived automatically from the preset — see the [preset → Connect
 
 ## eve agent
 
+```ts [eve-agent.ts]
+// agent/agent.ts
+import { defineAgent } from 'eve'
+
+export default defineAgent({
+  model: 'anthropic/claude-sonnet-5',
+  // TODO(eve-connect-bundle): remove when eve externalizes transitive @vercel/connect
+  build: {
+    externalDependencies: ['@vercel/connect'],
+  },
+})
+```
+
 ```ts [eve-connect.ts]
 // agent/tools/github.ts
 import { connectGithubTools } from '@github-tools/sdk/connect/eve'
@@ -50,6 +63,10 @@ export default connectGithubTools('github/my-connector', {
   preset: 'maintainer',
 })
 ```
+
+::note
+**eve bundling** — `build.externalDependencies` keeps `@vercel/connect` out of the authored-module bundle. Without it, `eve dev` fails when the SDK is workspace-linked. This is temporary until eve handles transitive Connect imports upstream.
+::
 
 See [`examples/eve-agent`](https://github.com/vercel-labs/github-tools/tree/main/examples/eve-agent) for a runnable example.
 

--- a/apps/docs/content/docs/3.guide/6.vercel-connect.md
+++ b/apps/docs/content/docs/3.guide/6.vercel-connect.md
@@ -80,9 +80,11 @@ import { createGithubTools } from '@github-tools/sdk'
 
 const tools = createGithubTools({
   preset: 'ci-ops',
-  token: connectGithubToken('github/my-connector'),
+  token: connectGithubToken('github/my-connector', { preset: 'ci-ops' }),
 })
 ```
+
+Pass the same `preset` to both calls — `connectGithubToken` derives Connect scopes from its own `preset` option, independently of the one you give `createGithubTools`. Omitting it mints a token scoped to the union of every preset instead of just `ci-ops`.
 
 ## Multi-tenant and repository scoping
 
@@ -109,6 +111,8 @@ const tools = connectGithubTools('github/my-connector', {
 ### Create a GitHub connector
 
 Create a connector from the [Vercel dashboard](https://vercel.com/docs/connect) (or `vercel connect` in the CLI), then install it on the GitHub org or user account your agent needs.
+
+Or jump straight to the GitHub connector creation form with this [deeplink](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fconnect%2Fcreate%3Ftype%3Dgithub).
 
 ### Link it to your project
 

--- a/apps/docs/content/docs/4.api/2.reference.md
+++ b/apps/docs/content/docs/4.api/2.reference.md
@@ -312,9 +312,11 @@ import { createGithubTools } from '@github-tools/sdk'
 
 const tools = createGithubTools({
   preset: 'ci-ops',
-  token: connectGithubToken('github/my-connector'),
+  token: connectGithubToken('github/my-connector', { preset: 'ci-ops' }),
 })
 ```
+
+Pass the same `preset` to `connectGithubToken` — it derives Connect scopes independently of the `preset` given to `createGithubTools`.
 
 ## `connectGithubScopesForPreset(preset?)`
 

--- a/apps/docs/content/docs/4.api/2.reference.md
+++ b/apps/docs/content/docs/4.api/2.reference.md
@@ -262,6 +262,64 @@ type EveApprovalValue =
 
 Also exports individual eve tool factories (`listPullRequests()`, `createIssue()`, …) for one-tool-per-file layouts. Approval supports `once`, predicates, and eve helper passthrough — unlike the Workflow subpath, approval **is enforced** at runtime.
 
+## `connectGithubTools(connector, options?)`
+
+Import from `@github-tools/sdk/connect`. Returns the same tool record as `createGithubTools`, backed by a Vercel Connect connector. Scopes are derived from `preset` unless overridden in `connect.scopes`:
+
+```ts [connect-tools.ts]
+import { connectGithubTools } from '@github-tools/sdk/connect'
+
+const tools = connectGithubTools('github/my-connector', {
+  preset: 'code-review',
+  connect: {
+    installationId: 'inst_abc',
+    repositories: ['my-org/my-repo'],
+  },
+})
+```
+
+```ts [types-connect.ts]
+type ConnectGithubToolsOptions = GithubToolsOptions & {
+  connect?: GithubConnectParams
+}
+
+type GithubConnectParams = Omit<ConnectTokenParams, 'subject'> & {
+  repositories?: string[]
+}
+```
+
+`subject` is always `{ type: 'app' }`. See [Vercel Connect guide](/guide/vercel-connect).
+
+## `connectGithubTools(connector, options?)` — eve
+
+Import from `@github-tools/sdk/connect/eve`. Same as the AI SDK variant but returns a `defineDynamic` sentinel:
+
+```ts [connect-eve.ts]
+import { connectGithubTools } from '@github-tools/sdk/connect/eve'
+
+export default connectGithubTools('github/my-connector', {
+  preset: 'maintainer',
+})
+```
+
+## `connectGithubToken(connector, options?)`
+
+Returns a lazy `GithubTokenInput` backed by `getToken`. Use with `createGithubTools` when you only need the token provider:
+
+```ts [connect-token-provider.ts]
+import { connectGithubToken } from '@github-tools/sdk/connect'
+import { createGithubTools } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  preset: 'ci-ops',
+  token: connectGithubToken('github/my-connector'),
+})
+```
+
+## `connectGithubScopesForPreset(preset?)`
+
+Returns Vercel Connect scope strings for a preset or combined presets. Without a preset, returns the union of all preset scopes.
+
 ## `resolveGithubToken(token?)`
 
 Resolves a `GithubTokenInput` (token string, async provider, or the `process.env.GITHUB_TOKEN` fallback) to a token string. Throws when no token is available.

--- a/apps/docs/content/docs/4.api/2.reference.md
+++ b/apps/docs/content/docs/4.api/2.reference.md
@@ -292,7 +292,7 @@ type GithubConnectParams = Omit<ConnectTokenParams, 'subject'> & {
 
 ## `connectGithubTools(connector, options?)` — eve
 
-Import from `@github-tools/sdk/connect/eve`. Same as the AI SDK variant but returns a `defineDynamic` sentinel:
+Import from `@github-tools/sdk/connect/eve`. Same as the AI SDK variant but returns a `defineDynamic` sentinel. Set `build.externalDependencies: ['@vercel/connect']` in `agent.ts` until eve externalizes transitive Connect imports from workspace-linked packages (`TODO(eve-connect-bundle)`).
 
 ```ts [connect-eve.ts]
 import { connectGithubTools } from '@github-tools/sdk/connect/eve'

--- a/examples/eve-agent/README.md
+++ b/examples/eve-agent/README.md
@@ -42,10 +42,12 @@ Open the dev TUI and ask it to review a pull request on a repo your connector ca
 
 ```
 agent/
-  agent.ts              # eve agent config
+  agent.ts              # eve agent config (externalizes @vercel/connect for bundling)
   instructions.md       # system prompt
   tools/github.ts       # GitHub tools via connectGithubTools()
 ```
+
+`agent.ts` sets `build.externalDependencies: ['@vercel/connect']` so `eve dev` can bundle `connectGithubTools` — a workaround until [eve](https://eve.dev) handles transitive Connect imports from workspace-linked packages without extra config.
 
 ## Customize
 

--- a/examples/eve-agent/README.md
+++ b/examples/eve-agent/README.md
@@ -1,8 +1,6 @@
 # GitHub eve Agent
 
-Minimal [eve](https://eve.dev) agent using `@github-tools/sdk/eve` with the `maintainer` preset.
-
-> **Temporary:** this example uses [Vercel Connect](https://vercel.com/docs/connect) (`github/test-github-tools`) instead of a `GITHUB_TOKEN` PAT. Revert `agent/tools/github.ts` to drop the `token` provider when you're done testing.
+Minimal [eve](https://eve.dev) agent using `@github-tools/sdk/connect/eve` with the `maintainer` preset and a [Vercel Connect](https://vercel.com/docs/connect) connector.
 
 ## Setup
 
@@ -46,7 +44,7 @@ Open the dev TUI and ask it to review a pull request on a repo your connector ca
 agent/
   agent.ts              # eve agent config
   instructions.md       # system prompt
-  tools/github.ts       # GitHub tools via createGithubTools() + Vercel Connect
+  tools/github.ts       # GitHub tools via connectGithubTools()
 ```
 
 ## Customize
@@ -54,12 +52,10 @@ agent/
 Swap the preset or configure approval:
 
 ```ts
-export default createGithubTools({
+import { connectGithubTools } from '@github-tools/sdk/connect/eve'
+
+export default connectGithubTools('github/test-github-tools', {
   preset: ['code-review', 'issue-triage'],
-  token: () => getToken('github/test-github-tools', {
-    subject: { type: 'app' },
-    scopes: ['contents:read', 'pull_requests:read'],
-  }),
   requireApproval: {
     mergePullRequest: true,
     addPullRequestComment: 'once',
@@ -67,4 +63,4 @@ export default createGithubTools({
 })
 ```
 
-See the [@github-tools/sdk README](../../packages/github-tools/README.md#eve) for the full eve integration guide.
+See the [@github-tools/sdk README](../../packages/github-tools/README.md#vercel-connect) for the full Connect integration guide.

--- a/examples/eve-agent/agent/agent.ts
+++ b/examples/eve-agent/agent/agent.ts
@@ -2,4 +2,10 @@ import { defineAgent } from 'eve'
 
 export default defineAgent({
   model: 'anthropic/claude-sonnet-5',
+  // TODO(eve-connect-bundle): remove when eve externalizes transitive @vercel/connect
+  // imports from workspace-linked packages without build.externalDependencies.
+  // See https://github.com/vercel-labs/github-tools/pull/44
+  build: {
+    externalDependencies: ['@vercel/connect'],
+  },
 })

--- a/examples/eve-agent/agent/tools/github.ts
+++ b/examples/eve-agent/agent/tools/github.ts
@@ -1,27 +1,5 @@
-import { getToken } from '@vercel/connect'
-import { createGithubTools } from '@github-tools/sdk/eve'
+import { connectGithubTools } from '@github-tools/sdk/connect/eve'
 
-// TEMP: Vercel Connect instead of GITHUB_TOKEN — connector "test-github-tools" on github-tools-docs
-const CONNECTOR_UID = 'github/test-github-tools'
-
-/** Scopes for the maintainer preset — https://github-tools.com/guide/tokens-and-auth */
-const MAINTAINER_SCOPES = [
-  'contents:read',
-  'contents:write',
-  'pull_requests:read',
-  'pull_requests:write',
-  'issues:read',
-  'issues:write',
-  'actions:read',
-  'actions:write',
-  'administration:read',
-  'administration:write',
-] as const
-
-export default createGithubTools({
+export default connectGithubTools('github/test-github-tools', {
   preset: 'maintainer',
-  token: () => getToken(CONNECTOR_UID, {
-    subject: { type: 'app' },
-    scopes: [...MAINTAINER_SCOPES],
-  }),
 })

--- a/examples/pr-review-agent/.gitignore
+++ b/examples/pr-review-agent/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .output
 .env
+/.swc

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -257,9 +257,11 @@ import { connectGithubToken } from '@github-tools/sdk/connect'
 
 createGithubTools({
   preset: 'ci-ops',
-  token: connectGithubToken('github/my-connector'),
+  token: connectGithubToken('github/my-connector', { preset: 'ci-ops' }),
 })
 ```
+
+Pass the same `preset` to `connectGithubToken` — it derives Connect scopes independently of the `preset` given to `createGithubTools`.
 
 Override installation, repositories, or scopes via `connect`:
 

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -232,6 +232,16 @@ const tools = connectGithubTools('github/my-connector', {
 For eve agents, import from `@github-tools/sdk/connect/eve`:
 
 ```ts
+// agent/agent.ts — TODO(eve-connect-bundle): drop externalDependencies when eve fixes upstream
+import { defineAgent } from 'eve'
+
+export default defineAgent({
+  model: 'anthropic/claude-sonnet-5',
+  build: { externalDependencies: ['@vercel/connect'] },
+})
+```
+
+```ts
 // agent/tools/github.ts
 import { connectGithubTools } from '@github-tools/sdk/connect/eve'
 

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -213,6 +213,59 @@ All presets work with `createDurableGithubAgent`. Write tools honor `requireAppr
 
 > `workflow` and `@ai-sdk/workflow` are optional peer dependencies — install them only when using the workflow subpath.
 
+## Vercel Connect
+
+[Vercel Connect](https://vercel.com/docs/connect) mints short-lived GitHub tokens from a connector — no PAT to store. The `@github-tools/sdk/connect` subpath derives scopes from your preset automatically.
+
+```sh
+pnpm add @vercel/connect
+```
+
+```ts
+import { connectGithubTools } from '@github-tools/sdk/connect'
+
+const tools = connectGithubTools('github/my-connector', {
+  preset: 'code-review',
+})
+```
+
+For eve agents, import from `@github-tools/sdk/connect/eve`:
+
+```ts
+// agent/tools/github.ts
+import { connectGithubTools } from '@github-tools/sdk/connect/eve'
+
+export default connectGithubTools('github/my-connector', {
+  preset: 'maintainer',
+})
+```
+
+Token provider only (custom factories):
+
+```ts
+import { connectGithubToken } from '@github-tools/sdk/connect'
+
+createGithubTools({
+  preset: 'ci-ops',
+  token: connectGithubToken('github/my-connector'),
+})
+```
+
+Override installation, repositories, or scopes via `connect`:
+
+```ts
+connectGithubTools('github/my-connector', {
+  preset: 'issue-triage',
+  connect: {
+    installationId: 'inst_abc',
+    repositories: ['my-org/my-repo'],
+    scopes: ['issues:write'],
+  },
+})
+```
+
+> `@vercel/connect` is an optional peer dependency — install it only when using the `/connect` subpath.
+
 ## eve
 
 [eve](https://eve.dev) is Vercel's filesystem-first agent framework. The `@github-tools/sdk/eve` subpath registers all GitHub tools via `defineDynamic` — one file, zero CLI.

--- a/packages/github-tools/package.json
+++ b/packages/github-tools/package.json
@@ -28,6 +28,14 @@
     "./eve": {
       "types": "./dist/eve.d.mts",
       "import": "./dist/eve.mjs"
+    },
+    "./connect": {
+      "types": "./dist/connect.d.mts",
+      "import": "./dist/connect.mjs"
+    },
+    "./connect/eve": {
+      "types": "./dist/connect/eve.d.mts",
+      "import": "./dist/connect/eve.mjs"
     }
   },
   "main": "./dist/index.mjs",
@@ -59,6 +67,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/workflow": "^1.0.16",
+    "@vercel/connect": "^0.3.2",
     "@workflow/ai": "^4.1.2",
     "ai": "^6.0.97 || ^7.0.0",
     "eve": "^0.19.0",
@@ -77,6 +86,9 @@
     },
     "eve": {
       "optional": true
+    },
+    "@vercel/connect": {
+      "optional": true
     }
   },
   "devDependencies": {
@@ -84,6 +96,7 @@
     "@ai-sdk/provider": "^4.0.2",
     "@ai-sdk/provider-utils": "^5.0.5",
     "@types/node": "^25.6.0",
+    "@vercel/connect": "^0.3.2",
     "ai": "^7.0.0",
     "eslint": "^10.3.0",
     "eve": "^0.19.0",

--- a/packages/github-tools/src/connect/eve.ts
+++ b/packages/github-tools/src/connect/eve.ts
@@ -5,6 +5,11 @@ import type { ConnectGithubEveToolsOptions } from './types'
 /**
  * Register eve GitHub tools backed by a Vercel Connect connector.
  * Scopes are derived from `preset` unless overridden in `connect.scopes`.
+ *
+ * TODO(eve-connect-bundle): eve's authored-module bundler inlines workspace-linked
+ * SDK code and code-splits `@vercel/connect` unless the agent sets
+ * `build.externalDependencies: ['@vercel/connect']` in `agent.ts`. Remove that
+ * requirement when upstream eve externalizes this path.
  */
 export function connectGithubTools(
   connector: string,

--- a/packages/github-tools/src/connect/eve.ts
+++ b/packages/github-tools/src/connect/eve.ts
@@ -1,0 +1,20 @@
+import { createGithubTools as createEveGithubTools } from '../eve'
+import { connectGithubToken } from './token'
+import type { ConnectGithubEveToolsOptions } from './types'
+
+/**
+ * Register eve GitHub tools backed by a Vercel Connect connector.
+ * Scopes are derived from `preset` unless overridden in `connect.scopes`.
+ */
+export function connectGithubTools(
+  connector: string,
+  options: ConnectGithubEveToolsOptions = {},
+) {
+  const { connect, preset, ...rest } = options
+
+  return createEveGithubTools({
+    ...rest,
+    preset,
+    token: connectGithubToken(connector, { preset, params: connect }),
+  })
+}

--- a/packages/github-tools/src/connect/index.ts
+++ b/packages/github-tools/src/connect/index.ts
@@ -1,0 +1,9 @@
+export { PRESET_CONNECT_SCOPES, connectGithubScopesForPreset } from './scopes'
+export { connectGithubToken } from './token'
+export { connectGithubTools } from './tools'
+export type {
+  ConnectGithubEveToolsOptions,
+  ConnectGithubTokenOptions,
+  ConnectGithubToolsOptions,
+  GithubConnectParams,
+} from './types'

--- a/packages/github-tools/src/connect/params.ts
+++ b/packages/github-tools/src/connect/params.ts
@@ -1,0 +1,30 @@
+import type { ConnectTokenParams } from '@vercel/connect'
+import { connectGithubScopesForPreset } from './scopes'
+import type { ConnectGithubTokenOptions, GithubConnectParams } from './types'
+
+export function resolveGithubConnectTokenParams(
+  options: ConnectGithubTokenOptions = {},
+): ConnectTokenParams {
+  const { preset, params } = options
+  const scopes = params?.scopes ?? connectGithubScopesForPreset(preset)
+  return buildConnectTokenParams(scopes, params)
+}
+
+function buildConnectTokenParams(
+  scopes: string[],
+  params?: GithubConnectParams,
+): ConnectTokenParams {
+  const { repositories, ...rest } = params ?? {}
+
+  const authorizationDetails = rest.authorizationDetails
+    ?? (repositories?.length
+      ? [{ type: 'github_app_installation' as const, repositories }]
+      : undefined)
+
+  return {
+    subject: { type: 'app' },
+    ...rest,
+    scopes,
+    ...(authorizationDetails && { authorizationDetails }),
+  }
+}

--- a/packages/github-tools/src/connect/scopes.test.ts
+++ b/packages/github-tools/src/connect/scopes.test.ts
@@ -6,6 +6,9 @@ describe('connectGithubScopesForPreset', () => {
     expect(connectGithubScopesForPreset('repo-explorer')).toEqual([
       'contents:read',
       'metadata:read',
+      'pull_requests:read',
+      'issues:read',
+      'actions:read',
     ])
   })
 
@@ -15,9 +18,11 @@ describe('connectGithubScopesForPreset', () => {
       'contents:read',
       'metadata:read',
       'pull_requests:read',
+      'issues:read',
+      'actions:read',
       'pull_requests:write',
     ]))
-    expect(scopes).toHaveLength(4)
+    expect(scopes).toHaveLength(6)
   })
 
   it('returns the union of all preset scopes when no preset is given', () => {

--- a/packages/github-tools/src/connect/scopes.test.ts
+++ b/packages/github-tools/src/connect/scopes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { PRESET_CONNECT_SCOPES, connectGithubScopesForPreset } from './scopes'
+
+describe('connectGithubScopesForPreset', () => {
+  it('returns scopes for a single preset', () => {
+    expect(connectGithubScopesForPreset('repo-explorer')).toEqual([
+      'contents:read',
+      'metadata:read',
+    ])
+  })
+
+  it('deduplicates scopes when combining presets', () => {
+    const scopes = connectGithubScopesForPreset(['repo-explorer', 'code-review'])
+    expect(scopes).toEqual(expect.arrayContaining([
+      'contents:read',
+      'metadata:read',
+      'pull_requests:read',
+      'pull_requests:write',
+    ]))
+    expect(scopes).toHaveLength(4)
+  })
+
+  it('returns the union of all preset scopes when no preset is given', () => {
+    const allPresets = Object.values(PRESET_CONNECT_SCOPES).flat()
+    const scopes = connectGithubScopesForPreset()
+    expect(scopes).toHaveLength(new Set(allPresets).size)
+    expect(scopes).toEqual(expect.arrayContaining(allPresets))
+  })
+
+  it('includes administration scopes for maintainer', () => {
+    expect(connectGithubScopesForPreset('maintainer')).toEqual(
+      expect.arrayContaining(['administration:read', 'administration:write']),
+    )
+  })
+})

--- a/packages/github-tools/src/connect/scopes.ts
+++ b/packages/github-tools/src/connect/scopes.ts
@@ -1,0 +1,60 @@
+import type { GithubToolPreset } from '../core/presets'
+
+/** Vercel Connect scope strings mapped to each {@link GithubToolPreset}. */
+export const PRESET_CONNECT_SCOPES = {
+  'repo-explorer': [
+    'contents:read',
+    'metadata:read',
+  ],
+  'code-review': [
+    'contents:read',
+    'metadata:read',
+    'pull_requests:read',
+    'pull_requests:write',
+  ],
+  'issue-triage': [
+    'contents:read',
+    'metadata:read',
+    'issues:read',
+    'issues:write',
+  ],
+  'ci-ops': [
+    'contents:read',
+    'metadata:read',
+    'actions:read',
+    'actions:write',
+  ],
+  'maintainer': [
+    'contents:read',
+    'contents:write',
+    'metadata:read',
+    'pull_requests:read',
+    'pull_requests:write',
+    'issues:read',
+    'issues:write',
+    'actions:read',
+    'actions:write',
+    'administration:read',
+    'administration:write',
+  ],
+} as const satisfies Record<GithubToolPreset, readonly string[]>
+
+/** Default scopes when no preset is specified — union of all preset scopes. */
+const ALL_CONNECT_SCOPES = [
+  ...new Set(Object.values(PRESET_CONNECT_SCOPES).flat()),
+] as string[]
+
+/**
+ * Returns Vercel Connect scopes for a preset or combined presets.
+ * Without a preset, returns the union of all preset scopes (full tool set).
+ */
+export function connectGithubScopesForPreset(
+  preset?: GithubToolPreset | GithubToolPreset[],
+): string[] {
+  if (!preset) return [...ALL_CONNECT_SCOPES]
+
+  const presets = Array.isArray(preset) ? preset : [preset]
+  return [
+    ...new Set(presets.flatMap(p => PRESET_CONNECT_SCOPES[p])),
+  ]
+}

--- a/packages/github-tools/src/connect/scopes.ts
+++ b/packages/github-tools/src/connect/scopes.ts
@@ -1,10 +1,26 @@
 import type { GithubToolPreset } from '../core/presets'
 
-/** Vercel Connect scope strings mapped to each {@link GithubToolPreset}. */
+/**
+ * Vercel Connect scope strings mapped to each {@link GithubToolPreset}.
+ *
+ * Scopes mirror GitHub App permissions (`contents`, `pull_requests`, `issues`,
+ * `actions`, `administration`, `metadata`) and must cover every read/write
+ * family a preset's tools touch, not just its primary domain.
+ *
+ * Gist tools in `repo-explorer` and `maintainer` are intentionally left
+ * unscoped: the Gists API only accepts GitHub App *user* access tokens, never
+ * installation tokens, and Connect always mints `subject: { type: 'app' }`
+ * installation tokens. Gist calls made with a Connect-derived token 403
+ * regardless of requested scopes — use a fine-grained PAT with the "Gists"
+ * account permission for those tools instead.
+ */
 export const PRESET_CONNECT_SCOPES = {
   'repo-explorer': [
     'contents:read',
     'metadata:read',
+    'pull_requests:read',
+    'issues:read',
+    'actions:read',
   ],
   'code-review': [
     'contents:read',

--- a/packages/github-tools/src/connect/token.test.ts
+++ b/packages/github-tools/src/connect/token.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getToken } = vi.hoisted(() => ({
+  getToken: vi.fn(async () => 'ghs_connect_token'),
+}))
+
+vi.mock('@vercel/connect', () => ({
+  getToken,
+}))
+
+import { connectGithubToken } from './token'
+
+function resolveConnectToken(
+  connector: string,
+  options?: Parameters<typeof connectGithubToken>[1],
+) {
+  const resolve = connectGithubToken(connector, options)
+  if (typeof resolve !== 'function') {
+    throw new Error('expected async token provider')
+  }
+  return resolve
+}
+
+describe('connectGithubToken', () => {
+  beforeEach(() => {
+    getToken.mockClear()
+  })
+
+  it('calls getToken with app subject and preset-derived scopes', async () => {
+    const resolve = resolveConnectToken('github/my-connector', {
+      preset: 'code-review',
+    })
+
+    await expect(resolve()).resolves.toBe('ghs_connect_token')
+    expect(getToken).toHaveBeenCalledWith('github/my-connector', {
+      subject: { type: 'app' },
+      scopes: [
+        'contents:read',
+        'metadata:read',
+        'pull_requests:read',
+        'pull_requests:write',
+      ],
+    }, undefined)
+  })
+
+  it('uses scope override from params instead of preset mapping', async () => {
+    const resolve = resolveConnectToken('github/my-connector', {
+      preset: 'maintainer',
+      params: { scopes: ['issues:write'] },
+    })
+
+    await resolve()
+    expect(getToken).toHaveBeenCalledWith('github/my-connector', {
+      subject: { type: 'app' },
+      scopes: ['issues:write'],
+    }, undefined)
+  })
+
+  it('maps repositories to github_app_installation authorization details', async () => {
+    const resolve = resolveConnectToken('github/my-connector', {
+      preset: 'issue-triage',
+      params: {
+        installationId: 'inst_abc',
+        repositories: ['vercel-labs/github-tools'],
+      },
+    })
+
+    await resolve()
+    expect(getToken).toHaveBeenCalledWith('github/my-connector', {
+      subject: { type: 'app' },
+      installationId: 'inst_abc',
+      scopes: [
+        'contents:read',
+        'metadata:read',
+        'issues:read',
+        'issues:write',
+      ],
+      authorizationDetails: [{
+        type: 'github_app_installation',
+        repositories: ['vercel-labs/github-tools'],
+      }],
+    }, undefined)
+  })
+
+  it('forwards connectOptions to getToken', async () => {
+    const connectOptions = { forceRefresh: true }
+    const resolve = resolveConnectToken('github/my-connector', {
+      preset: 'repo-explorer',
+      connectOptions,
+    })
+
+    await resolve()
+    expect(getToken).toHaveBeenCalledWith(
+      'github/my-connector',
+      expect.objectContaining({ subject: { type: 'app' } }),
+      connectOptions,
+    )
+  })
+})

--- a/packages/github-tools/src/connect/token.ts
+++ b/packages/github-tools/src/connect/token.ts
@@ -1,0 +1,20 @@
+import { getToken, type ConnectOptions } from '@vercel/connect'
+import type { GithubTokenInput } from '../core/token'
+import { resolveGithubConnectTokenParams } from './params'
+import type { ConnectGithubTokenOptions } from './types'
+
+/**
+ * Returns a lazy GitHub token provider backed by a Vercel Connect connector.
+ * Scopes are derived from `preset` unless overridden in `params.scopes`.
+ */
+export function connectGithubToken(
+  connector: string,
+  options: ConnectGithubTokenOptions = {},
+): GithubTokenInput {
+  const { connectOptions } = options
+  const tokenParams = resolveGithubConnectTokenParams(options)
+
+  return () => getToken(connector, tokenParams, connectOptions)
+}
+
+export type { ConnectOptions }

--- a/packages/github-tools/src/connect/tools.ts
+++ b/packages/github-tools/src/connect/tools.ts
@@ -1,0 +1,20 @@
+import { createGithubTools } from '../index'
+import { connectGithubToken } from './token'
+import type { ConnectGithubToolsOptions } from './types'
+
+/**
+ * Create GitHub tools backed by a Vercel Connect connector.
+ * Scopes are derived from `preset` unless overridden in `connect.scopes`.
+ */
+export function connectGithubTools(
+  connector: string,
+  options: ConnectGithubToolsOptions = {},
+) {
+  const { connect, preset, ...rest } = options
+
+  return createGithubTools({
+    ...rest,
+    preset,
+    token: connectGithubToken(connector, { preset, params: connect }),
+  })
+}

--- a/packages/github-tools/src/connect/types.ts
+++ b/packages/github-tools/src/connect/types.ts
@@ -1,0 +1,28 @@
+import type { ConnectOptions, ConnectTokenParams } from '@vercel/connect'
+import type { GithubToolPreset } from '../core/presets'
+import type { GithubToolsBaseOptions } from '../core/tool-types'
+import type { EveGithubToolsOptions } from '../eve/types'
+
+/**
+ * Token parameters for Vercel Connect GitHub connectors.
+ * `subject` is pinned to `{ type: 'app' }` by the SDK — same as `connectGitHubAdapter`.
+ */
+export type GithubConnectParams = Omit<ConnectTokenParams, 'subject'> & {
+  /** Restrict the token to specific repositories via GitHub authorization details. */
+  repositories?: string[]
+}
+
+export type ConnectGithubToolsOptions = GithubToolsBaseOptions & {
+  preset?: GithubToolPreset | GithubToolPreset[]
+  connect?: GithubConnectParams
+}
+
+export type ConnectGithubEveToolsOptions = Omit<EveGithubToolsOptions, 'token'> & {
+  connect?: GithubConnectParams
+}
+
+export type ConnectGithubTokenOptions = {
+  preset?: GithubToolPreset | GithubToolPreset[]
+  params?: GithubConnectParams
+  connectOptions?: ConnectOptions
+}

--- a/packages/github-tools/tsdown.config.ts
+++ b/packages/github-tools/tsdown.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     index: 'src/index.ts',
     workflow: 'src/workflow.ts',
     eve: 'src/eve.ts',
+    connect: 'src/connect/index.ts',
+    'connect/eve': 'src/connect/eve.ts',
   },
   format: 'esm',
   dts: true,
@@ -21,5 +23,6 @@ export default defineConfig({
     'eve',
     'eve/tools',
     'eve/tools/approval',
+    '@vercel/connect',
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,13 +46,13 @@ importers:
         version: 0.17.3
       '@nuxt/ui':
         specifier: ^4.7.1
-        version: 4.7.1(80675f272f43126b1aa0dcc2f1ad1187)
+        version: 4.7.1(60131c35c878a6e064bd4d763f8499ba)
       '@nuxthub/core':
         specifier: ^0.10.7
-        version: 0.10.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))
+        version: 0.10.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.2)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))
       '@nuxtjs/mdc':
         specifier: ^0.21.1
-        version: 0.21.1(magicast@0.5.3)
+        version: 0.21.1(magicast@0.5.2)
       '@vercel/blob':
         specifier: ^2.3.3
         version: 2.3.3
@@ -61,13 +61,13 @@ importers:
         version: 14.3.0(vue@3.5.34(typescript@6.0.3))
       '@workflow/ai':
         specifier: ^4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.0)(ai@7.0.15(zod@4.4.3))(workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(ai@7.0.15(zod@4.4.3))(workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(typescript@6.0.3))
       '@workflow/nitro':
         specifier: 4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/nuxt':
         specifier: ^4.0.11
-        version: 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)
+        version: 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.2)
       ai:
         specifier: ^7.0.0
         version: 7.0.15(zod@4.4.3)
@@ -85,10 +85,10 @@ importers:
         version: 2.2.1(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       nuxt:
         specifier: ^4.4.4
-        version: 4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2)
+        version: 4.4.4(e9f11ae722cb63b39c11139322034c2f)
       nuxt-auth-utils:
         specifier: ^0.5.29
-        version: 0.5.29(magicast@0.5.3)
+        version: 0.5.29(magicast@0.5.2)
       nuxt-charts:
         specifier: ^2.1.4
         version: 2.1.4(vue@3.5.34(typescript@6.0.3))
@@ -109,14 +109,14 @@ importers:
         version: 4.2.4
       workflow:
         specifier: ^4.5.0
-        version: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
+        version: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@nuxt/eslint':
         specifier: ^1.15.2
-        version: 1.15.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.3.0(jiti@2.7.0))(magicast@0.5.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.15.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.3.0(jiti@2.7.0))(magicast@0.5.2)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -137,25 +137,25 @@ importers:
     dependencies:
       '@nuxt/fonts':
         specifier: ^0.14.0
-        version: 0.14.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 0.14.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vue@3.5.34(typescript@6.0.3))
+        version: 2.0.1(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vue@3.5.34(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vue@3.5.34(typescript@6.0.3))
+        version: 2.0.0(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vue@3.5.34(typescript@6.0.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
       docus:
         specifier: ^5.12.3
-        version: 5.12.3(cb1cee4c277625c458780fdde585ceb9)
+        version: 5.12.3(4abb6b041d4f9559d8e56a4b45b4fd92)
       nuxt:
         specifier: ^4.4.4
-        version: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
+        version: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
       satori:
         specifier: ^0.26.0
         version: 0.26.0
@@ -168,13 +168,13 @@ importers:
     devDependencies:
       '@nuxt/eslint':
         specifier: ^1.15.2
-        version: 1.15.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.3.0(jiti@2.7.0))(magicast@0.5.2)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.15.2(@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)(eslint@10.3.0(jiti@2.7.0))(magicast@0.5.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       eslint:
         specifier: ^10.3.0
         version: 10.3.0(jiti@2.7.0)
       nuxtseo-layer-devtools:
         specifier: 5.3.2
-        version: 5.3.2(b1e93e7060f7b3a830cf7a3ea530fd05)
+        version: 5.3.2(58b9110a518076275d4e7f2f4419fc57)
 
   examples/eve-agent:
     dependencies:
@@ -248,7 +248,7 @@ importers:
         version: 5.0.5
       workflow:
         specifier: ^4.5.0
-        version: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
+        version: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -265,6 +265,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@vercel/connect':
+        specifier: ^0.3.2
+        version: 0.3.2(@ai-sdk/mcp@1.0.58(zod@4.4.3))(ai@7.0.16(zod@4.4.3))(eve@0.19.0(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)))
       ai:
         specifier: ^7.0.0
         version: 7.0.16(zod@4.4.3)
@@ -841,11 +844,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -13276,7 +13279,7 @@ snapshots:
 
   '@intlify/shared@11.4.2': {}
 
-  '@intlify/unplugin-vue-i18n@11.1.2(@vue/compiler-dom@3.5.39)(eslint@10.3.0(jiti@2.7.0))(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue-i18n@11.4.2(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))':
+  '@intlify/unplugin-vue-i18n@11.1.2(@vue/compiler-dom@3.5.39)(eslint@10.3.0(jiti@2.7.0))(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue-i18n@11.4.2(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.7.0))
       '@intlify/bundle-utils': 11.1.2(vue-i18n@11.4.2(vue@3.5.34(typescript@6.0.3)))
@@ -13292,7 +13295,7 @@ snapshots:
       unplugin: 2.3.11
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
-      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
       vue-i18n: 11.4.2(vue@3.5.34(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/compiler-dom'
@@ -13724,7 +13727,7 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/content@3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.27.7)(magicast@0.5.2)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nuxt/content@3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.27.7)(magicast@0.5.2)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.2)
       '@nuxtjs/mdc': 0.22.1(magicast@0.5.2)
@@ -13771,7 +13774,7 @@ snapshots:
       unified: 11.0.5
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.1.0
-      unplugin: 3.3.0(esbuild@0.27.7)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.27.7)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
@@ -13793,8 +13796,9 @@ snapshots:
       - utf-8-validate
       - vite
       - webpack
+    optional: true
 
-  '@nuxt/content@3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nuxt/content@3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@nuxtjs/mdc': 0.22.1(magicast@0.5.3)
@@ -13841,7 +13845,7 @@ snapshots:
       unified: 11.0.5
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.1.0
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
@@ -13863,7 +13867,6 @@ snapshots:
       - utf-8-validate
       - vite
       - webpack
-    optional: true
 
   '@nuxt/devalue@2.0.2': {}
 
@@ -13891,11 +13894,11 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       tinyexec: 1.2.4
-      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
 
@@ -14168,14 +14171,14 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.2.2(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
+  '@nuxt/icon@2.2.2(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@iconify/collections': 1.0.680
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.2
       '@iconify/vue': 5.0.1(vue@3.5.34(typescript@6.0.3))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/kit': 4.4.8(magicast@0.5.2)
       consola: 3.4.2
       local-pkg: 1.1.2
       mlly: 1.8.2
@@ -14189,14 +14192,14 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/icon@2.3.1(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
+  '@nuxt/icon@2.3.1(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@iconify/collections': 1.0.705
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.3
       '@iconify/vue': 5.0.1(vue@3.5.34(typescript@6.0.3))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       consola: 3.4.2
       local-pkg: 1.2.1
       mlly: 1.8.2
@@ -14210,9 +14213,9 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/image@2.0.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.2)(srvx@0.11.15)':
+  '@nuxt/image@2.0.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.3)(srvx@0.11.21)':
     dependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
@@ -14223,7 +14226,7 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.4
     optionalDependencies:
-      ipx: 3.1.1(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(srvx@0.11.15)
+      ipx: 3.1.1(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(srvx@0.11.21)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14247,9 +14250,9 @@ snapshots:
       - srvx
       - uploadthing
 
-  '@nuxt/kit@3.21.4(magicast@0.5.3)':
+  '@nuxt/kit@3.21.4(magicast@0.5.2)':
     dependencies:
-      c12: 3.3.4(magicast@0.5.3)
+      c12: 3.3.4(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       destr: 2.0.5
@@ -14317,6 +14320,56 @@ snapshots:
       scule: 1.3.0
       semver: 7.7.4
       tinyglobby: 0.2.16
+      ufo: 1.6.4
+      unctx: 2.5.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@4.4.7':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.3)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.1.0
+      ignore: 7.0.5
+      jiti: 2.7.0
+      klona: 2.0.6
+      mlly: 1.8.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 2.5.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@4.4.7(magicast@0.5.2)':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.2)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.1.0
+      ignore: 7.0.5
+      jiti: 2.7.0
+      klona: 2.0.6
+      mlly: 1.8.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      semver: 7.8.5
+      tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
       untyped: 2.0.0
@@ -14398,7 +14451,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.15)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(e9f11ae722cb63b39c11139322034c2f))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(srvx@0.11.15)(typescript@6.0.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -14416,8 +14469,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.15)
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(srvx@0.11.15)
+      nuxt: 4.4.4(e9f11ae722cb63b39c11139322034c2f)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -14468,7 +14521,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.21)(typescript@6.0.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -14486,8 +14539,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
-      nuxt: 4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2)
+      nitropack: 2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.21)
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -14576,18 +14629,18 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/ui@4.7.1(80675f272f43126b1aa0dcc2f1ad1187)':
+  '@nuxt/ui@4.7.1(60131c35c878a6e064bd4d763f8499ba)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.34(typescript@6.0.3))
-      '@nuxt/fonts': 0.14.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@nuxt/icon': 2.2.2(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/fonts': 0.14.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/icon': 2.2.2(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@nuxt/schema': 4.4.4
-      '@nuxtjs/color-mode': 3.5.2(magicast@0.5.3)
+      '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.2.4
-      '@tailwindcss/vite': 4.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tailwindcss/vite': 4.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/vue-table': 8.21.3(vue@3.5.34(typescript@6.0.3))
       '@tanstack/vue-virtual': 3.13.24(vue@3.5.34(typescript@6.0.3))
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
@@ -14638,14 +14691,14 @@ snapshots:
       typescript: 6.0.3
       ufo: 1.6.4
       unplugin: 3.0.0
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.4(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))
-      unplugin-vue-components: 32.0.0(@nuxt/kit@4.4.4(magicast@0.5.3))(vue@3.5.34(typescript@6.0.3))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.4(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))
+      unplugin-vue-components: 32.0.0(@nuxt/kit@4.4.4(magicast@0.5.2))(vue@3.5.34(typescript@6.0.3))
       vaul-vue: 0.4.1(reka-ui@2.9.6(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       vue-component-type-helpers: 3.2.8
     optionalDependencies:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
-      '@nuxt/content': 3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.27.7)(magicast@0.5.2)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(vue@3.5.34(typescript@6.0.3))
       zod: 4.4.3
     transitivePeerDependencies:
@@ -14690,18 +14743,18 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/ui@4.9.0(40b5340bc06d79a407615d2ad1152b84)':
+  '@nuxt/ui@4.9.0(09839b99c5dbbaabbd785b81274ba67b)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.34(typescript@6.0.3))
-      '@nuxt/fonts': 0.14.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@nuxt/icon': 2.3.1(magicast@0.5.2)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/fonts': 0.14.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/icon': 2.3.1(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@nuxt/schema': 4.4.8
-      '@nuxtjs/color-mode': 4.0.1(magicast@0.5.2)
+      '@nuxtjs/color-mode': 4.0.1(magicast@0.5.3)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.3.2
-      '@tailwindcss/vite': 4.3.2(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tailwindcss/vite': 4.3.2(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/vue-table': 8.21.3(vue@3.5.34(typescript@6.0.3))
       '@tanstack/vue-virtual': 3.13.31(vue@3.5.34(typescript@6.0.3))
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
@@ -14751,15 +14804,15 @@ snapshots:
       tinyglobby: 0.2.17
       typescript: 6.0.3
       ufo: 1.6.4
-      unplugin: 3.3.0(esbuild@0.27.7)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.8(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))
-      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.2))(esbuild@0.27.7)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      unplugin-auto-import: 21.0.0(@nuxt/kit@4.4.8(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
       vaul-vue: 0.4.1(reka-ui@2.9.10(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       vue-component-type-helpers: 3.3.6
     optionalDependencies:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
-      '@nuxt/content': 3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.27.7)(magicast@0.5.2)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/content': 3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -14808,7 +14861,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(e9f11ae722cb63b39c11139322034c2f))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.3)
@@ -14826,68 +14879,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
-      nypm: 0.6.6
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      postcss: 8.5.14
-      seroval: 1.5.4
-      std-env: 4.1.0
-      ufo: 1.6.4
-      unenv: 2.0.0-rc.24
-      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-checker: 0.13.0(eslint@10.3.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@6.0.3))
-      vue: 3.5.34(typescript@6.0.3)
-      vue-bundle-renderer: 2.2.0
-    optionalDependencies:
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      rolldown: 1.1.4
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.60.3)
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - oxlint
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
-  '@nuxt/vite-builder@4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)':
-    dependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.3)
-      '@vitejs/plugin-vue': 6.0.6(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
-      autoprefixer: 10.5.0(postcss@8.5.14)
-      consola: 3.4.2
-      cssnano: 7.1.9(postcss@8.5.14)
-      defu: 6.1.7
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.0
-      get-port-please: 3.2.0
-      jiti: 2.7.0
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nuxt: 4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2)
+      nuxt: 4.4.4(e9f11ae722cb63b39c11139322034c2f)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -14930,12 +14922,73 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxthub/core@0.10.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.3)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))':
+  '@nuxt/vite-builder@4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)':
+    dependencies:
+      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.3)
+      '@vitejs/plugin-vue': 6.0.6(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      autoprefixer: 10.5.0(postcss@8.5.14)
+      consola: 3.4.2
+      cssnano: 7.1.9(postcss@8.5.14)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.0
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
+      nypm: 0.6.6
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.14
+      seroval: 1.5.4
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite-plugin-checker: 0.13.0(eslint@10.3.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.2.8(typescript@6.0.3))
+      vue: 3.5.34(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      rolldown: 1.1.4
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.1.4)(rollup@4.60.3)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxthub/core@0.10.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.2)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))':
     dependencies:
       '@cloudflare/workers-types': 4.20260507.1
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@uploadthing/mime-types': 0.3.6
-      c12: 3.3.4(magicast@0.5.3)
+      c12: 3.3.4(magicast@0.5.2)
       chokidar: 5.0.0
       citty: 0.2.2
       consola: 3.4.2
@@ -14992,18 +15045,18 @@ snapshots:
       - uploadthing
       - vue-tsc
 
-  '@nuxtjs/color-mode@3.5.2(magicast@0.5.3)':
+  '@nuxtjs/color-mode@3.5.2(magicast@0.5.2)':
     dependencies:
-      '@nuxt/kit': 3.21.4(magicast@0.5.3)
+      '@nuxt/kit': 3.21.4(magicast@0.5.2)
       pathe: 1.1.2
       pkg-types: 1.3.1
       semver: 7.7.4
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/color-mode@4.0.1(magicast@0.5.2)':
+  '@nuxtjs/color-mode@4.0.1(magicast@0.5.3)':
     dependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       exsolve: 1.1.0
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -15011,15 +15064,15 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/i18n@10.4.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
+  '@nuxtjs/i18n@10.4.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@intlify/core': 11.4.2
       '@intlify/h3': 0.7.4
       '@intlify/shared': 11.4.2
-      '@intlify/unplugin-vue-i18n': 11.1.2(@vue/compiler-dom@3.5.39)(eslint@10.3.0(jiti@2.7.0))(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue-i18n@11.4.2(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
+      '@intlify/unplugin-vue-i18n': 11.1.2(@vue/compiler-dom@3.5.39)(eslint@10.3.0(jiti@2.7.0))(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue-i18n@11.4.2(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       '@intlify/utils': 0.14.1
       '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.60.3)
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@rollup/plugin-yaml': 4.1.2(rollup@4.60.3)
       '@vue/compiler-sfc': 3.5.34
       defu: 6.1.7
@@ -15071,18 +15124,18 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/mcp-toolkit@0.17.2(@vue/compiler-sfc@3.5.39)(h3@2.0.1-rc.22(crossws@0.4.9(srvx@0.11.15)))(magicast@0.5.2)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)':
+  '@nuxtjs/mcp-toolkit@0.17.2(@vue/compiler-sfc@3.5.39)(h3@2.0.1-rc.22(crossws@0.4.9(srvx@0.11.21)))(magicast@0.5.3)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
-      '@vitejs/plugin-vue': 6.0.7(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
-      h3: 2.0.1-rc.22(crossws@0.4.9(srvx@0.11.15))
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@vitejs/plugin-vue': 6.0.7(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      h3: 2.0.1-rc.22(crossws@0.4.9(srvx@0.11.21))
       tinyglobby: 0.2.17
-      vite-plugin-singlefile: 2.3.3(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite-plugin-singlefile: 2.3.3(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       zod: 4.4.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.39
-      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.3)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -15090,9 +15143,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxtjs/mdc@0.21.1(magicast@0.5.3)':
+  '@nuxtjs/mdc@0.21.1(magicast@0.5.2)':
     dependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@shikijs/core': 4.0.2
       '@shikijs/engine-javascript': 4.0.2
       '@shikijs/langs': 4.0.2
@@ -15189,6 +15242,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
       - supports-color
+    optional: true
 
   '@nuxtjs/mdc@0.22.1(magicast@0.5.3)':
     dependencies:
@@ -15239,17 +15293,16 @@ snapshots:
     transitivePeerDependencies:
       - magicast
       - supports-color
-    optional: true
 
-  '@nuxtjs/robots@6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)':
+  '@nuxtjs/robots@6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -16623,19 +16676,19 @@ snapshots:
       postcss: 8.5.16
       tailwindcss: 4.3.2
 
-  '@tailwindcss/vite@4.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@tailwindcss/vite@4.3.2(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.2(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
-      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@takumi-rs/core-darwin-arm64@1.8.7':
     optional: true
@@ -17491,9 +17544,9 @@ snapshots:
 
   '@uploadthing/mime-types@0.3.6': {}
 
-  '@vercel/analytics@2.0.1(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vue@3.5.34(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vue@3.5.34(typescript@6.0.3))':
     optionalDependencies:
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
       vue: 3.5.34(typescript@6.0.3)
 
   '@vercel/blob@2.3.3':
@@ -17527,6 +17580,14 @@ snapshots:
       '@ai-sdk/mcp': 1.0.58(zod@4.4.3)
       ai: 7.0.15(zod@4.4.3)
       eve: 0.19.0(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.15(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(microsandbox@0.6.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@vercel/connect@0.3.2(@ai-sdk/mcp@1.0.58(zod@4.4.3))(ai@7.0.16(zod@4.4.3))(eve@0.19.0(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+    optionalDependencies:
+      '@ai-sdk/mcp': 1.0.58(zod@4.4.3)
+      ai: 7.0.16(zod@4.4.3)
+      eve: 0.19.0(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49)':
     dependencies:
@@ -17570,9 +17631,9 @@ snapshots:
       mixpart: 0.0.6
       picocolors: 1.1.1
 
-  '@vercel/speed-insights@2.0.0(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vue@3.5.34(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vue@3.5.34(typescript@6.0.3))':
     optionalDependencies:
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
       vue: 3.5.34(typescript@6.0.3)
 
   '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
@@ -17593,10 +17654,10 @@ snapshots:
       vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.3)
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.3)
 
   '@vitest/expect@3.2.6':
@@ -17848,13 +17909,13 @@ snapshots:
 
   '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/nuxt@14.3.0(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vue@3.5.34(typescript@6.0.3))':
+  '@vueuse/nuxt@14.3.0(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
       '@vueuse/metadata': 14.3.0
       local-pkg: 1.2.1
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
       vue: 3.5.34(typescript@6.0.3)
     transitivePeerDependencies:
       - magicast
@@ -17872,12 +17933,12 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@workflow/ai@4.1.2(@opentelemetry/api@1.9.0)(ai@7.0.15(zod@4.4.3))(workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3))':
+  '@workflow/ai@4.1.2(@opentelemetry/api@1.9.0)(ai@7.0.15(zod@4.4.3))(workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(typescript@6.0.3))':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@workflow/serde': 4.1.1
       ai: 7.0.15(zod@4.4.3)
-      workflow: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
+      workflow: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(typescript@6.0.3)
       zod: 4.3.6
     optionalDependencies:
       '@ai-sdk/anthropic': 3.0.75(zod@4.3.6)
@@ -17892,7 +17953,7 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@workflow/serde': 4.1.1
       ai: 7.0.16(zod@4.4.3)
-      workflow: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
+      workflow: 4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(typescript@6.0.3)
       zod: 4.3.6
     optionalDependencies:
       '@ai-sdk/anthropic': 3.0.75(zod@4.3.6)
@@ -18200,9 +18261,19 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/nuxt@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)':
+  '@workflow/nuxt@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)':
     dependencies:
-      '@nuxt/kit': 4.4.7(magicast@0.5.3)
+      '@nuxt/kit': 4.4.7
+      '@workflow/nitro': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - magicast
+      - supports-color
+
+  '@workflow/nuxt@4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.2)':
+    dependencies:
+      '@nuxt/kit': 4.4.7(magicast@0.5.2)
       '@workflow/nitro': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -19157,11 +19228,6 @@ snapshots:
     optionalDependencies:
       srvx: 0.11.21
 
-  crossws@0.4.9(srvx@0.11.15):
-    optionalDependencies:
-      srvx: 0.11.15
-    optional: true
-
   crossws@0.4.9(srvx@0.11.21):
     optionalDependencies:
       srvx: 0.11.21
@@ -19536,7 +19602,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  docus@5.12.3(cb1cee4c277625c458780fdde585ceb9):
+  docus@5.12.3(4abb6b041d4f9559d8e56a4b45b4fd92):
     dependencies:
       '@ai-sdk/gateway': 3.0.143(zod@4.4.3)
       '@ai-sdk/mcp': 1.0.58(zod@4.4.3)
@@ -19545,14 +19611,14 @@ snapshots:
       '@iconify-json/lucide': 1.2.116
       '@iconify-json/simple-icons': 1.2.88
       '@iconify-json/vscode-icons': 1.2.63
-      '@nuxt/content': 3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.27.7)(magicast@0.5.2)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@nuxt/image': 2.0.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.2)(srvx@0.11.15)
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
-      '@nuxt/ui': 4.9.0(40b5340bc06d79a407615d2ad1152b84)
-      '@nuxtjs/i18n': 10.4.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
-      '@nuxtjs/mcp-toolkit': 0.17.2(@vue/compiler-sfc@3.5.39)(h3@2.0.1-rc.22(crossws@0.4.9(srvx@0.11.15)))(magicast@0.5.2)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
-      '@nuxtjs/mdc': 0.22.1(magicast@0.5.2)
-      '@nuxtjs/robots': 6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      '@nuxt/content': 3.15.0(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(esbuild@0.28.1)(magicast@0.5.3)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/image': 2.0.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(magicast@0.5.3)(srvx@0.11.21)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@nuxt/ui': 4.9.0(09839b99c5dbbaabbd785b81274ba67b)
+      '@nuxtjs/i18n': 10.4.0(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(@vue/compiler-dom@3.5.39)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.3)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      '@nuxtjs/mcp-toolkit': 0.17.2(@vue/compiler-sfc@3.5.39)(h3@2.0.1-rc.22(crossws@0.4.9(srvx@0.11.21)))(magicast@0.5.3)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      '@nuxtjs/mdc': 0.22.1(magicast@0.5.3)
+      '@nuxtjs/robots': 6.1.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
       '@shikijs/core': 4.3.1
       '@shikijs/engine-javascript': 4.3.1
       '@shikijs/langs': 4.3.1
@@ -19566,9 +19632,9 @@ snapshots:
       exsolve: 1.1.0
       git-url-parse: 16.1.0
       motion-v: 2.3.0(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
-      nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 6.6.0(4c0e8d79c51cdaca3bf25397204d1d30)
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
+      nuxt-llms: 0.2.0(magicast@0.5.3)
+      nuxt-og-image: 6.6.0(4d373269b718703bb2c7c1780cb95f41)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -20945,13 +21011,6 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  h3@2.0.1-rc.22(crossws@0.4.9(srvx@0.11.15)):
-    dependencies:
-      rou3: 0.8.1
-      srvx: 0.11.15
-    optionalDependencies:
-      crossws: 0.4.9(srvx@0.11.15)
-
   h3@2.0.1-rc.22(crossws@0.4.9(srvx@0.11.21)):
     dependencies:
       rou3: 0.8.1
@@ -21253,7 +21312,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipx@3.1.1(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(srvx@0.11.15):
+  ipx@3.1.1(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(srvx@0.11.21):
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       citty: 0.1.6
@@ -21263,7 +21322,7 @@ snapshots:
       etag: 1.8.1
       h3: 1.15.11
       image-meta: 0.2.2
-      listhen: 1.10.0(srvx@0.11.15)
+      listhen: 1.10.0(srvx@0.11.21)
       ofetch: 1.5.1
       pathe: 2.0.3
       sharp: 0.34.5
@@ -22443,7 +22502,7 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitropack@2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
+  nitropack@2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(srvx@0.11.15):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.3)
@@ -22481,7 +22540,7 @@ snapshots:
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
-      listhen: 1.10.0(srvx@0.11.21)
+      listhen: 1.10.0(srvx@0.11.15)
       magic-string: 0.30.21
       magicast: 0.5.2
       mime: 4.1.0
@@ -22548,7 +22607,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.15):
+  nitropack@2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.21):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.3)
@@ -22586,7 +22645,7 @@ snapshots:
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
-      listhen: 1.10.0(srvx@0.11.15)
+      listhen: 1.10.0(srvx@0.11.21)
       magic-string: 0.30.21
       magicast: 0.5.2
       mime: 4.1.0
@@ -22816,10 +22875,10 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-auth-utils@0.5.29(magicast@0.5.3):
+  nuxt-auth-utils@0.5.29(magicast@0.5.2):
     dependencies:
       '@adonisjs/hash': 9.1.1
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
       defu: 6.1.7
       h3: 1.15.11
       hookable: 6.1.1
@@ -22853,6 +22912,7 @@ snapshots:
       vue-component-meta: 3.2.8(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
+    optional: true
 
   nuxt-component-meta@0.17.2(magicast@0.5.3):
     dependencies:
@@ -22866,17 +22926,16 @@ snapshots:
       vue-component-meta: 3.2.8(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
-    optional: true
 
   nuxt-define@1.0.0: {}
 
-  nuxt-llms@0.2.0(magicast@0.5.2):
+  nuxt-llms@0.2.0(magicast@0.5.3):
     dependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@6.6.0(4c0e8d79c51cdaca3bf25397204d1d30):
+  nuxt-og-image@6.6.0(4d373269b718703bb2c7c1780cb95f41):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -22894,8 +22953,8 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.3
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
       nypm: 0.6.6
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -22915,8 +22974,8 @@ snapshots:
     optionalDependencies:
       '@resvg/resvg-js': 2.6.2
       '@takumi-rs/core': 1.8.7
-      fontless: 0.2.1(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      nitropack: 2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.15)
+      fontless: 0.2.1(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(ioredis@5.10.1)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      nitropack: 2.13.4(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(oxc-parser@0.135.0)(rolldown@1.1.4)(srvx@0.11.21)
       satori: 0.26.0
       sharp: 0.34.5
       tailwindcss: 4.3.2
@@ -22940,9 +22999,9 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config-kit@4.1.1(magicast@0.5.2)(vue@3.5.34(typescript@6.0.3)):
+  nuxt-site-config-kit@4.1.1(magicast@0.5.3)(vue@3.5.34(typescript@6.0.3)):
     dependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       site-config-stack: 4.1.1(vue@3.5.34(typescript@6.0.3))
       std-env: 4.1.0
       ufo: 1.6.4
@@ -22950,12 +23009,12 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
+  nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magicast@0.5.3)(vue@3.5.34(typescript@6.0.3))
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.0.8(vue@3.5.34(typescript@6.0.3))
@@ -22968,13 +23027,13 @@ snapshots:
       - vue
       - zod
 
-  nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
+  nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       h3: 1.15.11
-      nuxt-site-config-kit: 4.1.1(magicast@0.5.2)(vue@3.5.34(typescript@6.0.3))
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config-kit: 4.1.1(magicast@0.5.3)(vue@3.5.34(typescript@6.0.3))
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.1(vue@3.5.34(typescript@6.0.3))
@@ -22987,146 +23046,16 @@ snapshots:
       - vue
       - zod
 
-  nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1):
-    dependencies:
-      '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
-      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
-      '@nuxt/kit': 4.4.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.15)(typescript@6.0.3)
-      '@nuxt/schema': 4.4.4
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)
-      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.3))
-      '@vue/shared': 3.5.34
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      defu: 6.1.7
-      devalue: 5.8.0
-      errx: 0.1.0
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      hookable: 6.1.1
-      ignore: 7.0.5
-      impound: 1.1.5
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nypm: 0.6.6
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-minify: 0.128.0
-      oxc-parser: 0.128.0
-      oxc-transform: 0.128.0
-      oxc-walker: 0.7.0(oxc-parser@0.128.0)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.4
-      pkg-types: 2.3.1
-      rou3: 0.8.1
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 4.1.0
-      tinyglobby: 0.2.16
-      ufo: 1.6.4
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 6.2.0(oxc-parser@0.128.0)
-      unplugin: 3.0.0
-      unrouting: 0.1.7
-      untyped: 2.0.0
-      vue: 3.5.34(typescript@6.0.3)
-      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(vue@3.5.34(typescript@6.0.3))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 25.6.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/core'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - srvx
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
-  nuxt@4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2):
+  nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
       '@nuxt/kit': 4.4.4(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(oxc-parser@0.128.0)(rolldown@1.1.4)(srvx@0.11.21)(typescript@6.0.3)
       '@nuxt/schema': 4.4.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(6e2a6eb721b16b00fc7f91bad870a5f2))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(optionator@0.9.4)(rolldown@1.1.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.1.4)(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.3))
       '@vue/shared': 3.5.34
       chokidar: 5.0.0
@@ -23247,17 +23176,147 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-layer-devtools@5.3.2(b1e93e7060f7b3a830cf7a3ea530fd05):
+  nuxt@4.4.4(e9f11ae722cb63b39c11139322034c2f):
+    dependencies:
+      '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@6.0.3)
+      '@nuxt/cli': 3.35.1(@nuxt/schema@4.4.4)(cac@6.7.14)(magicast@0.5.2)
+      '@nuxt/devtools': 3.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.4.4(@babel/core@7.29.0)(@libsql/client@0.17.3)(@vercel/blob@2.3.3)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0)))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260507.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(pg@8.20.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.4(e9f11ae722cb63b39c11139322034c2f))(oxc-parser@0.128.0)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(srvx@0.11.15)(typescript@6.0.3)
+      '@nuxt/schema': 4.4.4
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.4(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.4.4(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.6.0)(eslint@10.3.0(jiti@2.7.0))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.4.4(e9f11ae722cb63b39c11139322034c2f))(optionator@0.9.4)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.0)(tsx@4.21.0)(typescript@6.0.3)(vue-tsc@3.2.8(typescript@6.0.3))(vue@3.5.34(typescript@6.0.3))(yaml@2.9.0)
+      '@unhead/vue': 2.1.13(vue@3.5.34(typescript@6.0.3))
+      '@vue/shared': 3.5.34
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.1
+      defu: 6.1.7
+      devalue: 5.8.0
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.1
+      ignore: 7.0.5
+      impound: 1.1.5
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.6
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.128.0
+      oxc-parser: 0.128.0
+      oxc-transform: 0.128.0
+      oxc-walker: 0.7.0(oxc-parser@0.128.0)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.1
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 4.1.0
+      tinyglobby: 0.2.16
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.2.0(oxc-parser@0.128.0)
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.34(typescript@6.0.3)
+      vue-router: 5.0.6(@vue/compiler-sfc@3.5.39)(vue@3.5.34(typescript@6.0.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - srvx
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
+
+  nuxtseo-layer-devtools@5.3.2(58b9110a518076275d4e7f2f4419fc57):
     dependencies:
       '@iconify-json/carbon': 1.2.24
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
-      '@nuxt/ui': 4.9.0(40b5340bc06d79a407615d2ad1152b84)
+      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@nuxt/ui': 4.9.0(09839b99c5dbbaabbd785b81274ba67b)
       '@shikijs/langs': 4.3.1
       '@shikijs/themes': 4.3.1
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
-      '@vueuse/nuxt': 14.3.0(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vue@3.5.34(typescript@6.0.3))
-      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      '@vueuse/nuxt': 14.3.0(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vue@3.5.34(typescript@6.0.3))
+      nuxtseo-shared: 5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
       ofetch: 1.5.1
       shiki: 4.3.1
       tailwindcss: 4.3.2
@@ -23340,42 +23399,16 @@ snapshots:
       - yup
       - zod
 
-  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
-      '@nuxt/schema': 4.4.8
-      birpc: 4.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
-      nypm: 0.6.8
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      radix3: 1.1.2
-      sirv: 3.0.2
-      std-env: 4.1.0
-      ufo: 1.6.4
-      vue: 3.5.34(typescript@6.0.3)
-    optionalDependencies:
-      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - magicast
-      - vite
-
-  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
-    dependencies:
-      '@clack/prompts': 1.7.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@nuxt/schema': 4.4.8
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.4.4(0f9bd609c9985086a36357e8af93f1f1)
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
       nypm: 0.6.8
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -23386,7 +23419,33 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.2)(nuxt@4.4.4(0f9bd609c9985086a36357e8af93f1f1))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      nuxt-site-config: 4.0.8(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - magicast
+      - vite
+
+  nuxtseo-shared@5.3.2(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt-site-config@4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3))(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3):
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.3(magicast@0.5.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@nuxt/schema': 4.4.8
+      birpc: 4.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: 4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288)
+      nypm: 0.6.8
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.1.0
+      ufo: 1.6.4
+      vue: 3.5.34(typescript@6.0.3)
+    optionalDependencies:
+      nuxt-site-config: 4.1.1(@nuxt/schema@4.4.8)(magicast@0.5.3)(nuxt@4.4.4(a82f4eab5fe1da4a1bbcaa4ac22f0288))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - magicast
@@ -25629,7 +25688,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.4(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3))):
+  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.4(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3))):
     dependencies:
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -25638,10 +25697,10 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
     optionalDependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
 
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.8(magicast@0.5.2))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3))):
+  unplugin-auto-import@21.0.0(@nuxt/kit@4.4.8(magicast@0.5.3))(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3))):
     dependencies:
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -25650,7 +25709,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
     optionalDependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
 
   unplugin-utils@0.3.1:
@@ -25658,7 +25717,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
 
-  unplugin-vue-components@32.0.0(@nuxt/kit@4.4.4(magicast@0.5.3))(vue@3.5.34(typescript@6.0.3)):
+  unplugin-vue-components@32.0.0(@nuxt/kit@4.4.4(magicast@0.5.2))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.1.2
@@ -25671,9 +25730,9 @@ snapshots:
       unplugin-utils: 0.3.1
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
-      '@nuxt/kit': 4.4.4(magicast@0.5.3)
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
 
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.2))(esbuild@0.27.7)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3)):
+  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.2.1
@@ -25682,11 +25741,11 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.27.7)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
       unplugin-utils: 0.3.1
       vue: 3.5.34(typescript@6.0.3)
     optionalDependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -25711,28 +25770,28 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.27.7
-      rolldown: 1.1.4
+      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       rollup: 4.60.3
       vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+    optional: true
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
       esbuild: 0.28.1
-      rolldown: 1.0.0-beta.57(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      rolldown: 1.1.4
       rollup: 4.60.3
       vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
-    optional: true
 
   unrouting@0.1.7:
     dependencies:
@@ -25992,10 +26051,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-singlefile@2.3.3(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vite-plugin-singlefile@2.3.3(rollup@4.60.3)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       micromatch: 4.0.8
-      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
       rollup: 4.60.3
 
@@ -26301,7 +26360,7 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3):
+  workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.2)(typescript@6.0.3):
     dependencies:
       '@workflow/astro': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/cli': 4.2.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
@@ -26310,7 +26369,35 @@ snapshots:
       '@workflow/nest': 0.0.10(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
       '@workflow/next': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/nitro': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
-      '@workflow/nuxt': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.3)
+      '@workflow/nuxt': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)(magicast@0.5.2)
+      '@workflow/rollup': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/sveltekit': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/typescript-plugin': 4.0.3(typescript@6.0.3)
+      '@workflow/utils': 4.1.3
+      ms: 2.1.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - '@nestjs/common'
+      - '@nestjs/core'
+      - '@swc/cli'
+      - '@swc/core'
+      - '@swc/helpers'
+      - magicast
+      - next
+      - supports-color
+      - typescript
+
+  workflow@4.5.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(typescript@6.0.3):
+    dependencies:
+      '@workflow/astro': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/cli': 4.2.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/core': 4.5.0(@opentelemetry/api@1.9.0)
+      '@workflow/errors': 4.1.4
+      '@workflow/nest': 0.0.10(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)
+      '@workflow/next': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/nitro': 4.1.1(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
+      '@workflow/nuxt': 4.0.11(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/rollup': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/sveltekit': 4.0.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.21)
       '@workflow/typescript-plugin': 4.0.3(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- Add `@github-tools/sdk/connect` and `@github-tools/sdk/connect/eve` subpaths with `connectGithubTools`, `connectGithubToken`, and `connectGithubScopesForPreset`
- Derive Vercel Connect scopes automatically from presets (Option A) — no manual scope lists for consumers
- Simplify the eve-agent example to a 3-line `connectGithubTools` setup
- Document the Connect flow in a new guide, API reference, and README; add a minor changeset

## Test plan

- [x] `pnpm --filter @github-tools/sdk test`
- [x] `pnpm --filter @github-tools/sdk typecheck`
- [x] `pnpm --filter @github-tools/sdk build`
- [x] `pnpm lint` (SDK)
- [ ] Manual: run `examples/eve-agent` with `github/test-github-tools` connector linked