### PR TITLE
feat: support a function for the Vercel Connect connector name

### DIFF
--- a/.changeset/dynamic-connector-resolver.md
+++ b/.changeset/dynamic-connector-resolver.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+`connectGithubTools` and `connectGithubToken` now accept a `() => string | Promise<string>` resolver in place of a static connector name, re-resolved on every call. Use it to pick a Vercel Connect connector dynamically — e.g. per environment (production vs. preview) or per tenant — instead of hardcoding one connector name.

--- a/.changeset/eve-extension-dynamic-connector.md
+++ b/.changeset/eve-extension-dynamic-connector.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/eve-extension": minor
+---
+
+The `connector` config field now also accepts a `() => string | Promise<string>` resolver, not just a static connector name, so a mounted extension can pick its Vercel Connect connector dynamically (e.g. per environment or tenant).

--- a/apps/docs/content/docs/2.frameworks/1.eve.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve.md
@@ -218,7 +218,7 @@ export default connectGithubTools('github/my-connector', {
 })
 ```
 
-See [Vercel Connect](/guide/vercel-connect#eve-agent) for the connector setup checklist and multi-tenant scoping.
+See [Vercel Connect](/guide/vercel-connect#eve-agent) for the connector setup checklist and multi-tenant scoping. `connector` also accepts a `() => string | Promise<string>` resolver for picking a connector per environment or tenant — see [dynamic connector selection](/guide/vercel-connect#dynamic-connector-selection).
 
 ## eve extension
 
@@ -237,6 +237,15 @@ export default githubExtension({
 ```
 
 `code-review` is used here (rather than `maintainer`) because it pairs cleanly with a Connect connector — `maintainer` and `repo-explorer` include gist tools, and GitHub only grants gist access to user access tokens, never the installation tokens Connect mints, so gist calls 403 over Connect (see [Tokens & Auth](/guide/tokens-and-auth#map-permissions-to-presets)). The `requireApproval` predicate above is also a real gate, not a no-op: write tools already require approval by `always()` by default, so `{ mergePullRequest: true }` would change nothing — a predicate is what actually narrows or loosens the default.
+
+`connector` also accepts a resolver function, so the same extension config can pick a connector dynamically:
+
+```ts [agent/extensions/github.ts]
+export default githubExtension({
+  connector: () => (process.env.VERCEL_ENV === 'production' ? 'github/prod-connector' : 'github/preview-connector'),
+  preset: 'code-review',
+})
+```
 
 Tools are exposed to the model as `<namespace>__<toolName>`, where `<namespace>` comes from the mount file's name — `agent/extensions/github.ts` yields `github__listPullRequests`, `github__createIssue`, and so on. Not yet published to npm; see [`examples/eve-extension-agent`](https://github.com/vercel-labs/github-tools/tree/main/examples/eve-extension-agent) and [`packages/github-tools-eve-extension`](https://github.com/vercel-labs/github-tools/tree/main/packages/github-tools-eve-extension) to build and consume it from the workspace.
 

--- a/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
+++ b/apps/docs/content/docs/3.guide/4.tokens-and-auth.md
@@ -111,7 +111,7 @@ const tools = createGithubTools({
 
 The provider is invoked at each tool execution, so short-lived tokens stay fresh across a long agent run. Note that in durable workflows the resolved token string is captured in the step arguments — a retried step reuses the token it was first invoked with rather than requesting a new one.
 
-Call `getToken` per request rather than caching the string yourself — the SDK keeps an in-process cache and refreshes tokens as they approach expiry. For multi-tenant connectors (one connector installed on several GitHub organizations), pass `installationId` to target a specific installation.
+Call `getToken` per request rather than caching the string yourself — the SDK keeps an in-process cache and refreshes tokens as they approach expiry. For multi-tenant connectors (one connector installed on several GitHub organizations), pass `installationId` to target a specific installation. When you need a *different connector* per environment or tenant rather than the same connector with a different installation, `connectGithubTools` / `connectGithubToken` also accept a `() => string | Promise<string>` resolver in place of a connector name — see [Vercel Connect: dynamic connector selection](/guide/vercel-connect#dynamic-connector-selection).
 
 ### Why Connect over a PAT
 

--- a/apps/docs/content/docs/3.guide/6.vercel-connect.md
+++ b/apps/docs/content/docs/3.guide/6.vercel-connect.md
@@ -105,6 +105,21 @@ const tools = connectGithubTools('github/my-connector', {
 
 `subject` is always `{ type: 'app' }` — same as `connectGitHubAdapter` from `@vercel/connect`.
 
+## Dynamic connector selection
+
+`connector` accepts a `() => string | Promise<string>` resolver instead of a static name — useful when the connector should vary by environment or tenant. It's re-resolved on every call, right alongside the token:
+
+```ts [connect-dynamic.ts]
+import { connectGithubTools } from '@github-tools/sdk/connect'
+
+const tools = connectGithubTools(
+  () => (process.env.VERCEL_ENV === 'production' ? 'github/prod-connector' : 'github/preview-connector'),
+  { preset: 'code-review' },
+)
+```
+
+The same resolver works with `connectGithubToken` and the eve variant of `connectGithubTools`.
+
 ## Setup checklist
 
 ::steps{level="3"}

--- a/apps/docs/content/docs/4.api/2.reference.md
+++ b/apps/docs/content/docs/4.api/2.reference.md
@@ -263,7 +263,7 @@ Also exports individual eve tool factories (`listPullRequests()`, `createIssue()
 
 ## `connectGithubTools(connector, options?)`
 
-Import from `@github-tools/sdk/connect`. Returns the same tool record as `createGithubTools`, backed by a Vercel Connect connector. Scopes are derived from `preset` unless overridden in `connect.scopes`:
+Import from `@github-tools/sdk/connect`. Returns the same tool record as `createGithubTools`, backed by a Vercel Connect connector. `connector` is a `GithubConnectorInput` — a name string or a `() => string | Promise<string>` resolver, re-resolved on every call (e.g. to pick a connector per environment or tenant). Scopes are derived from `preset` unless overridden in `connect.scopes`:
 
 ```ts [connect-tools.ts]
 import { connectGithubTools } from '@github-tools/sdk/connect'
@@ -285,9 +285,11 @@ type ConnectGithubToolsOptions = GithubToolsOptions & {
 type GithubConnectParams = Omit<ConnectTokenParams, 'subject'> & {
   repositories?: string[]
 }
+
+type GithubConnectorInput = string | (() => string | Promise<string>)
 ```
 
-`subject` is always `{ type: 'app' }`. See [Vercel Connect guide](/guide/vercel-connect).
+`subject` is always `{ type: 'app' }`. See [Vercel Connect guide](/guide/vercel-connect#dynamic-connector-selection) for the dynamic connector example.
 
 ## `connectGithubTools(connector, options?)` — eve
 
@@ -303,7 +305,7 @@ export default connectGithubTools('github/my-connector', {
 
 ## `connectGithubToken(connector, options?)`
 
-Returns a lazy `GithubTokenInput` backed by `getToken`. Use with `createGithubTools` when you only need the token provider:
+Returns a lazy `GithubTokenInput` backed by `getToken`. `connector` accepts the same `GithubConnectorInput` (name or resolver function) as `connectGithubTools`. Use with `createGithubTools` when you only need the token provider:
 
 ```ts [connect-token-provider.ts]
 import { connectGithubToken } from '@github-tools/sdk/connect'

--- a/packages/github-tools-eve-extension/README.md
+++ b/packages/github-tools-eve-extension/README.md
@@ -42,6 +42,15 @@ export default githubExtension({
 
 > `code-review` pairs cleanly with a Connect `connector` — `maintainer` and `repo-explorer` include gist tools, and GitHub only grants gist access to user access tokens, never the installation tokens Connect mints, so gist calls 403 over Connect. Write tools already require approval via `always()` by default, so a plain `{ someTool: true }` is a no-op — use a predicate (as above) when you actually want to narrow or loosen the default.
 
+`connector` also accepts a `() => string | Promise<string>` resolver, so the same config can pick a connector dynamically (e.g. by environment):
+
+```ts
+export default githubExtension({
+  connector: () => (process.env.VERCEL_ENV === 'production' ? 'github/prod-connector' : 'github/preview-connector'),
+  preset: 'code-review',
+})
+```
+
 Tools are exposed to the model as `<namespace>__<toolName>`, where `<namespace>` comes from the mount file's name — `agent/extensions/github.ts` yields `github__listPullRequests`, `github__createIssue`, and so on.
 
 See the runnable consumer at [`examples/eve-extension-agent`](../../examples/eve-extension-agent).
@@ -60,7 +69,7 @@ extension/
 | Field | Type | Notes |
 |---|---|---|
 | `token` | `string?` | Falls back to `GITHUB_TOKEN` when omitted and `connector` is not set |
-| `connector` | `string?` | Vercel Connect connector name; takes priority over `token` |
+| `connector` | `string \| (() => string \| Promise<string>)` (optional) | Vercel Connect connector name, or a resolver to pick one dynamically (e.g. per environment/tenant); takes priority over `token` |
 | `connect` | `record?` | Passed through to `getToken` when `connector` is set |
 | `preset` | preset name or array | `code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `maintainer` |
 | `requireApproval` | `boolean \| record` | Global or per-tool; per-tool values may be predicate functions |

--- a/packages/github-tools-eve-extension/extension/extension.ts
+++ b/packages/github-tools-eve-extension/extension/extension.ts
@@ -1,3 +1,4 @@
+import type { GithubConnectorInput } from '@github-tools/sdk/connect'
 import { defineExtension } from 'eve/extension'
 import { z } from 'zod'
 
@@ -12,8 +13,14 @@ export default defineExtension({
   config: z.object({
     /** GitHub PAT. Falls back to `GITHUB_TOKEN` when omitted and `connector` is not set. */
     token: z.string().optional(),
-    /** Vercel Connect connector name (e.g. `github/my-connector`). Takes priority over `token`. */
-    connector: z.string().optional(),
+    /**
+     * Vercel Connect connector name (e.g. `github/my-connector`), or a
+     * `() => string | Promise<string>` resolver for picking one dynamically
+     * (e.g. per environment or tenant). Takes priority over `token`.
+     */
+    connector: z.custom<GithubConnectorInput>(
+      value => typeof value === 'string' || typeof value === 'function',
+    ).optional(),
     /** Vercel Connect token params passed through to `getToken` when `connector` is set. */
     connect: z.record(z.string(), z.unknown()).optional(),
     /** Restrict tools to a preset (or array of presets). Omit for all 42 tools. */

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -280,6 +280,15 @@ connectGithubTools('github/my-connector', {
 
 > `@vercel/connect` is an optional peer dependency — install it only when using the `/connect` subpath.
 
+`connector` accepts a `() => string | Promise<string>` resolver instead of a static name, re-resolved on every call — useful to pick a connector per environment or tenant:
+
+```ts
+connectGithubTools(
+  () => (process.env.VERCEL_ENV === 'production' ? 'github/prod-connector' : 'github/preview-connector'),
+  { preset: 'code-review' },
+)
+```
+
 ## eve
 
 [eve](https://eve.dev) is Vercel's filesystem-first agent framework. The `@github-tools/sdk/eve` subpath registers all GitHub tools via `defineDynamic` — one file, zero CLI.

--- a/packages/github-tools/src/connect/connector.ts
+++ b/packages/github-tools/src/connect/connector.ts
@@ -1,0 +1,13 @@
+/**
+ * A Vercel Connect connector name, or a resolver that returns one.
+ *
+ * Use a function to pick the connector dynamically — e.g. a different
+ * connector per environment (`production` vs. `preview`) or per tenant.
+ * It's resolved lazily, on every token request, alongside the token itself.
+ */
+export type GithubConnectorInput = string | (() => string | Promise<string>)
+
+/** Resolves a {@link GithubConnectorInput} to a connector name string. */
+export async function resolveGithubConnector(connector: GithubConnectorInput): Promise<string> {
+  return typeof connector === 'function' ? await connector() : connector
+}

--- a/packages/github-tools/src/connect/eve.ts
+++ b/packages/github-tools/src/connect/eve.ts
@@ -1,4 +1,5 @@
 import { createGithubTools as createEveGithubTools } from '../eve'
+import type { GithubConnectorInput } from './connector'
 import { connectGithubToken } from './token'
 import type { ConnectGithubEveToolsOptions } from './types'
 
@@ -6,13 +7,16 @@ import type { ConnectGithubEveToolsOptions } from './types'
  * Register eve GitHub tools backed by a Vercel Connect connector.
  * Scopes are derived from `preset` unless overridden in `connect.scopes`.
  *
+ * `connector` may be a static name or a resolver function — e.g. to pick a
+ * different connector per environment (production vs. preview) or tenant.
+ *
  * TODO(eve-connect-bundle): eve's authored-module bundler inlines workspace-linked
  * SDK code and code-splits `@vercel/connect` unless the agent sets
  * `build.externalDependencies: ['@vercel/connect']` in `agent.ts`. Remove that
  * requirement when upstream eve externalizes this path.
  */
 export function connectGithubTools(
-  connector: string,
+  connector: GithubConnectorInput,
   options: ConnectGithubEveToolsOptions = {},
 ) {
   const { connect, preset, ...rest } = options

--- a/packages/github-tools/src/connect/index.ts
+++ b/packages/github-tools/src/connect/index.ts
@@ -1,3 +1,5 @@
+export { resolveGithubConnector } from './connector'
+export type { GithubConnectorInput } from './connector'
 export { PRESET_CONNECT_SCOPES, connectGithubScopesForPreset } from './scopes'
 export { connectGithubToken } from './token'
 export { connectGithubTools } from './tools'

--- a/packages/github-tools/src/connect/token.test.ts
+++ b/packages/github-tools/src/connect/token.test.ts
@@ -11,7 +11,7 @@ vi.mock('@vercel/connect', () => ({
 import { connectGithubToken } from './token'
 
 function resolveConnectToken(
-  connector: string,
+  connector: Parameters<typeof connectGithubToken>[0],
   options?: Parameters<typeof connectGithubToken>[1],
 ) {
   const resolve = connectGithubToken(connector, options)
@@ -95,5 +95,54 @@ describe('connectGithubToken', () => {
       expect.objectContaining({ subject: { type: 'app' } }),
       connectOptions,
     )
+  })
+
+  it('resolves a sync function connector', async () => {
+    const connectorFn = vi.fn(() => 'github/dynamic-connector')
+    const resolve = resolveConnectToken(connectorFn, { preset: 'code-review' })
+
+    expect(connectorFn).not.toHaveBeenCalled()
+
+    await resolve()
+    expect(connectorFn).toHaveBeenCalledTimes(1)
+    expect(getToken).toHaveBeenCalledWith(
+      'github/dynamic-connector',
+      expect.objectContaining({ subject: { type: 'app' } }),
+      undefined,
+    )
+  })
+
+  it('resolves an async function connector', async () => {
+    const connectorFn = vi.fn(async () => 'github/dynamic-connector')
+    const resolve = resolveConnectToken(connectorFn, { preset: 'code-review' })
+
+    await resolve()
+    expect(getToken).toHaveBeenCalledWith(
+      'github/dynamic-connector',
+      expect.objectContaining({ subject: { type: 'app' } }),
+      undefined,
+    )
+  })
+
+  it('re-resolves a function connector on every call', async () => {
+    let env = 'preview'
+    const connectorFn = vi.fn(() => `github/${env}-connector`)
+    const resolve = resolveConnectToken(connectorFn, { preset: 'code-review' })
+
+    await resolve()
+    expect(getToken).toHaveBeenLastCalledWith(
+      'github/preview-connector',
+      expect.anything(),
+      undefined,
+    )
+
+    env = 'production'
+    await resolve()
+    expect(getToken).toHaveBeenLastCalledWith(
+      'github/production-connector',
+      expect.anything(),
+      undefined,
+    )
+    expect(connectorFn).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/github-tools/src/connect/token.ts
+++ b/packages/github-tools/src/connect/token.ts
@@ -1,20 +1,25 @@
 import { getToken, type ConnectOptions } from '@vercel/connect'
 import type { GithubTokenInput } from '../core/token'
+import { resolveGithubConnector, type GithubConnectorInput } from './connector'
 import { resolveGithubConnectTokenParams } from './params'
 import type { ConnectGithubTokenOptions } from './types'
 
 /**
  * Returns a lazy GitHub token provider backed by a Vercel Connect connector.
  * Scopes are derived from `preset` unless overridden in `params.scopes`.
+ *
+ * `connector` may be a static name or a resolver function — e.g. to pick a
+ * different connector per environment (production vs. preview) or tenant.
+ * It's re-resolved on every call, alongside the token itself.
  */
 export function connectGithubToken(
-  connector: string,
+  connector: GithubConnectorInput,
   options: ConnectGithubTokenOptions = {},
 ): GithubTokenInput {
   const { connectOptions } = options
   const tokenParams = resolveGithubConnectTokenParams(options)
 
-  return () => getToken(connector, tokenParams, connectOptions)
+  return async () => getToken(await resolveGithubConnector(connector), tokenParams, connectOptions)
 }
 
 export type { ConnectOptions }

--- a/packages/github-tools/src/connect/tools.ts
+++ b/packages/github-tools/src/connect/tools.ts
@@ -1,13 +1,17 @@
 import { createGithubTools } from '../index'
+import type { GithubConnectorInput } from './connector'
 import { connectGithubToken } from './token'
 import type { ConnectGithubToolsOptions } from './types'
 
 /**
  * Create GitHub tools backed by a Vercel Connect connector.
  * Scopes are derived from `preset` unless overridden in `connect.scopes`.
+ *
+ * `connector` may be a static name or a resolver function — e.g. to pick a
+ * different connector per environment (production vs. preview) or tenant.
  */
 export function connectGithubTools(
-  connector: string,
+  connector: GithubConnectorInput,
   options: ConnectGithubToolsOptions = {},
 ) {
   const { connect, preset, ...rest } = options


### PR DESCRIPTION
Let connector be a `() => string | Promise<string>` in addition to a static name, so agents can pick a connector dynamically (e.g., per environment or tenant) instead of hardcoding one. This applies to connectGithubTools/connectGithubToken (AI SDK and eve subpaths) and the @github-tools/eve-extension connector config field.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:

### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- chat (the chat application)
- deps (dependencies)
- docs (the documentation site)
- eve (the eve extension package)
- sdk (the @github-tools/sdk package)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
