### PR TITLE
feat(eve): add @github-tools/eve-extension mountable eve extension

### DIFF
--- a/.changeset/nine-crickets-sail.md
+++ b/.changeset/nine-crickets-sail.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": patch
+---
+
+Document `@github-tools/eve-extension` — a mountable eve extension distribution for the GitHub tools, built on top of the existing `@github-tools/sdk/eve` subpath. See `packages/github-tools-eve-extension` and the `examples/eve-extension-agent` starter.

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -24,6 +24,7 @@ jobs:
           scopes: |
             sdk
             chat
+            eve
             deps
           types: |
             breaking

--- a/apps/docs/content/docs/2.frameworks/1.eve.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve.md
@@ -29,6 +29,10 @@ links:
 
 [eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files** — all 42 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves.
 
+::callout{icon="i-custom:eve"}
+There are two ways to add the tools to an eve agent: importing `@github-tools/sdk/eve` directly (below), or mounting them as an [eve extension](#eve-extension) via `@github-tools/eve-extension`. Both are supported today — the extension is the direction this integration is moving toward and will become the recommended way to add GitHub tools to an eve agent.
+::
+
 ::prompt
 ---
 description: Add GitHub tools to an eve agent
@@ -218,7 +222,7 @@ See [Vercel Connect](/guide/vercel-connect#eve-agent) for the connector setup ch
 
 ## eve extension
 
-`@github-tools/eve-extension` packages the same tools as a mountable [eve extension](https://eve.dev/docs/extensions) instead of importing `@github-tools/sdk/eve` directly into `agent/tools/`:
+`@github-tools/eve-extension` packages the same tools as a mountable [eve extension](https://eve.dev/docs/extensions) instead of importing `@github-tools/sdk/eve` directly into `agent/tools/`. **This is the recommended direction going forward** — the direct `@github-tools/sdk/eve` import above keeps working and isn't going away, but new agents should prefer the extension:
 
 ```ts [agent/extensions/github.ts]
 import githubExtension from '@github-tools/eve-extension'
@@ -233,6 +237,8 @@ export default githubExtension({
 ```
 
 Tools are exposed to the model as `<namespace>__<toolName>`, where `<namespace>` comes from the mount file's name — `agent/extensions/github.ts` yields `github__listPullRequests`, `github__createIssue`, and so on. Not yet published to npm; see [`examples/eve-extension-agent`](https://github.com/vercel-labs/github-tools/tree/main/examples/eve-extension-agent) and [`packages/github-tools-eve-extension`](https://github.com/vercel-labs/github-tools/tree/main/packages/github-tools-eve-extension) to build and consume it from the workspace.
+
+Once published, this extension will become the primary, recommended way to add GitHub tools to an eve agent; `@github-tools/sdk/eve` remains supported for direct imports.
 
 ## External references
 

--- a/apps/docs/content/docs/2.frameworks/1.eve.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve.md
@@ -216,6 +216,24 @@ export default connectGithubTools('github/my-connector', {
 
 See [Vercel Connect](/guide/vercel-connect#eve-agent) for the connector setup checklist and multi-tenant scoping.
 
+## eve extension
+
+`@github-tools/eve-extension` packages the same tools as a mountable [eve extension](https://eve.dev/docs/extensions) instead of importing `@github-tools/sdk/eve` directly into `agent/tools/`:
+
+```ts [agent/extensions/github.ts]
+import githubExtension from '@github-tools/eve-extension'
+
+export default githubExtension({
+  connector: 'github/my-connector', // or token: process.env.GITHUB_TOKEN
+  preset: 'maintainer',
+  requireApproval: {
+    mergePullRequest: true,
+  },
+})
+```
+
+Tools are exposed to the model as `<namespace>__<toolName>`, where `<namespace>` comes from the mount file's name — `agent/extensions/github.ts` yields `github__listPullRequests`, `github__createIssue`, and so on. Not yet published to npm; see [`examples/eve-extension-agent`](https://github.com/vercel-labs/github-tools/tree/main/examples/eve-extension-agent) and [`packages/github-tools-eve-extension`](https://github.com/vercel-labs/github-tools/tree/main/packages/github-tools-eve-extension) to build and consume it from the workspace.
+
 ## External references
 
 - [How to build a GitHub agent with eve and GitHub Tools](https://vercel.com/kb/guide/github-agent-eve)

--- a/examples/eve-extension-agent/.gitignore
+++ b/examples/eve-extension-agent/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 .eve
 .output
+.vercel
+.env*

--- a/examples/eve-extension-agent/.gitignore
+++ b/examples/eve-extension-agent/.gitignore
@@ -1,0 +1,4 @@
+.env
+node_modules
+.eve
+.output

--- a/examples/eve-extension-agent/README.md
+++ b/examples/eve-extension-agent/README.md
@@ -1,0 +1,68 @@
+# GitHub eve Extension Agent
+
+Minimal [eve](https://eve.dev) agent mounting `@github-tools/eve-extension` with the
+`code-review` preset and a [Vercel Connect](https://vercel.com/docs/connect) connector.
+
+## Setup
+
+### 1. Link the Connect connector
+
+The connector `github/test-github-tools` must be linked to your Vercel project and installed on
+the GitHub org/repos you want the agent to access.
+
+### 2. Pull the OIDC token for local dev
+
+```bash
+pnpm install
+cd examples/eve-extension-agent
+vercel link    # select the github-tools-docs project (or your linked project)
+vercel env pull
+```
+
+This writes `VERCEL_OIDC_TOKEN` into `.env`. Re-run `vercel env pull` when the token expires.
+
+Requires Node 24+ and `ai` v7 (peer of `eve` v0.19+).
+
+## Run
+
+From the example directory:
+
+```bash
+pnpm dev
+# or: npx eve dev
+```
+
+From the monorepo root:
+
+```bash
+pnpm dev:eve-extension-agent
+```
+
+## Project structure
+
+```
+agent/
+  agent.ts               # eve agent config
+  instructions.md        # system prompt
+  extensions/
+    github.ts            # GitHub tools via @github-tools/eve-extension
+```
+
+## Customize
+
+Swap the preset or configure approval:
+
+```ts
+import githubExtension from '@github-tools/eve-extension'
+
+export default githubExtension({
+  connector: 'github/test-github-tools',
+  preset: ['code-review', 'issue-triage'],
+  requireApproval: {
+    mergePullRequest: true,
+    addPullRequestComment: 'once',
+  },
+})
+```
+
+See the [@github-tools/eve-extension README](../../packages/github-tools-eve-extension/README.md).

--- a/examples/eve-extension-agent/agent/agent.ts
+++ b/examples/eve-extension-agent/agent/agent.ts
@@ -1,0 +1,5 @@
+import { defineAgent } from 'eve'
+
+export default defineAgent({
+  model: 'anthropic/claude-sonnet-5',
+})

--- a/examples/eve-extension-agent/agent/extensions/github.ts
+++ b/examples/eve-extension-agent/agent/extensions/github.ts
@@ -1,0 +1,9 @@
+import githubExtension from '@github-tools/eve-extension'
+
+export default githubExtension({
+  connector: 'github/test-github-tools',
+  preset: 'code-review',
+  requireApproval: {
+    addPullRequestComment: ({ toolInput }: { toolInput?: { owner?: string } }) => toolInput?.owner !== 'vercel-labs',
+  },
+})

--- a/examples/eve-extension-agent/agent/instructions.md
+++ b/examples/eve-extension-agent/agent/instructions.md
@@ -1,0 +1,3 @@
+You are a GitHub code-review assistant.
+
+Use the GitHub tools (mounted as `github__*`) to inspect pull requests, read changed files, and post review comments. Be concise and actionable. Ask before merging or closing anything destructive.

--- a/examples/eve-extension-agent/package.json
+++ b/examples/eve-extension-agent/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@github-tools/eve-extension-agent",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "dev": "eve dev"
+  },
+  "dependencies": {
+    "@github-tools/eve-extension": "workspace:*",
+    "ai": "^7.0.0",
+    "eve": "^0.26.2",
+    "zod": "^4.3.6"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "turbo run --filter=@github-tools/chat dev",
     "dev:pr-review-agent": "pnpm --filter @github-tools/pr-review-agent dev",
     "dev:eve-agent": "pnpm --filter @github-tools/eve-agent dev",
+    "dev:eve-extension-agent": "pnpm --filter @github-tools/eve-extension-agent dev",
     "docs:dev": "pnpm --filter @github-tools/docs dev",
     "docs:build": "pnpm --filter @github-tools/docs build",
     "docs:generate": "pnpm --filter @github-tools/docs generate",

--- a/packages/github-tools-eve-extension/README.md
+++ b/packages/github-tools-eve-extension/README.md
@@ -3,6 +3,10 @@
 GitHub tools for [eve](https://eve.dev), packaged as a mountable
 [eve extension](https://eve.dev/docs/extensions).
 
+This is the direction the eve integration is moving toward and will become the recommended way
+to add GitHub tools to an eve agent. The direct `@github-tools/sdk/eve` import remains supported
+in the meantime.
+
 See the runnable consumer at [`examples/eve-extension-agent`](../../examples/eve-extension-agent).
 
 ## Structure

--- a/packages/github-tools-eve-extension/README.md
+++ b/packages/github-tools-eve-extension/README.md
@@ -1,0 +1,52 @@
+# @github-tools/eve-extension
+
+GitHub tools for [eve](https://eve.dev), packaged as a mountable
+[eve extension](https://eve.dev/docs/extensions).
+
+See the runnable consumer at [`examples/eve-extension-agent`](../../examples/eve-extension-agent).
+
+## Structure
+
+```
+extension/
+  extension.ts        # defineExtension() config schema (token, connector, preset, requireApproval, ...)
+  tools/
+    github.ts          # defineDynamic() returning buildEveToolMap(...) filtered by preset
+```
+
+## Build
+
+```sh
+pnpm --filter @github-tools/eve-extension build   # runs `eve extension build`
+```
+
+## Mount it
+
+```ts
+// agent/extensions/github.ts
+import githubExtension from '@github-tools/eve-extension'
+
+export default githubExtension({
+  connector: 'github/my-connector',   // or token: process.env.GITHUB_TOKEN
+  preset: 'maintainer',
+  requireApproval: {
+    mergePullRequest: true,
+    addPullRequestComment: ({ toolInput }) => toolInput?.owner !== 'vercel-labs',
+  },
+})
+```
+
+Tools are exposed to the model as `<namespace>__<toolName>`, where `<namespace>` comes from the
+mount file's name (`extensions/github.ts` → `github__listPullRequests`, `github__createIssue`, ...).
+
+## Config schema (`extension/extension.ts`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `token` | `string?` | Falls back to `GITHUB_TOKEN` when omitted and `connector` is not set |
+| `connector` | `string?` | Vercel Connect connector name; takes priority over `token` |
+| `connect` | `record?` | Passed through to `getToken` when `connector` is set |
+| `preset` | preset name or array | `code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `maintainer` |
+| `requireApproval` | `boolean \| record` | Global or per-tool; per-tool values may be predicate functions |
+| `overrides` | `record` | Per-tool `description` / `approval` / `toModelOutput` / `outputSchema` |
+| `author` / `committer` / `coAuthors` | commit identity | Attribution for commit-creating tools |

--- a/packages/github-tools-eve-extension/extension/extension.ts
+++ b/packages/github-tools-eve-extension/extension/extension.ts
@@ -1,0 +1,29 @@
+import { defineExtension } from 'eve/extension'
+import { z } from 'zod'
+
+const presetNameSchema = z.enum(['code-review', 'issue-triage', 'ci-ops', 'repo-explorer', 'maintainer'])
+
+const commitIdentitySchema = z.object({
+  name: z.string(),
+  email: z.string(),
+})
+
+export default defineExtension({
+  config: z.object({
+    /** GitHub PAT. Falls back to `GITHUB_TOKEN` when omitted and `connector` is not set. */
+    token: z.string().optional(),
+    /** Vercel Connect connector name (e.g. `github/my-connector`). Takes priority over `token`. */
+    connector: z.string().optional(),
+    /** Vercel Connect token params passed through to `getToken` when `connector` is set. */
+    connect: z.record(z.string(), z.unknown()).optional(),
+    /** Restrict tools to a preset (or array of presets). Omit for all 42 tools. */
+    preset: z.union([presetNameSchema, z.array(presetNameSchema)]).optional(),
+    /** Global boolean or per-tool approval config — may hold predicate functions. */
+    requireApproval: z.union([z.boolean(), z.record(z.string(), z.unknown())]).optional(),
+    /** Per-tool overrides (description, approval, toModelOutput, outputSchema). */
+    overrides: z.record(z.string(), z.unknown()).optional(),
+    author: commitIdentitySchema.optional(),
+    committer: commitIdentitySchema.optional(),
+    coAuthors: z.array(commitIdentitySchema).optional(),
+  }),
+})

--- a/packages/github-tools-eve-extension/extension/tools/github.ts
+++ b/packages/github-tools-eve-extension/extension/tools/github.ts
@@ -1,0 +1,26 @@
+import { connectGithubToken } from '@github-tools/sdk/connect'
+import { buildEveToolMap, type EveApprovalConfig, type EveToolOverrides } from '@github-tools/sdk/eve'
+import { defineDynamic } from 'eve/tools'
+import extension from '../extension'
+
+export default defineDynamic({
+  events: {
+    'session.started': async () => {
+      const { token, connector, connect, preset, requireApproval, overrides, author, committer, coAuthors } = extension.config
+
+      const resolvedToken = connector
+        ? connectGithubToken(connector, { preset, params: connect })
+        : token
+
+      return buildEveToolMap({
+        token: resolvedToken,
+        preset,
+        requireApproval: requireApproval as EveApprovalConfig | undefined,
+        overrides: overrides as EveToolOverrides | undefined,
+        author,
+        committer,
+        coAuthors,
+      })
+    },
+  },
+})

--- a/packages/github-tools-eve-extension/package.json
+++ b/packages/github-tools-eve-extension/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@github-tools/eve-extension",
+  "version": "0.0.0",
+  "private": true,
+  "description": "GitHub tools for eve, distributed as a mountable eve extension (https://eve.dev/docs/extensions)",
+  "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
+  "eve": {
+    "extension": {
+      "source": "./extension",
+      "dist": "./dist/extension"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "eve extension build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@github-tools/sdk": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "peerDependencies": {
+    "@vercel/connect": ">=0.3.2",
+    "eve": "*"
+  },
+  "peerDependenciesMeta": {
+    "@vercel/connect": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vercel/connect": "^0.4.2",
+    "eve": "^0.26.2",
+    "typescript": "^6.0.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "./tools": {
+      "types": "./dist/tools/index.d.ts",
+      "default": "./dist/tools/index.mjs"
+    }
+  }
+}

--- a/packages/github-tools-eve-extension/tsconfig.json
+++ b/packages/github-tools-eve-extension/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "lib": ["ESNext"],
+    "types": ["node"]
+  },
+  "include": ["extension"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -284,6 +284,8 @@ connectGithubTools('github/my-connector', {
 
 [eve](https://eve.dev) is Vercel's filesystem-first agent framework. The `@github-tools/sdk/eve` subpath registers all GitHub tools via `defineDynamic` — one file, zero CLI.
 
+> A mountable [eve extension](https://eve.dev/docs/extensions), `@github-tools/eve-extension`, is also available and is the direction this integration is moving toward — it will become the recommended way to add GitHub tools to an eve agent. The direct import below remains supported. See [`packages/github-tools-eve-extension`](../github-tools-eve-extension) and [`examples/eve-extension-agent`](../../examples/eve-extension-agent).
+
 ```sh
 pnpm add @github-tools/sdk eve ai zod
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,21 @@ importers:
         specifier: ^0.6.3
         version: 0.6.3
 
+  examples/eve-extension-agent:
+    dependencies:
+      '@github-tools/eve-extension':
+        specifier: workspace:*
+        version: link:../../packages/github-tools-eve-extension
+      ai:
+        specifier: ^7.0.0
+        version: 7.0.16(zod@4.4.3)
+      eve:
+        specifier: ^0.26.2
+        version: 0.26.2(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+
   examples/pr-review-agent:
     dependencies:
       '@chat-adapter/github':
@@ -220,7 +235,7 @@ importers:
         version: 4.34.0(ai@6.0.175(zod@4.4.3))(zod@4.4.3)
       evlog:
         specifier: latest
-        version: 2.22.0(39ebe393d732c11f2d0d4924daa09496)
+        version: 2.22.1(39ebe393d732c11f2d0d4924daa09496)
       workflow:
         specifier: latest
         version: 4.6.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.21))(@swc/helpers@0.5.21)(magicast@0.5.3)(typescript@6.0.3)
@@ -289,6 +304,28 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  packages/github-tools-eve-extension:
+    dependencies:
+      '@github-tools/sdk':
+        specifier: workspace:*
+        version: link:../github-tools
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vercel/connect':
+        specifier: ^0.4.2
+        version: 0.4.2(@ai-sdk/mcp@1.0.58(zod@4.4.3))(ai@7.0.16(zod@4.4.3))(eve@0.26.2(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)))
+      eve:
+        specifier: ^0.26.2
+        version: 0.26.2(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -7439,8 +7476,8 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  evlog@2.22.0:
-    resolution: {integrity: sha512-xWLQIf93SPldkAuIKQPbeUlqfPrsurBOJIqbKu3KB+a5TQVqUp3qE3edvbKKmdZDmcB2v+w9pIt/RWknV9pQTw==}
+  evlog@2.22.1:
+    resolution: {integrity: sha512-5IfmtCk4Mq/ZsCtykxftgWV8LkqjQu28ssEcwWpqbnqYxkolzo4iyh+my2tM8cZoTCDMnnIFp+X9tyspVE8NsA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@nestjs/common': '>=11.1.28'
@@ -17589,6 +17626,14 @@ snapshots:
       ai: 7.0.16(zod@4.4.3)
       eve: 0.26.2(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  '@vercel/connect@0.4.2(@ai-sdk/mcp@1.0.58(zod@4.4.3))(ai@7.0.16(zod@4.4.3))(eve@0.26.2(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+    optionalDependencies:
+      '@ai-sdk/mcp': 1.0.58(zod@4.4.3)
+      ai: 7.0.16(zod@4.4.3)
+      eve: 0.26.2(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+
   '@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49)':
     dependencies:
       '@vercel/oidc': 3.4.0
@@ -20446,6 +20491,52 @@ snapshots:
       - xml2js
       - zephyr-agent
 
+  eve@0.26.2(@opentelemetry/api@1.9.0)(@vercel/queue@0.3.1)(ai@7.0.16(zod@4.4.3))(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      ai: 7.0.16(zod@4.4.3)
+      nitro: 3.0.260610-beta(@vercel/queue@0.3.1)(dotenv@17.4.2)(giget@3.2.0)(jiti@2.7.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.0)(tsx@4.21.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/queue'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - dotenv
+      - drizzle-orm
+      - giget
+      - idb-keyval
+      - ioredis
+      - jiti
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - rollup
+      - sqlite3
+      - uploadthing
+      - vite
+      - wrangler
+      - xml2js
+      - zephyr-agent
+
   event-target-shim@5.0.1: {}
 
   events-universal@1.0.1:
@@ -20462,7 +20553,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.8
 
-  evlog@2.22.0(39ebe393d732c11f2d0d4924daa09496):
+  evlog@2.22.1(39ebe393d732c11f2d0d4924daa09496):
     optionalDependencies:
       '@nestjs/common': 11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxt/kit': 4.4.8(magicast@0.5.3)


### PR DESCRIPTION
## Summary

Adds `@github-tools/eve-extension`, a mountable [eve extension](https://eve.dev/docs/extensions) distribution for the GitHub tools, alongside the existing `@github-tools/sdk/eve` subpath (which remains the direct-import option).

- **`packages/github-tools-eve-extension`** — new package exposing a dynamic tool set (`defineDynamic` + `buildEveToolMap`) and an extension config schema (`defineExtension`) covering `token`, `connector` (Vercel Connect), `preset`, `requireApproval`, `overrides`, and authoring fields (`author`, `committer`, `coAuthors`). Mounted tools are auto-namespaced by eve (e.g. `github__listPullRequests`).
- **`examples/eve-extension-agent`** — starter agent that mounts the extension via Vercel Connect, mirroring `examples/eve-agent`'s code-review setup.
- **Docs** — new "eve extension" section in `apps/docs/content/docs/2.frameworks/1.eve.md` documenting the extension as an alternative to the direct `@github-tools/sdk/eve` import.
- Root `package.json` script `dev:eve-extension-agent` to run the example from the repo root.
- Changeset (patch on `@github-tools/sdk`) documenting the new option.

## Verification

- `pnpm --filter @github-tools/eve-extension build` and `typecheck` pass.
- `eve build` / `eve info` succeed for the example agent with the extension mounted via the same Vercel Connect connector used by `examples/eve-agent`.