### PR TITLE
docs: add working-context guide and align examples with Connect

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,9 +59,10 @@ Every tool splits into a **core** function (pure logic) and a **tool factory** (
    - `packages/github-tools/src/agents.ts` — mention the tool in `PRESET_INSTRUCTIONS` for presets where it changes the agent's behavior
 4. **Chat app metadata** — add a `GITHUB_TOOL_META` entry in `apps/chat/shared/utils/tools/github.ts`
 5. **Documentation**:
-   - `apps/docs/content/docs/4.api/1.tools-catalog.md`
-   - `apps/docs/content/docs/3.guide/2.approval-control.md` (write tools only)
-   - `apps/docs/content/docs/3.guide/1.presets.md` and `apps/docs/content/docs/3.guide/4.tokens-and-auth.md` if the tool changes a preset's tool list or scopes
+   - `apps/docs/content/docs/5.api/1.tools-catalog.md`
+   - `apps/docs/content/docs/4.guide/2.approval-control.md` (write tools only)
+   - `apps/docs/content/docs/4.guide/1.presets.md` and `apps/docs/content/docs/4.guide/4.tokens-and-auth.md` if the tool changes a preset's tool list or scopes
+   - `apps/docs/content/docs/4.guide/6.working-context.md` if the tool is a composite or changes default payload behavior (`detail`, `includePatch`, ranges)
    - `packages/github-tools/README.md` (tool tables, preset tables, write tools list, token permissions) — the root `README.md` is a symlink to this file, no separate edit needed
    - New preset? Add it to `packages/github-tools-eve-extension/extension/extension.ts`'s `presetNameSchema` enum too
 6. **Changeset** — `pnpm changeset` (`minor`)

--- a/apps/docs/content/docs/1.getting-started/1.introduction.md
+++ b/apps/docs/content/docs/1.getting-started/1.introduction.md
@@ -111,7 +111,7 @@ The direct [`@github-tools/sdk/eve`](/deprecated/eve) import is deprecated in fa
 
 ## Explore the tools
 
-The SDK covers repositories, branches, pull requests, issues, commits, releases, checks and statuses, code search, gists, and workflows: 53 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame uses the GraphQL `Commit.blame` field) and is fully typed with [Zod](https://zod.dev) schemas.
+The SDK covers repositories, branches, pull requests, issues, commits, releases, checks and statuses, code search, gists, and workflows: 57 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame uses the GraphQL `Commit.blame` field) and is fully typed with [Zod](https://zod.dev) schemas.
 
 Browse the full list in the [Tools Catalog](/api/tools-catalog).
 

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with the eve extension
-description: Mount @github-tools/eve-extension under agent/extensions/ to add all 53 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
+description: Mount @github-tools/eve-extension under agent/extensions/ to add all 57 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
 seo:
   title: Build a GitHub agent with the eve extension
   description: Mount @github-tools/eve-extension under agent/extensions/, the recommended way to add GitHub tools to an eve agent.
@@ -28,7 +28,7 @@ links:
     variant: subtle
 ---
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 53 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 57 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
 
 ::callout{icon="i-custom:eve"}
 This is the **recommended way** to add GitHub tools to an eve agent. The lower-level direct import, [`@github-tools/sdk/eve`](/deprecated/eve), is **deprecated** in its favor. It keeps working, but new agents should mount the extension instead.
@@ -169,7 +169,7 @@ export default githubExtension({
 
 ```ts [agent/extensions/github.ts]
 export default githubExtension({
-  preset: 'maintainer', // all 53 tools
+  preset: 'maintainer', // all 57 tools
   exclude: ['createRepository', 'deleteGist'], // minus these two
 })
 ```

--- a/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
+++ b/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
@@ -118,7 +118,7 @@ Full policy options (including `overrides.needsApproval`): [Control write safety
 
 ## Trim tool context with toolpick
 
-With all 53 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
+With all 57 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'
@@ -153,7 +153,7 @@ const tools = {
 }
 ```
 
-See the [Tools Catalog](/api/tools-catalog) for all 53 factories.
+See the [Tools Catalog](/api/tools-catalog) for all 57 factories.
 
 ## When to level up
 

--- a/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
+++ b/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
@@ -46,7 +46,7 @@ Build an eve manager agent that delegates GitHub work to specialist sub-agents i
 
 ::
 
-Instead of one agent holding all 53 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
+Instead of one agent holding all 57 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
 
 ## Why declared subagents
 

--- a/apps/docs/content/docs/3.examples/7.recipes.md
+++ b/apps/docs/content/docs/3.examples/7.recipes.md
@@ -124,7 +124,7 @@ See the [full eve version of this task](/examples/eve-stale-issue-triager) for a
 
 ## Reduce tool context with toolpick
 
-With all 53 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
+With all 57 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'

--- a/apps/docs/content/docs/4.guide/6.working-context.md
+++ b/apps/docs/content/docs/4.guide/6.working-context.md
@@ -1,0 +1,87 @@
+---
+title: Working Context and Composites
+description: Default owner/repo/PR/issue/ref on tools, prefer composite reads, and keep payloads lean with detail, includePatch, and line ranges.
+navigation:
+  title: Working context
+path: /guide/working-context
+links:
+  - label: Tools catalog
+    icon: i-lucide-list-tree
+    to: /api/tools-catalog
+    color: neutral
+    variant: subtle
+  - label: API reference
+    icon: i-lucide-braces
+    to: /api/reference
+    color: neutral
+    variant: subtle
+  - label: Scope with presets
+    icon: i-lucide-layers
+    to: /guide/presets
+    color: neutral
+    variant: subtle
+---
+
+Agents burn tokens on repeated `owner` / `repo` args, multi-hop reads, and fat payloads (full PR diffs, long issue bodies, entire files). The SDK ships three levers that work together: a **working context**, **composite tools**, and **lean defaults**.
+
+## Working context
+
+Pass `context` to `createGithubTools`, `createGithubAgent`, or `createDurableGithubAgent` to default `owner`, `repo`, `pullNumber`, `issueNumber`, and/or `ref` on matching tool inputs. Matching schema fields become optional and fill from context when omitted. Agents also get a short system-prompt block describing the context:
+
+```ts [context.ts]
+import { createGithubTools, createGithubAgent } from '@github-tools/sdk'
+
+const tools = createGithubTools({
+  preset: 'code-review',
+  context: { owner: 'vercel', repo: 'ai', pullNumber: 42 },
+})
+
+const agent = createGithubAgent({
+  model: 'anthropic/claude-sonnet-4.6',
+  preset: 'code-review',
+  context: { owner: 'vercel', repo: 'ai', pullNumber: 42 },
+})
+```
+
+The same option is available on the [eve extension](/frameworks/eve-extension) via `context` in the mount config.
+
+## Composite tools
+
+Prefer one composite call over chaining several reads:
+
+| Tool | Returns |
+|---|---|
+| `getPullRequestContext` | PR details + files + reviews (+ optional CI checks) |
+| `getIssueContext` | Issue + `labelNames` + recent comments |
+| `getReleaseContext` | Release + previous release + tag comparison |
+| `getCiFailureContext` | Combined status, failing checks, failed workflow jobs/steps |
+
+Call independent follow-up reads **in the same step** when you already know the arguments (for example `getIssueContext` and `listIssues` together).
+
+## Lean payload defaults
+
+| Default | Behavior | Override |
+|---|---|---|
+| `detail: 'summary'` | Truncates long bodies (~500 chars) on `getPullRequest`, `getIssue`, and release getters | `detail: 'full'` |
+| `getIssueContext` | Defaults to `detail: 'full'` (one-shot) and returns `labelNames` (strings), not full label objects | `detail: 'summary'`; use `listLabels` for descriptions |
+| `includePatch: false` | Omits diff patches on `listPullRequestFiles`, `getCommit`, `compareCommits` | `includePatch: true`; optionally `filenames` on `listPullRequestFiles` |
+| File ranges | Prefer `startLine` / `endLine` / `maxLines` on `getFileContent` | Omit ranges only for small files |
+| `maxPages` | List tools fetch one page by default | Set `maxPages` to combine sequential pages in one call |
+
+## Example: code review bootstrap
+
+```ts [review-bootstrap.ts]
+import { createGithubAgent } from '@github-tools/sdk'
+
+const agent = createGithubAgent({
+  model: 'anthropic/claude-sonnet-4.6',
+  preset: 'code-review',
+  context: { owner: 'vercel-labs', repo: 'github-tools', pullNumber: 39 },
+})
+
+// Prefer getPullRequestContext first, then listPullRequestFiles with
+// includePatch + filenames for only the files you need to inspect.
+await agent.generate({ prompt: 'Summarize this PR and list two review findings. Read-only.' })
+```
+
+See the [tools catalog](/api/tools-catalog) for the full list and the [API reference](/api/reference) for `context` on `createGithubTools`.

--- a/apps/docs/content/docs/6.deprecated/1.eve.md
+++ b/apps/docs/content/docs/6.deprecated/1.eve.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with eve (direct import)
-description: Deprecated. The direct @github-tools/sdk/eve import registers all 53 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
+description: Deprecated. The direct @github-tools/sdk/eve import registers all 57 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
 seo:
   title: Build a GitHub agent with eve (direct import, deprecated)
   description: Deprecated direct-import path for eve agents. See the eve extension for the recommended approach.
@@ -36,7 +36,7 @@ links:
 **Deprecated.** `@github-tools/sdk/eve` (the direct import documented on this page) is deprecated in favor of [`@github-tools/eve-extension`](/frameworks/eve-extension), the recommended way to add GitHub tools to an eve agent. This direct import keeps working and isn't being removed, but new agents should [mount the extension](/frameworks/eve-extension) instead. See [migrating from the direct import](/frameworks/eve-extension#migrating-from-the-direct-import).
 ::
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 53 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 57 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
 
 ::prompt
 ---

--- a/examples/pr-review-agent/.env.example
+++ b/examples/pr-review-agent/.env.example
@@ -1,8 +1,14 @@
-# GitHub Personal Access Token (repo scope)
-GITHUB_TOKEN=ghp_...
+# Vercel Connect GitHub connector name (linked to your Vercel project)
+GITHUB_CONNECT_CONNECTOR=github/test-github-tools
+
+# Pulled via `vercel env pull` for local Connect auth
+# VERCEL_OIDC_TOKEN=...
 
 # Webhook secret (must match your GitHub webhook config)
 GITHUB_WEBHOOK_SECRET=...
 
 # Bot username for @mention detection
 GITHUB_AGENT_USERNAME=my-review-agent
+
+# Optional fallback if you prefer a PAT instead of Connect
+# GITHUB_TOKEN=ghp_...

--- a/examples/pr-review-agent/README.md
+++ b/examples/pr-review-agent/README.md
@@ -4,7 +4,7 @@ A durable PR review agent in **~60 lines of code**. Tag it on any pull request, 
 
 Built with:
 
-- **[@github-tools/sdk](https://github-tools.com)**: 53 AI-callable GitHub tools (PRs, commits, issues, releases, code search...)
+- **[@github-tools/sdk](https://github-tools.com)**: 57 AI-callable GitHub tools (PRs, commits, issues, releases, code search...)
 - **[Chat SDK](https://chat-sdk.dev)**: multi-platform agent framework with the GitHub adapter
 - **[Vercel Workflow](https://useworkflow.dev)**: durable execution that survives timeouts and restarts
 - **[evlog](https://evlog.dev)**: AI observability (token usage, tool calls, cost, timing)
@@ -36,11 +36,14 @@ Each tool call is a **durable step**: if the server crashes mid-review, the work
 
 ### 1. Environment variables
 
-Copy `.env.example` to `.env`:
+Copy `.env.example` to `.env`, then link the Vercel project and pull the OIDC token for [Vercel Connect](https://github-tools.com/guide/vercel-connect):
 
 ```bash
-# GitHub PAT with repo scope (or fine-grained with Issues + PRs read/write)
-GITHUB_TOKEN=ghp_...
+vercel link    # select the project that has the GitHub connector
+vercel env pull
+
+# Connector name must match the linked Connect connector
+GITHUB_CONNECT_CONNECTOR=github/test-github-tools
 
 # Must match your GitHub webhook config
 GITHUB_WEBHOOK_SECRET=...
@@ -48,6 +51,8 @@ GITHUB_WEBHOOK_SECRET=...
 # Agent username, this is how @mentions are detected
 GITHUB_AGENT_USERNAME=my-review-agent
 ```
+
+The workflow mints a short-lived token via `connectGithubToken` from `@github-tools/sdk/connect` (preset `code-review`). Set `GITHUB_TOKEN` only if you prefer a PAT instead of Connect.
 
 > **Important**: use a different GitHub account for the agent than the one commenting. The Chat SDK filters self-messages to prevent loops.
 

--- a/examples/pr-review-agent/server/workflows/review.ts
+++ b/examples/pr-review-agent/server/workflows/review.ts
@@ -1,10 +1,13 @@
-import { createHook, getWorkflowMetadata } from 'workflow'
 import { createGithubAgent } from '@github-tools/sdk'
+import { connectGithubToken } from '@github-tools/sdk/connect'
+import { createHook, getWorkflowMetadata } from 'workflow'
 import { createLogger } from 'evlog'
 import { createAILogger, createEvlogIntegration } from 'evlog/ai'
 import type { ChatTurnPayload, GitHubContext } from '../lib/agent'
 
-async function runAgentTurn(prompt: string, instructions: string) {
+const CONNECTOR = process.env.GITHUB_CONNECT_CONNECTOR || 'github/test-github-tools'
+
+async function runAgentTurn(prompt: string, instructions: string, ctx: GitHubContext) {
   'use step'
   const log = createLogger()
   const ai = createAILogger(log, {
@@ -14,8 +17,14 @@ async function runAgentTurn(prompt: string, instructions: string) {
 
   const agent = createGithubAgent({
     model: ai.wrap('anthropic/claude-sonnet-4.6') as any,
+    token: connectGithubToken(CONNECTOR, { preset: 'code-review' }),
     preset: 'code-review',
     requireApproval: false,
+    context: {
+      owner: ctx.owner,
+      repo: ctx.repo,
+      ...(ctx.isPullRequest ? { pullNumber: ctx.issueNumber } : { issueNumber: ctx.issueNumber }),
+    },
     additionalInstructions: instructions,
     experimental_telemetry: {
       isEnabled: true,
@@ -55,9 +64,9 @@ export async function reviewWorkflow(prompt: string, ctx: GitHubContext) {
 
   using hook = createHook<ChatTurnPayload>({ token: workflowRunId })
 
-  await runAgentTurn(prompt, instructions)
+  await runAgentTurn(prompt, instructions, ctx)
 
   for await (const event of hook) {
-    await runAgentTurn(event.text, instructions)
+    await runAgentTurn(event.text, instructions, ctx)
   }
 }


### PR DESCRIPTION
## Summary
- Add the working-context guide (`4.guide/6.working-context.md`) covering `context`, composites, `includePatch`, `detail`, and `maxPages`
- Fix CONTRIBUTING doc paths (`4.api` → `5.api`, `3.guide` → `4.guide`)
- Replace stale 53 → 57 tool counts across docs and examples
- Switch `examples/pr-review-agent` to `connectGithubToken` so it matches the docs claim that examples use Connect

## Test plan
- [ ] Docs site renders the new working-context page
- [ ] CONTRIBUTING links resolve
- [ ] pr-review-agent README / `.env.example` document Connect correctly