### PR TITLE
feat(sdk): add issue, PR, and release mutation tools

### DIFF
--- a/.changeset/eight-lions-edit.md
+++ b/.changeset/eight-lions-edit.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Add 8 mutation tools: `updateIssue` (also reopens closed issues via `state: 'open'`), `updateIssueComment`, `deleteIssueComment`, `updatePullRequest` (title, body, state, base, and draft status — draft toggling uses the GitHub GraphQL API), `updatePullRequestComment`, `deletePullRequestComment`, `updateRelease`, and `deleteRelease`. Added to the `code-review`, `issue-triage`, `release-manager`, and `maintainer` presets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Overview
 
-`@github-tools/sdk` wraps GitHub's REST API as 57 AI SDK-compatible tools for agents and `generateText`/`streamText` calls — with presets, approval control, and integrations for eve, Vercel Workflow, and Chat SDK. Docs: [github-tools.com](https://github-tools.com).
+`@github-tools/sdk` wraps GitHub's REST API as 65 AI SDK-compatible tools for agents and `generateText`/`streamText` calls — with presets, approval control, and integrations for eve, Vercel Workflow, and Chat SDK. Docs: [github-tools.com](https://github-tools.com).
 
 ## Commands
 

--- a/apps/chat/shared/utils/tools/github.ts
+++ b/apps/chat/shared/utils/tools/github.ts
@@ -23,7 +23,10 @@ export const GITHUB_TOOL_META: Record<GithubToolName, GithubToolMeta> = {
   getPullRequest: { title: 'Get Pull Request', label: 'Pull request fetched', labelActive: 'Fetching pull request', icon: 'i-lucide-git-pull-request' },
   createPullRequest: { title: 'Create Pull Request', label: 'Pull request created', labelActive: 'Creating pull request', icon: 'i-lucide-git-pull-request-arrow' },
   mergePullRequest: { title: 'Merge Pull Request', label: 'Pull request merged', labelActive: 'Merging pull request', icon: 'i-lucide-git-merge' },
+  updatePullRequest: { title: 'Update Pull Request', label: 'Pull request updated', labelActive: 'Updating pull request', icon: 'i-lucide-git-pull-request-arrow' },
   addPullRequestComment: { title: 'Comment on PR', label: 'Comment posted', labelActive: 'Posting PR comment', icon: 'i-lucide-message-square-plus' },
+  updatePullRequestComment: { title: 'Update PR Comment', label: 'Comment updated', labelActive: 'Updating PR comment', icon: 'i-lucide-message-square-text' },
+  deletePullRequestComment: { title: 'Delete PR Comment', label: 'Comment deleted', labelActive: 'Deleting PR comment', icon: 'i-lucide-message-square-x' },
   listPullRequestFiles: { title: 'List PR Files', label: 'Files listed', labelActive: 'Listing PR files', icon: 'i-lucide-file-diff' },
   listPullRequestReviews: { title: 'List PR Reviews', label: 'Reviews listed', labelActive: 'Listing PR reviews', icon: 'i-lucide-message-circle' },
   createPullRequestReview: { title: 'Submit PR Review', label: 'Review submitted', labelActive: 'Submitting PR review', icon: 'i-lucide-shield-check' },
@@ -34,7 +37,10 @@ export const GITHUB_TOOL_META: Record<GithubToolName, GithubToolMeta> = {
   getIssueContext: { title: 'Issue Context', label: 'Issue context loaded', labelActive: 'Loading issue context', icon: 'i-lucide-layers' },
   createIssue: { title: 'Create Issue', label: 'Issue created', labelActive: 'Creating issue', icon: 'i-lucide-circle-plus' },
   addIssueComment: { title: 'Comment on Issue', label: 'Comment posted', labelActive: 'Posting issue comment', icon: 'i-lucide-message-square-plus' },
+  updateIssueComment: { title: 'Update Issue Comment', label: 'Comment updated', labelActive: 'Updating issue comment', icon: 'i-lucide-message-square-text' },
+  deleteIssueComment: { title: 'Delete Issue Comment', label: 'Comment deleted', labelActive: 'Deleting issue comment', icon: 'i-lucide-message-square-x' },
   closeIssue: { title: 'Close Issue', label: 'Issue closed', labelActive: 'Closing issue', icon: 'i-lucide-circle-check' },
+  updateIssue: { title: 'Update Issue', label: 'Issue updated', labelActive: 'Updating issue', icon: 'i-lucide-circle-dot' },
   listLabels: { title: 'List Labels', label: 'Labels listed', labelActive: 'Listing labels', icon: 'i-lucide-tags' },
   addLabels: { title: 'Add Labels', label: 'Labels added', labelActive: 'Adding labels', icon: 'i-lucide-tag' },
   removeLabel: { title: 'Remove Label', label: 'Label removed', labelActive: 'Removing label', icon: 'i-lucide-x' },
@@ -67,7 +73,9 @@ export const GITHUB_TOOL_META: Record<GithubToolName, GithubToolMeta> = {
   getLatestRelease: { title: 'Get Latest Release', label: 'Latest release fetched', labelActive: 'Fetching latest release', icon: 'i-lucide-tag' },
   getRelease: { title: 'Get Release', label: 'Release fetched', labelActive: 'Fetching release', icon: 'i-lucide-tag' },
   getReleaseContext: { title: 'Release Context', label: 'Release context loaded', labelActive: 'Loading release context', icon: 'i-lucide-layers' },
-  createRelease: { title: 'Create Release', label: 'Release created', labelActive: 'Creating release', icon: 'i-lucide-rocket' }
+  createRelease: { title: 'Create Release', label: 'Release created', labelActive: 'Creating release', icon: 'i-lucide-rocket' },
+  updateRelease: { title: 'Update Release', label: 'Release updated', labelActive: 'Updating release', icon: 'i-lucide-tag' },
+  deleteRelease: { title: 'Delete Release', label: 'Release deleted', labelActive: 'Deleting release', icon: 'i-lucide-trash-2' }
 }
 
 export const GITHUB_TOOL_NAMES = new Set<string>(Object.keys(GITHUB_TOOL_META))

--- a/apps/docs/content/docs/1.getting-started/1.introduction.md
+++ b/apps/docs/content/docs/1.getting-started/1.introduction.md
@@ -111,7 +111,7 @@ The direct [`@github-tools/sdk/eve`](/deprecated/eve) import is deprecated in fa
 
 ## Explore the tools
 
-The SDK covers repositories, branches, pull requests, issues, commits, releases, checks and statuses, code search, gists, and workflows: 57 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame uses the GraphQL `Commit.blame` field) and is fully typed with [Zod](https://zod.dev) schemas.
+The SDK covers repositories, branches, pull requests, issues, commits, releases, checks and statuses, code search, gists, and workflows: 65 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame uses the GraphQL `Commit.blame` field) and is fully typed with [Zod](https://zod.dev) schemas.
 
 Browse the full list in the [Tools Catalog](/api/tools-catalog).
 

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with the eve extension
-description: Mount @github-tools/eve-extension under agent/extensions/ to add all 57 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
+description: Mount @github-tools/eve-extension under agent/extensions/ to add all 65 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
 seo:
   title: Build a GitHub agent with the eve extension
   description: Mount @github-tools/eve-extension under agent/extensions/, the recommended way to add GitHub tools to an eve agent.
@@ -28,7 +28,7 @@ links:
     variant: subtle
 ---
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 57 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 65 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
 
 ::callout{icon="i-custom:eve"}
 This is the **recommended way** to add GitHub tools to an eve agent. The legacy direct registration APIs (`createGithubTools` and per-tool factories from [`@github-tools/sdk/eve`](/deprecated/eve)) are **deprecated** in its favor. They keep working for existing `agent/tools/` setups, but new agents should mount the extension instead. Shared runtime helpers used by this extension live on `@github-tools/sdk/eve-runtime` (not deprecated).
@@ -169,7 +169,7 @@ export default githubExtension({
 
 ```ts [agent/extensions/github.ts]
 export default githubExtension({
-  preset: 'maintainer', // all 57 tools
+  preset: 'maintainer', // all 65 tools
   exclude: ['createRepository', 'deleteGist'], // minus these two
 })
 ```

--- a/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
+++ b/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
@@ -118,7 +118,7 @@ Full policy options (including `overrides.needsApproval`): [Control write safety
 
 ## Trim tool context with toolpick
 
-With all 57 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
+With all 65 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'
@@ -153,7 +153,7 @@ const tools = {
 }
 ```
 
-See the [Tools Catalog](/api/tools-catalog) for all 57 factories.
+See the [Tools Catalog](/api/tools-catalog) for all 65 factories.
 
 ## When to level up
 

--- a/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
+++ b/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
@@ -46,7 +46,7 @@ Build an eve manager agent that delegates GitHub work to specialist sub-agents i
 
 ::
 
-Instead of one agent holding all 57 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
+Instead of one agent holding all 65 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
 
 ## Why declared subagents
 

--- a/apps/docs/content/docs/3.examples/7.recipes.md
+++ b/apps/docs/content/docs/3.examples/7.recipes.md
@@ -124,7 +124,7 @@ See the [full eve version of this task](/examples/eve-stale-issue-triager) for a
 
 ## Reduce tool context with toolpick
 
-With all 57 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
+With all 65 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'

--- a/apps/docs/content/docs/4.guide/1.presets.md
+++ b/apps/docs/content/docs/4.guide/1.presets.md
@@ -82,10 +82,10 @@ const tools = createGithubTools({
 |---|---|---|
 | `repo-explorer` | repository metadata, branches, file content, repo tree, code search, gists, workflows, checks/statuses, releases | knowledge retrieval, repo Q&A |
 | `ci-ops` | workflows, runs, jobs, checks/statuses, commits, repository context | CI monitoring, build ops |
-| `code-review` | pull requests, commits, compare diff, file diffs, checks/statuses, review comments, reviewer requests | PR copilots, change summaries |
-| `issue-triage` | issues, labels, comments, assignees, close/create | support triage, backlog bots |
+| `code-review` | pull requests, commits, compare diff, file diffs, checks/statuses, updates, review comments, reviewer requests | PR copilots, change summaries |
+| `issue-triage` | issues, labels, comments, assignees, close/create/update/reopen | support triage, backlog bots |
 | `security-audit` | read-only exploration, PR/CI visibility, checks/statuses, compare diff, plus issue creation to report findings | vulnerability scanning, risk reporting |
-| `release-manager` | releases, compare diff, commits, workflow runs, pull requests | changelog generation, release cutting |
+| `release-manager` | releases, compare diff, commits, workflow runs, pull requests, update/delete releases | changelog generation, release cutting |
 | `maintainer` | all tool families including branch creation, forking, repo creation, gists, and workflows | operator workflows with strict approvals |
 
 ## Pair presets with token scopes

--- a/apps/docs/content/docs/4.guide/2.approval-control.md
+++ b/apps/docs/content/docs/4.guide/2.approval-control.md
@@ -85,12 +85,18 @@ const tools = createGithubTools({
 | `createOrUpdateFile` | High | Always require approval |
 | `mergePullRequest` | High | Always require approval |
 | `closeIssue` | Medium | Require in production repos |
+| `updateIssue` | Medium | Require in production repos |
 | `createPullRequest` | Medium | Optional in trusted CI |
+| `updatePullRequest` | Medium | Require in production repos |
 | `createBranch` | Low | Usually skip |
 | `addPullRequestComment` | Low | Usually skip |
+| `updatePullRequestComment` | Low | Usually skip |
+| `deletePullRequestComment` | Medium | Require in production repos |
 | `createPullRequestReview` | Medium | Require in production repos |
 | `requestReviewers` | Low | Usually skip |
 | `addIssueComment` | Low | Usually skip |
+| `updateIssueComment` | Low | Usually skip |
+| `deleteIssueComment` | Medium | Require in production repos |
 | `addLabels` | Low | Usually skip |
 | `removeLabel` | Low | Usually skip |
 | `addAssignees` | Low | Usually skip |
@@ -103,6 +109,8 @@ const tools = createGithubTools({
 | `cancelWorkflowRun` | High | Always require approval |
 | `rerunWorkflowRun` | Medium | Require in production repos |
 | `createRelease` | High | Always require approval |
+| `updateRelease` | Medium | Require in production repos |
+| `deleteRelease` | High | Always require approval |
 
 ## Override approval per tool
 

--- a/apps/docs/content/docs/5.api/1.tools-catalog.md
+++ b/apps/docs/content/docs/5.api/1.tools-catalog.md
@@ -71,7 +71,10 @@ Available in `code-review` and `maintainer` presets:
 | `getPullRequestContext` | fetch PR details plus files, reviews, and optional CI checks in one call | No |
 | `createPullRequest` | open a new pull request | Yes |
 | `mergePullRequest` | merge a pull request | Yes |
-| `addPullRequestComment` | post a review comment | Yes |
+| `updatePullRequest` | update a pull request's title, body, state, base branch, or draft status | Yes |
+| `addPullRequestComment` | post a comment on a pull request | Yes |
+| `updatePullRequestComment` | edit the body of a pull request comment | Yes |
+| `deletePullRequestComment` | permanently delete a pull request comment | Yes |
 | `createPullRequestReview` | submit a formal review (approve, request changes, or comment) with inline comments | Yes |
 | `requestReviewers` | request reviews from users or teams on a pull request | Yes |
 
@@ -86,7 +89,10 @@ Available in `issue-triage` and `maintainer` presets:
 | `getIssueContext` | fetch an issue plus label names and recent comments in one call | No |
 | `createIssue` | create a new issue | Yes |
 | `addIssueComment` | post a comment on an issue | Yes |
+| `updateIssueComment` | edit the body of an issue comment | Yes |
+| `deleteIssueComment` | permanently delete an issue comment | Yes |
 | `closeIssue` | close an issue thread | Yes |
+| `updateIssue` | update an issue's title, body, labels, milestone, or assignees — set `state: 'open'` to reopen | Yes |
 | `listLabels` | list labels available in a repository | No |
 | `addLabels` | add labels to an issue or pull request | Yes |
 | `removeLabel` | remove a label from an issue or pull request | Yes |
@@ -142,6 +148,8 @@ Available in `repo-explorer`, `release-manager`, and `maintainer` presets:
 | `getRelease` | get a specific release by ID, including its assets | No |
 | `getReleaseContext` | fetch a release plus the previous release and tag comparison in one call | No |
 | `createRelease` | create a new release (and its tag if needed) | Yes |
+| `updateRelease` | update a release's tag, target, title, notes, draft, or prerelease status | Yes |
+| `deleteRelease` | permanently delete a release (does not delete the underlying git tag) | Yes |
 
 ## Search and commit tools
 

--- a/apps/docs/content/docs/6.deprecated/1.eve.md
+++ b/apps/docs/content/docs/6.deprecated/1.eve.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with eve (direct import)
-description: Deprecated. The direct @github-tools/sdk/eve import registers all 57 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
+description: Deprecated. The direct @github-tools/sdk/eve import registers all 65 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
 seo:
   title: Build a GitHub agent with eve (direct import, deprecated)
   description: Deprecated direct-import path for eve agents. See the eve extension for the recommended approach.
@@ -36,7 +36,7 @@ links:
 **Deprecated.** The **direct registration APIs** on this page — `createGithubTools`, the per-tool factories, and `connectGithubTools` from `@github-tools/sdk/connect/eve` — are deprecated in favor of [`@github-tools/eve-extension`](/frameworks/eve-extension). They keep working for existing `agent/tools/` agents and aren't being removed, but new agents should [mount the extension](/frameworks/eve-extension) instead. Shared runtime helpers used by the extension (`listEveToolDescriptors`, `executeGithubEveTool`, approval mappers, …) live on **`@github-tools/sdk/eve-runtime`** and are **not** deprecated.
 ::
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 57 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 65 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
 
 ::prompt
 ---

--- a/apps/docs/skills/github-tools-agents/SKILL.md
+++ b/apps/docs/skills/github-tools-agents/SKILL.md
@@ -116,7 +116,7 @@ See `./references/eve-agents.md` and `/deprecated/eve`.
 | `ci-ops` | Actions workflows, runs, trigger/cancel/rerun |
 | `security-audit` | Vulnerability scanning, risk reporting |
 | `release-manager` | Changelog generation, release cutting |
-| `maintainer` | All 57 tools |
+| `maintainer` | All 65 tools |
 
 Array presets merge: `preset: ['code-review', 'issue-triage']`.
 

--- a/examples/pr-review-agent/README.md
+++ b/examples/pr-review-agent/README.md
@@ -4,7 +4,7 @@ A durable PR review agent in **~60 lines of code**. Tag it on any pull request, 
 
 Built with:
 
-- **[@github-tools/sdk](https://github-tools.com)**: 57 AI-callable GitHub tools (PRs, commits, issues, releases, code search...)
+- **[@github-tools/sdk](https://github-tools.com)**: 65 AI-callable GitHub tools (PRs, commits, issues, releases, code search...)
 - **[Chat SDK](https://chat-sdk.dev)**: multi-platform agent framework with the GitHub adapter
 - **[Vercel Workflow](https://useworkflow.dev)**: durable execution that survives timeouts and restarts
 - **[evlog](https://evlog.dev)**: AI observability (token usage, tool calls, cost, timing)

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -33,7 +33,7 @@ They all reach the GitHub API, but none of them were built as an agent's tool la
 | Production agents that must survive restarts and timeouts | [Durable Agents](#durable-agents-vercel-workflow-sdk) |
 | A GitHub, Slack, or Discord bot | [Chat SDK docs](https://github-tools.com/frameworks/chat-sdk) |
 
-53 tools cover repositories, branches, pull requests, issues, commits, releases, checks and statuses, search, gists, and workflows. See the full [Tools Catalog](https://github-tools.com/api/tools-catalog). Write operations support granular approval control out of the box.
+65 tools cover repositories, branches, pull requests, issues, commits, releases, checks and statuses, search, gists, and workflows. See the full [Tools Catalog](https://github-tools.com/api/tools-catalog). Write operations support granular approval control out of the box.
 
 ## Installation
 
@@ -93,13 +93,13 @@ createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
 
 | Preset | Tools included |
 |---|---|
-| `code-review` | `getPullRequest`, `listPullRequests`, `listPullRequestFiles`, `listPullRequestReviews`, `getPullRequestContext`, `getFileContent`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`, `getRepository`, `listBranches`, `searchCode`, `listCheckRuns`, `getCombinedStatus`, `addPullRequestComment`, `createPullRequestReview`, `requestReviewers` |
-| `issue-triage` | `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `closeIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `getRepository`, `searchRepositories`, `searchCode` |
+| `code-review` | `getPullRequest`, `listPullRequests`, `listPullRequestFiles`, `listPullRequestReviews`, `getPullRequestContext`, `getFileContent`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`, `getRepository`, `listBranches`, `searchCode`, `listCheckRuns`, `getCombinedStatus`, `updatePullRequest`, `addPullRequestComment`, `updatePullRequestComment`, `deletePullRequestComment`, `createPullRequestReview`, `requestReviewers` |
+| `issue-triage` | `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `getRepository`, `searchRepositories`, `searchCode` |
 | `repo-explorer` | All read-only tools including gists, workflows, checks/statuses, and releases (no write operations) |
 | `ci-ops` | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `listCheckRuns`, `getCombinedStatus`, `getCiFailureContext`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `getRepository`, `listBranches`, `listCommits`, `getCommit` |
 | `security-audit` | Read-only exploration (`getFileContent`, `getRepositoryTree`, `searchCode`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`), PR and CI visibility, plus `createIssue`, `addIssueComment`, `addLabels` to report findings (no destructive writes) |
-| `release-manager` | `listReleases`, `getLatestRelease`, `getRelease`, `getReleaseContext`, `createRelease`, `compareCommits`, `listCommits`, `getCommit`, `listWorkflowRuns`, `getWorkflowRun`, `listPullRequests`, `getPullRequest`, `getRepository`, `listBranches` |
-| `maintainer` | All 57 tools |
+| `release-manager` | `listReleases`, `getLatestRelease`, `getRelease`, `getReleaseContext`, `createRelease`, `updateRelease`, `deleteRelease`, `compareCommits`, `listCommits`, `getCommit`, `listWorkflowRuns`, `getWorkflowRun`, `listPullRequests`, `getPullRequest`, `getRepository`, `listBranches` |
+| `maintainer` | All 65 tools |
 
 Omit `preset` to get all tools (same as `maintainer`). Full breakdown: [Tools Catalog](https://github-tools.com/api/tools-catalog).
 
@@ -146,7 +146,7 @@ createGithubTools({
 })
 ```
 
-Write tools: `createBranch`, `forkRepository`, `createRepository`, `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `addPullRequestComment`, `createPullRequestReview`, `requestReviewers`, `createIssue`, `addIssueComment`, `closeIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `createGist`, `updateGist`, `deleteGist`, `createGistComment`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `createRelease`.
+Write tools: `createBranch`, `forkRepository`, `createRepository`, `createOrUpdateFile`, `createPullRequest`, `mergePullRequest`, `updatePullRequest`, `addPullRequestComment`, `updatePullRequestComment`, `deletePullRequestComment`, `createPullRequestReview`, `requestReviewers`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `createGist`, `updateGist`, `deleteGist`, `createGistComment`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `createRelease`, `updateRelease`, `deleteRelease`.
 
 All other tools are read-only and never require approval.
 
@@ -418,6 +418,8 @@ eve replays completed steps but re-runs steps interrupted mid-execution. Write t
 | `closeIssue` | Natural when already closed |
 | `createBranch` | Natural when branch exists at same SHA |
 | `removeAssignees` | Natural: removing an assignee that isn't assigned is a no-op on GitHub |
+| `updateIssue`, `updatePullRequest`, `updateRelease`, `updateIssueComment`, `updatePullRequestComment` | **Not** idempotent: each call applies a new revision |
+| `deleteIssueComment`, `deletePullRequestComment`, `deleteRelease` | **Not** idempotent: deleting an already-deleted resource returns 404 from GitHub |
 | `addIssueComment`, `createIssue`, `mergePullRequest`, `createRelease`, … | **Not** idempotent: each call creates new side effects |
 
 Gate non-idempotent writes behind `always()` or `once()` where replay safety matters.
@@ -469,7 +471,10 @@ List tools (`listCommits`, `listPullRequests`, `listIssues`, `listWorkflowRuns`,
 | `getPullRequestContext` | Fetch PR details plus files, reviews, and optional CI checks in one call |
 | `createPullRequest` | Open a new PR |
 | `mergePullRequest` | Merge a PR (merge, squash, or rebase) |
+| `updatePullRequest` | Update a PR's title, body, state, base branch, or draft status |
 | `addPullRequestComment` | Post a comment on a PR |
+| `updatePullRequestComment` | Edit the body of a PR comment |
+| `deletePullRequestComment` | Permanently delete a PR comment |
 | `createPullRequestReview` | Submit a formal review (approve, request changes, or comment) with inline comments |
 | `requestReviewers` | Request reviews from users or teams on a PR |
 
@@ -482,7 +487,10 @@ List tools (`listCommits`, `listPullRequests`, `listIssues`, `listWorkflowRuns`,
 | `getIssueContext` | Fetch an issue plus label names and recent comments in one call |
 | `createIssue` | Open a new issue |
 | `addIssueComment` | Post a comment on an issue |
+| `updateIssueComment` | Edit the body of an issue comment |
+| `deleteIssueComment` | Permanently delete an issue comment |
 | `closeIssue` | Close an issue (completed or not planned) |
+| `updateIssue` | Update an issue's title, body, labels, milestone, or assignees — set `state: 'open'` to reopen |
 | `listLabels` | List labels available in a repository |
 | `addLabels` | Add labels to an issue or pull request |
 | `removeLabel` | Remove a label from an issue or pull request |
@@ -530,6 +538,8 @@ List tools (`listCommits`, `listPullRequests`, `listIssues`, `listWorkflowRuns`,
 | `getRelease` | Get a specific release by ID, including its assets |
 | `getReleaseContext` | Fetch a release plus the previous release and tag comparison in one call |
 | `createRelease` | Create a new release (and its tag if needed) |
+| `updateRelease` | Update a release's tag, target, title, notes, draft, or prerelease status |
+| `deleteRelease` | Permanently delete a release (does not delete the underlying git tag) |
 
 ### Commits
 
@@ -559,12 +569,12 @@ Create one at **GitHub → Settings → Developer settings → Personal access t
 |---|---|---|
 | **Metadata** | Read-only | Always required (auto-included) |
 | **Contents** | Read-only | `getRepository`, `listBranches`, `getFileContent`, `getRepositoryTree`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`, `listReleases`, `getLatestRelease`, `getRelease`, `getReleaseContext` |
-| **Contents** | Read and write | `createBranch`, `createOrUpdateFile`, `createRelease` |
+| **Contents** | Read and write | `createBranch`, `createOrUpdateFile`, `createRelease`, `updateRelease`, `deleteRelease` |
 | **Administration** | Read and write | `forkRepository`, `createRepository` |
 | **Pull requests** | Read-only | `listPullRequests`, `getPullRequest`, `listPullRequestFiles`, `listPullRequestReviews`, `getPullRequestContext` |
-| **Pull requests** | Read and write | `createPullRequest`, `mergePullRequest`, `addPullRequestComment`, `createPullRequestReview`, `requestReviewers` |
+| **Pull requests** | Read and write | `createPullRequest`, `mergePullRequest`, `updatePullRequest`, `addPullRequestComment`, `updatePullRequestComment`, `deletePullRequestComment`, `createPullRequestReview`, `requestReviewers` |
 | **Issues** | Read-only | `listIssues`, `getIssue`, `getIssueContext`, `listLabels` |
-| **Issues** | Read and write | `createIssue`, `addIssueComment`, `closeIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees` |
+| **Issues** | Read and write | `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees` |
 | **Gists** | Read-only | `listGists`, `getGist`, `listGistComments` |
 | **Gists** | Read and write | `createGist`, `updateGist`, `deleteGist`, `createGistComment` |
 | **Actions** | Read-only | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `getCiFailureContext` |

--- a/packages/github-tools/src/agents.ts
+++ b/packages/github-tools/src/agents.ts
@@ -25,6 +25,7 @@ When reviewing a PR:
 - Use getBlame then getCommit(includePatch true) only when line history matters
 - Check for bugs, logic errors, and edge cases; be constructive
 - Use createPullRequestReview for formal reviews when asked
+- Use updatePullRequest to change title, body, base branch, or draft status; addPullRequestComment / updatePullRequestComment / deletePullRequestComment to manage comments
 
 ${SHARED_RULES}`,
 
@@ -35,6 +36,8 @@ When triaging issues:
 - Never re-call getIssueContext for the same issue
 - Pick labels from labelNames; use addLabels / removeLabel to apply them
 - Create issues with clear titles and descriptions when asked
+- Use updateIssue to edit title, body, labels, milestone, or assignees, and to reopen a closed issue (state: 'open') — there is no separate reopen tool
+- Use updateIssueComment / deleteIssueComment to correct or remove existing comments
 
 ${SHARED_RULES}`,
 
@@ -76,6 +79,7 @@ When preparing a release:
 - Use compareCommits / listCommits for more changelog detail; getCiFailureContext before cutting
 - createRelease with generateReleaseNotes when there is no manual changelog
 - Double-check the target branch or SHA — releases and tags are hard to undo
+- Use updateRelease to fix notes or toggle draft/prerelease after publishing; deleteRelease only when explicitly asked — it does not delete the underlying tag
 
 ${SHARED_RULES}`,
 

--- a/packages/github-tools/src/core/issues.ts
+++ b/packages/github-tools/src/core/issues.ts
@@ -178,6 +178,85 @@ export async function closeIssueCore({ token, owner, repo, issueNumber, stateRea
   }
 }
 
+export const updateIssueInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  issueNumber: z.number().describe('Issue number'),
+  title: z.string().optional().describe('New issue title'),
+  body: z.string().optional().describe('New issue description (supports Markdown)'),
+  state: z.enum(['open', 'closed']).optional().describe('Open or close the issue — set open to reopen a closed issue, closed to close it'),
+  stateReason: z.enum(['completed', 'not_planned', 'reopened']).optional().describe('Reason for the state change (ignored unless state changes)'),
+  labels: z.array(z.string()).optional().describe('Labels to set on the issue — replaces the existing set'),
+  milestone: z.number().nullable().optional().describe('Milestone number to associate, or null to remove the milestone'),
+  assignees: z.array(z.string()).optional().describe('GitHub usernames to set as assignees — replaces the existing set'),
+})
+
+export const updateIssueDescription = 'Update a GitHub issue — title, body, labels, milestone, or assignees. Set state open to reopen a closed issue, or closed to close it'
+
+/** Not idempotent — each call applies a new revision. */
+export async function updateIssueCore({ token, owner, repo, issueNumber, title, body, state, stateReason, labels, milestone, assignees }: { token: string, owner: string, repo: string, issueNumber: number, title?: string, body?: string, state?: 'open' | 'closed', stateReason?: 'completed' | 'not_planned' | 'reopened', labels?: string[], milestone?: number | null, assignees?: string[] }) {
+  const octokit = createOctokit(token)
+  const { data } = await octokit.rest.issues.update({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    title,
+    body,
+    state,
+    state_reason: stateReason,
+    labels,
+    milestone,
+    assignees,
+  })
+  return {
+    number: data.number,
+    title: data.title,
+    state: data.state,
+    url: data.html_url,
+    labels: data.labels.map(l => (typeof l === 'string' ? l : l.name)),
+    assignees: data.assignees?.map(a => a.login),
+    milestone: data.milestone?.number ?? null,
+    closedAt: data.closed_at,
+    updatedAt: data.updated_at,
+  }
+}
+
+export const updateIssueCommentInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  commentId: z.number().describe('Comment ID (from listIssueComments)'),
+  body: z.string().describe('New comment text (supports Markdown)'),
+})
+
+export const updateIssueCommentDescription = 'Update the body of a comment on a GitHub issue'
+
+/** Not idempotent — each call applies a new revision. */
+export async function updateIssueCommentCore({ token, owner, repo, commentId, body }: { token: string, owner: string, repo: string, commentId: number, body: string }) {
+  const octokit = createOctokit(token)
+  const { data } = await octokit.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
+  return {
+    id: data.id,
+    url: data.html_url,
+    body: data.body,
+    updatedAt: data.updated_at,
+  }
+}
+
+export const deleteIssueCommentInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  commentId: z.number().describe('Comment ID to delete'),
+})
+
+export const deleteIssueCommentDescription = 'Delete a comment from a GitHub issue permanently'
+
+/** Not idempotent — deleting an already-deleted comment returns 404 from GitHub. */
+export async function deleteIssueCommentCore({ token, owner, repo, commentId }: { token: string, owner: string, repo: string, commentId: number }) {
+  const octokit = createOctokit(token)
+  await octokit.rest.issues.deleteComment({ owner, repo, comment_id: commentId })
+  return { deleted: true, commentId }
+}
+
 export const listLabelsInputSchema = z.object({
   owner: z.string().describe('Repository owner'),
   repo: z.string().describe('Repository name'),

--- a/packages/github-tools/src/core/presets.ts
+++ b/packages/github-tools/src/core/presets.ts
@@ -11,26 +11,29 @@ export const PRESET_TOOLS = {
    *
    * Tools: `getPullRequest`, `listPullRequests`, `listPullRequestFiles`, `listPullRequestReviews`, `getPullRequestContext`,
    * `getFileContent`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`, `getRepository`, `listBranches`,
-   * `searchCode`, `listCheckRuns`, `getCombinedStatus`, `addPullRequestComment`, `createPullRequestReview`, `requestReviewers`.
+   * `searchCode`, `listCheckRuns`, `getCombinedStatus`, `updatePullRequest`, `addPullRequestComment`, `updatePullRequestComment`,
+   * `deletePullRequestComment`, `createPullRequestReview`, `requestReviewers`.
    *
    * Agent prompt: optimized for thorough PR review with inline feedback.
    */
   'code-review': [
     'getPullRequest', 'listPullRequests', 'listPullRequestFiles', 'listPullRequestReviews', 'getPullRequestContext', 'getFileContent', 'listCommits', 'getCommit', 'getBlame', 'compareCommits',
     'getRepository', 'listBranches', 'searchCode', 'listCheckRuns', 'getCombinedStatus',
-    'addPullRequestComment', 'createPullRequestReview', 'requestReviewers',
+    'updatePullRequest', 'addPullRequestComment', 'updatePullRequestComment', 'deletePullRequestComment', 'createPullRequestReview', 'requestReviewers',
   ],
   /**
    * **Issue triage** — manage and organize GitHub issues.
    *
-   * Tools: `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `closeIssue`,
-   * `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `getRepository`, `searchRepositories`, `searchCode`.
+   * Tools: `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`,
+   * `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `getRepository`,
+   * `searchRepositories`, `searchCode`.
    *
    * Prefer `getIssueContext` (issue + `labelNames` + recent comments) over separate get/list calls.
+   * Reopen a closed issue with `updateIssue` (`state: 'open'`) — there is no separate reopen tool.
    * Agent prompt: optimized for categorizing, labeling, and responding to issues.
    */
   'issue-triage': [
-    'listIssues', 'getIssueContext', 'createIssue', 'addIssueComment', 'closeIssue',
+    'listIssues', 'getIssueContext', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
     'addLabels', 'removeLabel', 'addAssignees', 'removeAssignees',
     'getRepository', 'searchRepositories', 'searchCode',
   ],
@@ -92,7 +95,7 @@ export const PRESET_TOOLS = {
    * **Release manager** — prepare and publish GitHub releases.
    *
    * Tools: `getRepository`, `listBranches`, `listCommits`, `getCommit`, `compareCommits`,
-   * `listReleases`, `getLatestRelease`, `getRelease`, `getReleaseContext`, `createRelease`,
+   * `listReleases`, `getLatestRelease`, `getRelease`, `getReleaseContext`, `createRelease`, `updateRelease`, `deleteRelease`,
    * `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `triggerWorkflow`,
    * `listPullRequests`, `getPullRequest`.
    *
@@ -100,7 +103,7 @@ export const PRESET_TOOLS = {
    */
   'release-manager': [
     'getRepository', 'listBranches', 'listCommits', 'getCommit', 'compareCommits',
-    'listReleases', 'getLatestRelease', 'getRelease', 'getReleaseContext', 'createRelease',
+    'listReleases', 'getLatestRelease', 'getRelease', 'getReleaseContext', 'createRelease', 'updateRelease', 'deleteRelease',
     'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs', 'triggerWorkflow',
     'listPullRequests', 'getPullRequest',
   ],
@@ -113,15 +116,15 @@ export const PRESET_TOOLS = {
    */
   'maintainer': [
     'getRepository', 'listBranches', 'getFileContent', 'getRepositoryTree', 'createBranch', 'forkRepository', 'createRepository', 'createOrUpdateFile',
-    'listPullRequests', 'getPullRequest', 'listPullRequestFiles', 'listPullRequestReviews', 'getPullRequestContext', 'createPullRequest', 'mergePullRequest', 'addPullRequestComment', 'createPullRequestReview', 'requestReviewers',
-    'listIssues', 'getIssue', 'getIssueContext', 'createIssue', 'addIssueComment', 'closeIssue',
+    'listPullRequests', 'getPullRequest', 'listPullRequestFiles', 'listPullRequestReviews', 'getPullRequestContext', 'createPullRequest', 'mergePullRequest', 'updatePullRequest', 'addPullRequestComment', 'updatePullRequestComment', 'deletePullRequestComment', 'createPullRequestReview', 'requestReviewers',
+    'listIssues', 'getIssue', 'getIssueContext', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
     'listLabels', 'addLabels', 'removeLabel', 'addAssignees', 'removeAssignees',
     'listCommits', 'getCommit', 'getBlame', 'compareCommits',
     'searchCode', 'searchRepositories',
     'listGists', 'getGist', 'listGistComments', 'createGist', 'updateGist', 'deleteGist', 'createGistComment',
     'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs', 'triggerWorkflow', 'cancelWorkflowRun', 'rerunWorkflowRun',
     'listCheckRuns', 'getCombinedStatus', 'getCiFailureContext',
-    'listReleases', 'getLatestRelease', 'getRelease', 'getReleaseContext', 'createRelease',
+    'listReleases', 'getLatestRelease', 'getRelease', 'getReleaseContext', 'createRelease', 'updateRelease', 'deleteRelease',
   ],
 } as const
 

--- a/packages/github-tools/src/core/pull-requests.ts
+++ b/packages/github-tools/src/core/pull-requests.ts
@@ -96,6 +96,55 @@ export async function createPullRequestCore({ token, owner, repo, title, body, h
   }
 }
 
+const MARK_READY_FOR_REVIEW_MUTATION = `
+  mutation($pullRequestId: ID!) {
+    markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+      pullRequest { id }
+    }
+  }
+`
+
+const CONVERT_TO_DRAFT_MUTATION = `
+  mutation($pullRequestId: ID!) {
+    convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+      pullRequest { id }
+    }
+  }
+`
+
+export const updatePullRequestInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  pullNumber: z.number().describe('Pull request number'),
+  title: z.string().optional().describe('New pull request title'),
+  body: z.string().optional().describe('New pull request description (supports Markdown)'),
+  state: z.enum(['open', 'closed']).optional().describe('Open or close the pull request'),
+  base: z.string().optional().describe('Change the base branch to merge into'),
+  draft: z.boolean().optional().describe('Convert to draft (true) or mark as ready for review (false)'),
+})
+
+export const updatePullRequestDescription = 'Update a pull request — title, body, state, base branch, or draft status. Draft toggling uses the GitHub GraphQL API since the REST update endpoint does not support it'
+
+/** Not idempotent — each call applies a new revision. */
+export async function updatePullRequestCore({ token, owner, repo, pullNumber, title, body, state, base, draft }: { token: string, owner: string, repo: string, pullNumber: number, title?: string, body?: string, state?: 'open' | 'closed', base?: string, draft?: boolean }) {
+  const octokit = createOctokit(token)
+  const { data } = await octokit.rest.pulls.update({ owner, repo, pull_number: pullNumber, title, body, state, base })
+
+  if (draft !== undefined && draft !== data.draft) {
+    await octokit.graphql(draft ? CONVERT_TO_DRAFT_MUTATION : MARK_READY_FOR_REVIEW_MUTATION, { pullRequestId: data.node_id })
+  }
+
+  return {
+    number: data.number,
+    title: data.title,
+    state: data.state,
+    draft: draft ?? data.draft,
+    url: data.html_url,
+    base: data.base.ref,
+    updatedAt: data.updated_at,
+  }
+}
+
 export const mergePullRequestInputSchema = z.object({
   owner: z.string().describe('Repository owner'),
   repo: z.string().describe('Repository name'),
@@ -164,6 +213,42 @@ export async function addPullRequestCommentCore({ token, owner, repo, pullNumber
     author: data.user?.login,
     createdAt: data.created_at,
   }
+}
+
+export const updatePullRequestCommentInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  commentId: z.number().describe('Comment ID (from the comment returned by addPullRequestComment)'),
+  body: z.string().describe('New comment text (supports Markdown)'),
+})
+
+export const updatePullRequestCommentDescription = 'Update the body of a comment on a pull request'
+
+/** Not idempotent — each call applies a new revision. */
+export async function updatePullRequestCommentCore({ token, owner, repo, commentId, body }: { token: string, owner: string, repo: string, commentId: number, body: string }) {
+  const octokit = createOctokit(token)
+  const { data } = await octokit.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
+  return {
+    id: data.id,
+    url: data.html_url,
+    body: data.body,
+    updatedAt: data.updated_at,
+  }
+}
+
+export const deletePullRequestCommentInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  commentId: z.number().describe('Comment ID to delete'),
+})
+
+export const deletePullRequestCommentDescription = 'Delete a comment from a pull request permanently'
+
+/** Not idempotent — deleting an already-deleted comment returns 404 from GitHub. */
+export async function deletePullRequestCommentCore({ token, owner, repo, commentId }: { token: string, owner: string, repo: string, commentId: number }) {
+  const octokit = createOctokit(token)
+  await octokit.rest.issues.deleteComment({ owner, repo, comment_id: commentId })
+  return { deleted: true, commentId }
 }
 
 export const listPullRequestFilesInputSchema = z.object({

--- a/packages/github-tools/src/core/releases.ts
+++ b/packages/github-tools/src/core/releases.ts
@@ -133,3 +133,58 @@ export async function createReleaseCore({ token, owner, repo, tagName, target, n
     createdAt: data.created_at,
   }
 }
+
+export const updateReleaseInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  releaseId: z.number().describe('Release ID (from listReleases or getLatestRelease)'),
+  tagName: z.string().optional().describe('New tag name for the release'),
+  target: z.string().optional().describe('Branch name or commit SHA to tag'),
+  name: z.string().optional().describe('New release title'),
+  body: z.string().optional().describe('New release notes (supports Markdown)'),
+  draft: z.boolean().optional().describe('Mark as a draft release'),
+  prerelease: z.boolean().optional().describe('Mark as a prerelease'),
+})
+
+export const updateReleaseDescription = 'Update an existing release — tag, target, title, notes, draft, or prerelease status'
+
+/** Not idempotent — each call applies a new revision. */
+export async function updateReleaseCore({ token, owner, repo, releaseId, tagName, target, name, body, draft, prerelease }: { token: string, owner: string, repo: string, releaseId: number, tagName?: string, target?: string, name?: string, body?: string, draft?: boolean, prerelease?: boolean }) {
+  const octokit = createOctokit(token)
+  const { data } = await octokit.rest.repos.updateRelease({
+    owner,
+    repo,
+    release_id: releaseId,
+    tag_name: tagName,
+    target_commitish: target,
+    name,
+    body,
+    draft,
+    prerelease,
+  })
+  return {
+    id: data.id,
+    tagName: data.tag_name,
+    name: data.name,
+    body: data.body,
+    url: data.html_url,
+    draft: data.draft,
+    prerelease: data.prerelease,
+    publishedAt: data.published_at,
+  }
+}
+
+export const deleteReleaseInputSchema = z.object({
+  owner: z.string().describe('Repository owner'),
+  repo: z.string().describe('Repository name'),
+  releaseId: z.number().describe('Release ID to delete'),
+})
+
+export const deleteReleaseDescription = 'Delete a release permanently (does not delete the underlying git tag)'
+
+/** Not idempotent — deleting an already-deleted release returns 404 from GitHub. */
+export async function deleteReleaseCore({ token, owner, repo, releaseId }: { token: string, owner: string, repo: string, releaseId: number }) {
+  const octokit = createOctokit(token)
+  await octokit.rest.repos.deleteRelease({ owner, repo, release_id: releaseId })
+  return { deleted: true, releaseId }
+}

--- a/packages/github-tools/src/core/tool-names.ts
+++ b/packages/github-tools/src/core/tool-names.ts
@@ -27,8 +27,14 @@ export const GITHUB_TOOL_NAMES = {
   createPullRequest: 'createPullRequest',
   /** Merge a pull request. Requires approval by default. */
   mergePullRequest: 'mergePullRequest',
+  /** Update a pull request — title, body, state, base branch, or draft status. Requires approval by default. */
+  updatePullRequest: 'updatePullRequest',
   /** Add a comment to a pull request. Requires approval by default. */
   addPullRequestComment: 'addPullRequestComment',
+  /** Update the body of a comment on a pull request. Requires approval by default. */
+  updatePullRequestComment: 'updatePullRequestComment',
+  /** Delete a comment from a pull request permanently. Requires approval by default. */
+  deletePullRequestComment: 'deletePullRequestComment',
   /** List files changed in a pull request with status and stats. Patches omitted by default — set includePatch true for diffs. */
   listPullRequestFiles: 'listPullRequestFiles',
   /** List reviews on a pull request (approvals, change requests, and comments). */
@@ -49,8 +55,14 @@ export const GITHUB_TOOL_NAMES = {
   createIssue: 'createIssue',
   /** Add a comment to a GitHub issue. Requires approval by default. */
   addIssueComment: 'addIssueComment',
+  /** Update the body of a comment on a GitHub issue. Requires approval by default. */
+  updateIssueComment: 'updateIssueComment',
+  /** Delete a comment from a GitHub issue permanently. Requires approval by default. */
+  deleteIssueComment: 'deleteIssueComment',
   /** Close an open GitHub issue. Requires approval by default. */
   closeIssue: 'closeIssue',
+  /** Update a GitHub issue — title, body, state, labels, milestone, or assignees. Requires approval by default. */
+  updateIssue: 'updateIssue',
   /** List labels available in a GitHub repository. */
   listLabels: 'listLabels',
   /** Add labels to an issue or pull request. Requires approval by default. */
@@ -117,6 +129,10 @@ export const GITHUB_TOOL_NAMES = {
   getReleaseContext: 'getReleaseContext',
   /** Create a new release (and its tag if needed) in a GitHub repository. Requires approval by default. */
   createRelease: 'createRelease',
+  /** Update an existing release — tag, target, title, notes, draft, or prerelease status. Requires approval by default. */
+  updateRelease: 'updateRelease',
+  /** Delete a release permanently. Requires approval by default. */
+  deleteRelease: 'deleteRelease',
 } as const
 
 export type GithubToolName = typeof GITHUB_TOOL_NAMES[keyof typeof GITHUB_TOOL_NAMES]

--- a/packages/github-tools/src/core/write-tools.ts
+++ b/packages/github-tools/src/core/write-tools.ts
@@ -15,8 +15,14 @@ export const GITHUB_WRITE_TOOLS = {
   createPullRequest: 'createPullRequest',
   /** Merge a pull request. Requires approval by default. */
   mergePullRequest: 'mergePullRequest',
+  /** Update a pull request. Requires approval by default. */
+  updatePullRequest: 'updatePullRequest',
   /** Add a comment to a pull request. Requires approval by default. */
   addPullRequestComment: 'addPullRequestComment',
+  /** Update a pull request comment. Requires approval by default. */
+  updatePullRequestComment: 'updatePullRequestComment',
+  /** Delete a pull request comment. Requires approval by default. */
+  deletePullRequestComment: 'deletePullRequestComment',
   /** Submit a pull request review with optional inline comments. Requires approval by default. */
   createPullRequestReview: 'createPullRequestReview',
   /** Request reviews from users or teams on a pull request. Requires approval by default. */
@@ -25,8 +31,14 @@ export const GITHUB_WRITE_TOOLS = {
   createIssue: 'createIssue',
   /** Add a comment to a GitHub issue. Requires approval by default. */
   addIssueComment: 'addIssueComment',
+  /** Update a GitHub issue comment. Requires approval by default. */
+  updateIssueComment: 'updateIssueComment',
+  /** Delete a GitHub issue comment. Requires approval by default. */
+  deleteIssueComment: 'deleteIssueComment',
   /** Close an open GitHub issue. Requires approval by default. */
   closeIssue: 'closeIssue',
+  /** Update a GitHub issue. Requires approval by default. */
+  updateIssue: 'updateIssue',
   /** Add labels to an issue or pull request. Requires approval by default. */
   addLabels: 'addLabels',
   /** Remove a label from an issue or pull request. Requires approval by default. */
@@ -51,6 +63,10 @@ export const GITHUB_WRITE_TOOLS = {
   rerunWorkflowRun: 'rerunWorkflowRun',
   /** Create a new release (and its tag if needed) in a GitHub repository. Requires approval by default. */
   createRelease: 'createRelease',
+  /** Update an existing release. Requires approval by default. */
+  updateRelease: 'updateRelease',
+  /** Delete a release permanently. Requires approval by default. */
+  deleteRelease: 'deleteRelease',
 } as const
 
 export type GithubWriteToolName = typeof GITHUB_WRITE_TOOLS[keyof typeof GITHUB_WRITE_TOOLS]

--- a/packages/github-tools/src/eve/registry.ts
+++ b/packages/github-tools/src/eve/registry.ts
@@ -147,11 +147,32 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       execute: withToken(pullRequests.mergePullRequestCore, ctx, { coAuthors: ctx.coAuthors }),
     },
     {
+      name: 'updatePullRequest',
+      writeTool: 'updatePullRequest',
+      description: pullRequests.updatePullRequestDescription,
+      inputSchema: pullRequests.updatePullRequestInputSchema,
+      execute: withToken(pullRequests.updatePullRequestCore, ctx),
+    },
+    {
       name: 'addPullRequestComment',
       writeTool: 'addPullRequestComment',
       description: pullRequests.addPullRequestCommentDescription,
       inputSchema: pullRequests.addPullRequestCommentInputSchema,
       execute: withToken(pullRequests.addPullRequestCommentCore, ctx),
+    },
+    {
+      name: 'updatePullRequestComment',
+      writeTool: 'updatePullRequestComment',
+      description: pullRequests.updatePullRequestCommentDescription,
+      inputSchema: pullRequests.updatePullRequestCommentInputSchema,
+      execute: withToken(pullRequests.updatePullRequestCommentCore, ctx),
+    },
+    {
+      name: 'deletePullRequestComment',
+      writeTool: 'deletePullRequestComment',
+      description: pullRequests.deletePullRequestCommentDescription,
+      inputSchema: pullRequests.deletePullRequestCommentInputSchema,
+      execute: withToken(pullRequests.deletePullRequestCommentCore, ctx),
     },
     {
       name: 'listPullRequestFiles',
@@ -220,11 +241,32 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       execute: withToken(issues.addIssueCommentCore, ctx),
     },
     {
+      name: 'updateIssueComment',
+      writeTool: 'updateIssueComment',
+      description: issues.updateIssueCommentDescription,
+      inputSchema: issues.updateIssueCommentInputSchema,
+      execute: withToken(issues.updateIssueCommentCore, ctx),
+    },
+    {
+      name: 'deleteIssueComment',
+      writeTool: 'deleteIssueComment',
+      description: issues.deleteIssueCommentDescription,
+      inputSchema: issues.deleteIssueCommentInputSchema,
+      execute: withToken(issues.deleteIssueCommentCore, ctx),
+    },
+    {
       name: 'closeIssue',
       writeTool: 'closeIssue',
       description: issues.closeIssueDescription,
       inputSchema: issues.closeIssueInputSchema,
       execute: withToken(issues.closeIssueCore, ctx),
+    },
+    {
+      name: 'updateIssue',
+      writeTool: 'updateIssue',
+      description: issues.updateIssueDescription,
+      inputSchema: issues.updateIssueInputSchema,
+      execute: withToken(issues.updateIssueCore, ctx),
     },
     {
       name: 'listLabels',
@@ -437,6 +479,20 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       description: releases.createReleaseDescription,
       inputSchema: releases.createReleaseInputSchema,
       execute: withToken(releases.createReleaseCore, ctx),
+    },
+    {
+      name: 'updateRelease',
+      writeTool: 'updateRelease',
+      description: releases.updateReleaseDescription,
+      inputSchema: releases.updateReleaseInputSchema,
+      execute: withToken(releases.updateReleaseCore, ctx),
+    },
+    {
+      name: 'deleteRelease',
+      writeTool: 'deleteRelease',
+      description: releases.deleteReleaseDescription,
+      inputSchema: releases.deleteReleaseInputSchema,
+      execute: withToken(releases.deleteReleaseCore, ctx),
     },
   ]
 

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -1,13 +1,13 @@
 import type { ToolSet } from 'ai'
 import { getRepository, listBranches, getFileContent, getRepositoryTree, createBranch, forkRepository, createRepository, createOrUpdateFile } from './tools/repository'
-import { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, addPullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
-import { listIssues, getIssue, createIssue, addIssueComment, closeIssue, listLabels, addLabels, removeLabel, addAssignees, removeAssignees } from './tools/issues'
+import { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, updatePullRequest, addPullRequestComment, updatePullRequestComment, deletePullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
+import { listIssues, getIssue, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, addAssignees, removeAssignees } from './tools/issues'
 import { searchCode, searchRepositories } from './tools/search'
 import { listCommits, getCommit, getBlame, compareCommits } from './tools/commits'
 import { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 import { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
 import { listCheckRuns, getCombinedStatus } from './tools/checks'
-import { listReleases, getLatestRelease, getRelease, createRelease } from './tools/releases'
+import { listReleases, getLatestRelease, getRelease, createRelease, updateRelease, deleteRelease } from './tools/releases'
 import { getPullRequestContext, getIssueContext, getReleaseContext, getCiFailureContext } from './tools/bundles'
 import { resolveAiSdkApproval } from './core/approval'
 import { bindToolsContext } from './core/context'
@@ -127,7 +127,10 @@ export function createGithubTools({
     createOrUpdateFile: createOrUpdateFile(resolveToken, { ...approval('createOrUpdateFile'), author, committer, coAuthors }),
     createPullRequest: createPullRequest(resolveToken, approval('createPullRequest')),
     mergePullRequest: mergePullRequest(resolveToken, { ...approval('mergePullRequest'), coAuthors }),
+    updatePullRequest: updatePullRequest(resolveToken, approval('updatePullRequest')),
     addPullRequestComment: addPullRequestComment(resolveToken, approval('addPullRequestComment')),
+    updatePullRequestComment: updatePullRequestComment(resolveToken, approval('updatePullRequestComment')),
+    deletePullRequestComment: deletePullRequestComment(resolveToken, approval('deletePullRequestComment')),
     listPullRequestFiles: listPullRequestFiles(resolveToken),
     listPullRequestReviews: listPullRequestReviews(resolveToken),
     createPullRequestReview: createPullRequestReview(resolveToken, approval('createPullRequestReview')),
@@ -136,7 +139,10 @@ export function createGithubTools({
     getIssueContext: getIssueContext(resolveToken),
     createIssue: createIssue(resolveToken, approval('createIssue')),
     addIssueComment: addIssueComment(resolveToken, approval('addIssueComment')),
+    updateIssueComment: updateIssueComment(resolveToken, approval('updateIssueComment')),
+    deleteIssueComment: deleteIssueComment(resolveToken, approval('deleteIssueComment')),
     closeIssue: closeIssue(resolveToken, approval('closeIssue')),
+    updateIssue: updateIssue(resolveToken, approval('updateIssue')),
     listLabels: listLabels(resolveToken),
     addLabels: addLabels(resolveToken, approval('addLabels')),
     removeLabel: removeLabel(resolveToken, approval('removeLabel')),
@@ -164,6 +170,8 @@ export function createGithubTools({
     getRelease: getRelease(resolveToken),
     getReleaseContext: getReleaseContext(resolveToken),
     createRelease: createRelease(resolveToken, approval('createRelease')),
+    updateRelease: updateRelease(resolveToken, approval('updateRelease')),
+    deleteRelease: deleteRelease(resolveToken, approval('deleteRelease')),
   } satisfies AllGithubTools
 
   if (overrides) {
@@ -189,14 +197,14 @@ export type GithubTools = AllGithubTools & ToolSet
 // Re-export individual tool factories for cherry-picking
 export { createOctokit } from './client'
 export { getRepository, listBranches, getFileContent, getRepositoryTree, createBranch, forkRepository, createRepository, createOrUpdateFile } from './tools/repository'
-export { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, addPullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
-export { listIssues, getIssue, createIssue, addIssueComment, closeIssue, listLabels, addLabels, removeLabel, addAssignees, removeAssignees } from './tools/issues'
+export { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, updatePullRequest, addPullRequestComment, updatePullRequestComment, deletePullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
+export { listIssues, getIssue, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, addAssignees, removeAssignees } from './tools/issues'
 export { searchCode, searchRepositories } from './tools/search'
 export { listCommits, getCommit, getBlame, compareCommits } from './tools/commits'
 export { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 export { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
 export { listCheckRuns, getCombinedStatus } from './tools/checks'
-export { listReleases, getLatestRelease, getRelease, createRelease } from './tools/releases'
+export { listReleases, getLatestRelease, getRelease, createRelease, updateRelease, deleteRelease } from './tools/releases'
 export { getPullRequestContext, getIssueContext, getReleaseContext, getCiFailureContext } from './tools/bundles'
 export type { CommitIdentity, CommitToolOptions, GithubTool, Octokit, ToolOptions, ToolOverrides } from './types'
 export type { GithubTokenInput } from './core/token'

--- a/packages/github-tools/src/tools/issues.ts
+++ b/packages/github-tools/src/tools/issues.ts
@@ -15,6 +15,15 @@ import {
   closeIssueInputSchema,
   closeIssueDescription,
   closeIssueCore,
+  updateIssueInputSchema,
+  updateIssueDescription,
+  updateIssueCore,
+  updateIssueCommentInputSchema,
+  updateIssueCommentDescription,
+  updateIssueCommentCore,
+  deleteIssueCommentInputSchema,
+  deleteIssueCommentDescription,
+  deleteIssueCommentCore,
   listLabelsInputSchema,
   listLabelsDescription,
   listLabelsCore,
@@ -100,6 +109,48 @@ export const closeIssue = (token: GithubTokenInput, { needsApproval = true }: To
     needsApproval,
     inputSchema: closeIssueInputSchema,
     execute: async args => closeIssueStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function updateIssueStep(args: Parameters<typeof updateIssueCore>[0]) {
+  "use step"
+  return updateIssueCore(args)
+}
+
+/** Update a GitHub issue — title, body, state, labels, milestone, or assignees. Requires approval by default. */
+export const updateIssue = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: updateIssueDescription,
+    needsApproval,
+    inputSchema: updateIssueInputSchema,
+    execute: async args => updateIssueStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function updateIssueCommentStep(args: Parameters<typeof updateIssueCommentCore>[0]) {
+  "use step"
+  return updateIssueCommentCore(args)
+}
+
+/** Update the body of a comment on a GitHub issue. Requires approval by default. */
+export const updateIssueComment = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: updateIssueCommentDescription,
+    needsApproval,
+    inputSchema: updateIssueCommentInputSchema,
+    execute: async args => updateIssueCommentStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function deleteIssueCommentStep(args: Parameters<typeof deleteIssueCommentCore>[0]) {
+  "use step"
+  return deleteIssueCommentCore(args)
+}
+
+/** Delete a comment from a GitHub issue permanently. Requires approval by default. */
+export const deleteIssueComment = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: deleteIssueCommentDescription,
+    needsApproval,
+    inputSchema: deleteIssueCommentInputSchema,
+    execute: async args => deleteIssueCommentStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listLabelsStep(args: Parameters<typeof listLabelsCore>[0]) {

--- a/packages/github-tools/src/tools/pull-requests.ts
+++ b/packages/github-tools/src/tools/pull-requests.ts
@@ -12,9 +12,18 @@ import {
   mergePullRequestInputSchema,
   mergePullRequestDescription,
   mergePullRequestCore,
+  updatePullRequestInputSchema,
+  updatePullRequestDescription,
+  updatePullRequestCore,
   addPullRequestCommentInputSchema,
   addPullRequestCommentDescription,
   addPullRequestCommentCore,
+  updatePullRequestCommentInputSchema,
+  updatePullRequestCommentDescription,
+  updatePullRequestCommentCore,
+  deletePullRequestCommentInputSchema,
+  deletePullRequestCommentDescription,
+  deletePullRequestCommentCore,
   listPullRequestFilesInputSchema,
   listPullRequestFilesDescription,
   listPullRequestFilesCore,
@@ -90,6 +99,20 @@ export const mergePullRequest = (token: GithubTokenInput, { needsApproval = true
     execute: async args => mergePullRequestStep({ token: await resolveGithubToken(token), coAuthors, ...args }),
   })
 
+async function updatePullRequestStep(args: Parameters<typeof updatePullRequestCore>[0]) {
+  "use step"
+  return updatePullRequestCore(args)
+}
+
+/** Update a pull request — title, body, state, base branch, or draft status. Requires approval by default. */
+export const updatePullRequest = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: updatePullRequestDescription,
+    needsApproval,
+    inputSchema: updatePullRequestInputSchema,
+    execute: async args => updatePullRequestStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
 async function addPullRequestCommentStep(args: Parameters<typeof addPullRequestCommentCore>[0]) {
   "use step"
   return addPullRequestCommentCore(args)
@@ -102,6 +125,34 @@ export const addPullRequestComment = (token: GithubTokenInput, { needsApproval =
     needsApproval,
     inputSchema: addPullRequestCommentInputSchema,
     execute: async args => addPullRequestCommentStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function updatePullRequestCommentStep(args: Parameters<typeof updatePullRequestCommentCore>[0]) {
+  "use step"
+  return updatePullRequestCommentCore(args)
+}
+
+/** Update the body of a comment on a pull request. Requires approval by default. */
+export const updatePullRequestComment = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: updatePullRequestCommentDescription,
+    needsApproval,
+    inputSchema: updatePullRequestCommentInputSchema,
+    execute: async args => updatePullRequestCommentStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function deletePullRequestCommentStep(args: Parameters<typeof deletePullRequestCommentCore>[0]) {
+  "use step"
+  return deletePullRequestCommentCore(args)
+}
+
+/** Delete a comment from a pull request permanently. Requires approval by default. */
+export const deletePullRequestComment = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: deletePullRequestCommentDescription,
+    needsApproval,
+    inputSchema: deletePullRequestCommentInputSchema,
+    execute: async args => deletePullRequestCommentStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function listPullRequestFilesStep(args: Parameters<typeof listPullRequestFilesCore>[0]) {

--- a/packages/github-tools/src/tools/releases.ts
+++ b/packages/github-tools/src/tools/releases.ts
@@ -12,6 +12,12 @@ import {
   createReleaseInputSchema,
   createReleaseDescription,
   createReleaseCore,
+  updateReleaseInputSchema,
+  updateReleaseDescription,
+  updateReleaseCore,
+  deleteReleaseInputSchema,
+  deleteReleaseDescription,
+  deleteReleaseCore,
 } from '../core/releases'
 import { resolveGithubToken, type GithubTokenInput } from '../core/token'
 import type { ToolOptions, GithubTool } from '../types'
@@ -67,4 +73,32 @@ export const createRelease = (token: GithubTokenInput, { needsApproval = true }:
     needsApproval,
     inputSchema: createReleaseInputSchema,
     execute: async args => createReleaseStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function updateReleaseStep(args: Parameters<typeof updateReleaseCore>[0]) {
+  "use step"
+  return updateReleaseCore(args)
+}
+
+/** Update an existing release — tag, target, title, notes, draft, or prerelease status. Requires approval by default. */
+export const updateRelease = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: updateReleaseDescription,
+    needsApproval,
+    inputSchema: updateReleaseInputSchema,
+    execute: async args => updateReleaseStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function deleteReleaseStep(args: Parameters<typeof deleteReleaseCore>[0]) {
+  "use step"
+  return deleteReleaseCore(args)
+}
+
+/** Delete a release permanently. Requires approval by default. */
+export const deleteRelease = (token: GithubTokenInput, { needsApproval = true }: ToolOptions = {}): GithubTool =>
+  tool({
+    description: deleteReleaseDescription,
+    needsApproval,
+    inputSchema: deleteReleaseInputSchema,
+    execute: async args => deleteReleaseStep({ token: await resolveGithubToken(token), ...args }),
   })


### PR DESCRIPTION
## Summary
- Add `updateIssue` (reopen via `state: 'open'` — no separate reopen tool), `updatePullRequest` with draft ↔ ready via GraphQL, edit/delete issue and PR comments, and `updateRelease` / `deleteRelease`
- Wire presets (`issue-triage`, `code-review`, `release-manager`, `maintainer`), eve registry, chat meta, docs, and skill
- Tool count 57 → 65

Rebased onto `main` after #61 merged.

## Test plan
- [ ] `pnpm build && pnpm lint && pnpm typecheck`
- [ ] Update/reopen an issue via `updateIssue`
- [ ] Toggle PR draft with `updatePullRequest`
- [ ] Edit/delete comments and update/delete a release with approval