### PR TITLE
feat(sdk): add searchIssues and code search snippets

### DIFF
--- a/.changeset/tame-otters-search.md
+++ b/.changeset/tame-otters-search.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Add `searchIssues` to search issues and pull requests with GitHub qualifiers (`is:open`, `type:pr`, `label:bug`, …), with `sort` and `order` options. Added to the `issue-triage`, `repo-explorer`, `security-audit`, and `maintainer` presets. `searchCode` now requests text-match snippets from GitHub and returns them as `textMatches` on each result.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Overview
 
-`@github-tools/sdk` wraps GitHub's REST API as 65 AI SDK-compatible tools for agents and `generateText`/`streamText` calls — with presets, approval control, and integrations for eve, Vercel Workflow, and Chat SDK. Docs: [github-tools.com](https://github-tools.com).
+`@github-tools/sdk` wraps GitHub's REST API as 66 AI SDK-compatible tools for agents and `generateText`/`streamText` calls — with presets, approval control, and integrations for eve, Vercel Workflow, and Chat SDK. Docs: [github-tools.com](https://github-tools.com).
 
 ## Commands
 

--- a/apps/chat/shared/utils/tools/github.ts
+++ b/apps/chat/shared/utils/tools/github.ts
@@ -48,6 +48,7 @@ export const GITHUB_TOOL_META: Record<GithubToolName, GithubToolMeta> = {
   removeAssignees: { title: 'Remove Assignees', label: 'Assignees removed', labelActive: 'Removing assignees', icon: 'i-lucide-user-minus' },
   searchCode: { title: 'Search Code', label: 'Code searched', labelActive: 'Searching code', icon: 'i-lucide-search-code' },
   searchRepositories: { title: 'Search Repositories', label: 'Repositories searched', labelActive: 'Searching repositories', icon: 'i-lucide-search' },
+  searchIssues: { title: 'Search Issues', label: 'Issues searched', labelActive: 'Searching issues', icon: 'i-lucide-search' },
   listCommits: { title: 'List Commits', label: 'Commits listed', labelActive: 'Listing commits', icon: 'i-lucide-git-commit-horizontal' },
   getCommit: { title: 'Get Commit', label: 'Commit fetched', labelActive: 'Fetching commit', icon: 'i-lucide-git-commit-horizontal' },
   getBlame: { title: 'Git Blame', label: 'Blame loaded', labelActive: 'Loading blame', icon: 'i-lucide-scroll-text' },

--- a/apps/docs/content/docs/1.getting-started/1.introduction.md
+++ b/apps/docs/content/docs/1.getting-started/1.introduction.md
@@ -111,7 +111,7 @@ The direct [`@github-tools/sdk/eve`](/deprecated/eve) import is deprecated in fa
 
 ## Explore the tools
 
-The SDK covers repositories, branches, pull requests, issues, commits, releases, checks and statuses, code search, gists, and workflows: 65 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame uses the GraphQL `Commit.blame` field) and is fully typed with [Zod](https://zod.dev) schemas.
+The SDK covers repositories, branches, pull requests, issues, commits, releases, checks and statuses, code search, gists, and workflows: 66 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame uses the GraphQL `Commit.blame` field) and is fully typed with [Zod](https://zod.dev) schemas.
 
 Browse the full list in the [Tools Catalog](/api/tools-catalog).
 

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with the eve extension
-description: Mount @github-tools/eve-extension under agent/extensions/ to add all 65 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
+description: Mount @github-tools/eve-extension under agent/extensions/ to add all 66 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
 seo:
   title: Build a GitHub agent with the eve extension
   description: Mount @github-tools/eve-extension under agent/extensions/, the recommended way to add GitHub tools to an eve agent.
@@ -28,7 +28,7 @@ links:
     variant: subtle
 ---
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 65 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 66 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
 
 ::callout{icon="i-custom:eve"}
 This is the **recommended way** to add GitHub tools to an eve agent. The legacy direct registration APIs (`createGithubTools` and per-tool factories from [`@github-tools/sdk/eve`](/deprecated/eve)) are **deprecated** in its favor. They keep working for existing `agent/tools/` setups, but new agents should mount the extension instead. Shared runtime helpers used by this extension live on `@github-tools/sdk/eve-runtime` (not deprecated).
@@ -169,7 +169,7 @@ export default githubExtension({
 
 ```ts [agent/extensions/github.ts]
 export default githubExtension({
-  preset: 'maintainer', // all 65 tools
+  preset: 'maintainer', // all 66 tools
   exclude: ['createRepository', 'deleteGist'], // minus these two
 })
 ```

--- a/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
+++ b/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
@@ -118,7 +118,7 @@ Full policy options (including `overrides.needsApproval`): [Control write safety
 
 ## Trim tool context with toolpick
 
-With all 65 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
+With all 66 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'
@@ -153,7 +153,7 @@ const tools = {
 }
 ```
 
-See the [Tools Catalog](/api/tools-catalog) for all 65 factories.
+See the [Tools Catalog](/api/tools-catalog) for all 66 factories.
 
 ## When to level up
 

--- a/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
+++ b/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
@@ -46,7 +46,7 @@ Build an eve manager agent that delegates GitHub work to specialist sub-agents i
 
 ::
 
-Instead of one agent holding all 65 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
+Instead of one agent holding all 66 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
 
 ## Why declared subagents
 

--- a/apps/docs/content/docs/3.examples/7.recipes.md
+++ b/apps/docs/content/docs/3.examples/7.recipes.md
@@ -124,7 +124,7 @@ See the [full eve version of this task](/examples/eve-stale-issue-triager) for a
 
 ## Reduce tool context with toolpick
 
-With all 65 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
+With all 66 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'

--- a/apps/docs/content/docs/4.guide/1.presets.md
+++ b/apps/docs/content/docs/4.guide/1.presets.md
@@ -80,11 +80,11 @@ const tools = createGithubTools({
 
 | Preset | Tools included | Use case |
 |---|---|---|
-| `repo-explorer` | repository metadata, branches, file content, repo tree, code search, gists, workflows, checks/statuses, releases | knowledge retrieval, repo Q&A |
+| `repo-explorer` | repository metadata, branches, file content, repo tree, code and issue search, gists, workflows, checks/statuses, releases | knowledge retrieval, repo Q&A |
 | `ci-ops` | workflows, runs, jobs, checks/statuses, commits, repository context | CI monitoring, build ops |
 | `code-review` | pull requests, commits, compare diff, file diffs, checks/statuses, updates, review comments, reviewer requests | PR copilots, change summaries |
-| `issue-triage` | issues, labels, comments, assignees, close/create/update/reopen | support triage, backlog bots |
-| `security-audit` | read-only exploration, PR/CI visibility, checks/statuses, compare diff, plus issue creation to report findings | vulnerability scanning, risk reporting |
+| `issue-triage` | issues, issue search, labels, comments, assignees, close/create/update/reopen | support triage, backlog bots |
+| `security-audit` | read-only exploration, code and issue search, PR/CI visibility, checks/statuses, compare diff, plus issue creation to report findings | vulnerability scanning, risk reporting |
 | `release-manager` | releases, compare diff, commits, workflow runs, pull requests, update/delete releases | changelog generation, release cutting |
 | `maintainer` | all tool families including branch creation, forking, repo creation, gists, and workflows | operator workflows with strict approvals |
 

--- a/apps/docs/content/docs/4.guide/6.working-context.md
+++ b/apps/docs/content/docs/4.guide/6.working-context.md
@@ -67,6 +67,7 @@ Call independent follow-up reads **in the same step** when you already know the 
 | `includePatch: false` | Omits diff patches on `listPullRequestFiles`, `getCommit`, `compareCommits` | `includePatch: true`; optionally `filenames` on `listPullRequestFiles` |
 | File ranges | Prefer `startLine` / `endLine` / `maxLines` on `getFileContent` | Omit ranges only for small files |
 | `maxPages` | List tools fetch one page by default | Set `maxPages` to combine sequential pages in one call |
+| Text-match fragments | `searchCode` truncates each snippet to ~300 chars | None — fetch the file with `getFileContent` for full context |
 
 ## Example: code review bootstrap
 

--- a/apps/docs/content/docs/5.api/1.tools-catalog.md
+++ b/apps/docs/content/docs/5.api/1.tools-catalog.md
@@ -161,8 +161,9 @@ Available in all presets:
 | `getCommit` | read a single commit with file stats (patches omitted by default; set `includePatch` for diffs) | No |
 | `getBlame` | line-level git blame for a file (GraphQL) | No |
 | `compareCommits` | compare two branches, tags, or commits: ahead/behind counts, commits in between, and files that differ (patches omitted by default) | No |
-| `searchCode` | search code across repository files | No |
+| `searchCode` | search code across repository files, with matching text snippets when GitHub returns them | No |
 | `searchRepositories` | search repositories by query | No |
+| `searchIssues` | search issues and pull requests using qualifiers like `is:open` or `type:pr` | No |
 
 ## Fetch beyond one page
 

--- a/apps/docs/content/docs/6.deprecated/1.eve.md
+++ b/apps/docs/content/docs/6.deprecated/1.eve.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with eve (direct import)
-description: Deprecated. The direct @github-tools/sdk/eve import registers all 65 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
+description: Deprecated. The direct @github-tools/sdk/eve import registers all 66 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
 seo:
   title: Build a GitHub agent with eve (direct import, deprecated)
   description: Deprecated direct-import path for eve agents. See the eve extension for the recommended approach.
@@ -36,7 +36,7 @@ links:
 **Deprecated.** The **direct registration APIs** on this page — `createGithubTools`, the per-tool factories, and `connectGithubTools` from `@github-tools/sdk/connect/eve` — are deprecated in favor of [`@github-tools/eve-extension`](/frameworks/eve-extension). They keep working for existing `agent/tools/` agents and aren't being removed, but new agents should [mount the extension](/frameworks/eve-extension) instead. Shared runtime helpers used by the extension (`listEveToolDescriptors`, `executeGithubEveTool`, approval mappers, …) live on **`@github-tools/sdk/eve-runtime`** and are **not** deprecated.
 ::
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 65 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 66 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
 
 ::prompt
 ---

--- a/apps/docs/skills/github-tools-agents/SKILL.md
+++ b/apps/docs/skills/github-tools-agents/SKILL.md
@@ -116,7 +116,7 @@ See `./references/eve-agents.md` and `/deprecated/eve`.
 | `ci-ops` | Actions workflows, runs, trigger/cancel/rerun |
 | `security-audit` | Vulnerability scanning, risk reporting |
 | `release-manager` | Changelog generation, release cutting |
-| `maintainer` | All 65 tools |
+| `maintainer` | All 66 tools |
 
 Array presets merge: `preset: ['code-review', 'issue-triage']`.
 

--- a/examples/pr-review-agent/README.md
+++ b/examples/pr-review-agent/README.md
@@ -4,7 +4,7 @@ A durable PR review agent in **~60 lines of code**. Tag it on any pull request, 
 
 Built with:
 
-- **[@github-tools/sdk](https://github-tools.com)**: 65 AI-callable GitHub tools (PRs, commits, issues, releases, code search...)
+- **[@github-tools/sdk](https://github-tools.com)**: 66 AI-callable GitHub tools (PRs, commits, issues, releases, code search...)
 - **[Chat SDK](https://chat-sdk.dev)**: multi-platform agent framework with the GitHub adapter
 - **[Vercel Workflow](https://useworkflow.dev)**: durable execution that survives timeouts and restarts
 - **[evlog](https://evlog.dev)**: AI observability (token usage, tool calls, cost, timing)

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -33,7 +33,7 @@ They all reach the GitHub API, but none of them were built as an agent's tool la
 | Production agents that must survive restarts and timeouts | [Durable Agents](#durable-agents-vercel-workflow-sdk) |
 | A GitHub, Slack, or Discord bot | [Chat SDK docs](https://github-tools.com/frameworks/chat-sdk) |
 
-65 tools cover repositories, branches, pull requests, issues, commits, releases, checks and statuses, search, gists, and workflows. See the full [Tools Catalog](https://github-tools.com/api/tools-catalog). Write operations support granular approval control out of the box.
+66 tools cover repositories, branches, pull requests, issues, commits, releases, checks and statuses, search, gists, and workflows. See the full [Tools Catalog](https://github-tools.com/api/tools-catalog). Write operations support granular approval control out of the box.
 
 ## Installation
 
@@ -94,12 +94,12 @@ createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
 | Preset | Tools included |
 |---|---|
 | `code-review` | `getPullRequest`, `listPullRequests`, `listPullRequestFiles`, `listPullRequestReviews`, `getPullRequestContext`, `getFileContent`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`, `getRepository`, `listBranches`, `searchCode`, `listCheckRuns`, `getCombinedStatus`, `updatePullRequest`, `addPullRequestComment`, `updatePullRequestComment`, `deletePullRequestComment`, `createPullRequestReview`, `requestReviewers` |
-| `issue-triage` | `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `getRepository`, `searchRepositories`, `searchCode` |
+| `issue-triage` | `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `getRepository`, `searchRepositories`, `searchCode`, `searchIssues` |
 | `repo-explorer` | All read-only tools including gists, workflows, checks/statuses, and releases (no write operations) |
 | `ci-ops` | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `listCheckRuns`, `getCombinedStatus`, `getCiFailureContext`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `getRepository`, `listBranches`, `listCommits`, `getCommit` |
 | `security-audit` | Read-only exploration (`getFileContent`, `getRepositoryTree`, `searchCode`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`), PR and CI visibility, plus `createIssue`, `addIssueComment`, `addLabels` to report findings (no destructive writes) |
 | `release-manager` | `listReleases`, `getLatestRelease`, `getRelease`, `getReleaseContext`, `createRelease`, `updateRelease`, `deleteRelease`, `compareCommits`, `listCommits`, `getCommit`, `listWorkflowRuns`, `getWorkflowRun`, `listPullRequests`, `getPullRequest`, `getRepository`, `listBranches` |
-| `maintainer` | All 65 tools |
+| `maintainer` | All 66 tools |
 
 Omit `preset` to get all tools (same as `maintainer`). Full breakdown: [Tools Catalog](https://github-tools.com/api/tools-catalog).
 
@@ -554,8 +554,9 @@ List tools (`listCommits`, `listPullRequests`, `listIssues`, `listWorkflowRuns`,
 
 | Tool | Description |
 |---|---|
-| `searchCode` | Search code across GitHub with qualifier support |
+| `searchCode` | Search code across GitHub with qualifier support (includes matching text snippets when available) |
 | `searchRepositories` | Search repositories by keyword, topic, language, stars, … |
+| `searchIssues` | Search issues and pull requests using qualifiers like `is:open`, `type:pr`, or `label:bug` |
 
 ## GitHub Token
 
@@ -582,7 +583,7 @@ Create one at **GitHub → Settings → Developer settings → Personal access t
 | **Checks** | Read-only | `listCheckRuns`, `getCiFailureContext` |
 | **Commit statuses** | Read-only | `getCombinedStatus`, `getCiFailureContext` |
 
-Search tools (`searchCode`, `searchRepositories`) work with any token.
+Search tools (`searchCode`, `searchRepositories`, `searchIssues`) work with any token.
 
 ### Classic token
 

--- a/packages/github-tools/src/agents.ts
+++ b/packages/github-tools/src/agents.ts
@@ -32,7 +32,7 @@ ${SHARED_RULES}`,
   'issue-triage': `You are an issue triage assistant. Your job is to help manage and organize GitHub issues.
 
 When triaging issues:
-- Call getIssueContext exactly once (full body + labelNames + recent comments). In that same step, call listIssues if you need duplicate checks
+- Call getIssueContext exactly once (full body + labelNames + recent comments). In that same step, call listIssues or searchIssues if you need duplicate checks
 - Never re-call getIssueContext for the same issue
 - Pick labels from labelNames; use addLabels / removeLabel to apply them
 - Create issues with clear titles and descriptions when asked
@@ -55,6 +55,7 @@ ${SHARED_RULES}`,
 
 When auditing a repository:
 - Use searchCode for secrets and unsafe patterns; getBlame / listCommits to trace introductions
+- Use searchIssues to check for prior reports of the same vulnerability before filing a duplicate
 - Prefer getCiFailureContext or getPullRequestContext for CI / PR context
 - Use compareCommits to scope changes (includePatch only when you need diffs)
 - Report findings as issues with reproduction, impact, and severity
@@ -66,6 +67,7 @@ ${SHARED_RULES}`,
 
 When exploring repos:
 - Answer questions about structure and organization; find files and patterns with searchCode / getFileContent
+- Use searchIssues to find issues or pull requests by qualifier across a repository or organization
 - Prefer getPullRequestContext or getCiFailureContext when summarizing a PR or failing CI
 - Use getBlame for line ownership; summarize recent commits / PRs / issues when asked
 - Read-only — you cannot make changes

--- a/packages/github-tools/src/core/presets.ts
+++ b/packages/github-tools/src/core/presets.ts
@@ -26,7 +26,7 @@ export const PRESET_TOOLS = {
    *
    * Tools: `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`,
    * `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `addAssignees`, `removeAssignees`, `getRepository`,
-   * `searchRepositories`, `searchCode`.
+   * `searchRepositories`, `searchCode`, `searchIssues`.
    *
    * Prefer `getIssueContext` (issue + `labelNames` + recent comments) over separate get/list calls.
    * Reopen a closed issue with `updateIssue` (`state: 'open'`) — there is no separate reopen tool.
@@ -35,7 +35,7 @@ export const PRESET_TOOLS = {
   'issue-triage': [
     'listIssues', 'getIssueContext', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
     'addLabels', 'removeLabel', 'addAssignees', 'removeAssignees',
-    'getRepository', 'searchRepositories', 'searchCode',
+    'getRepository', 'searchRepositories', 'searchCode', 'searchIssues',
   ],
   /**
    * **CI operations** — monitor and manage GitHub Actions workflows.
@@ -66,7 +66,7 @@ export const PRESET_TOOLS = {
     'listIssues', 'getIssue', 'getIssueContext',
     'listLabels',
     'listCommits', 'getCommit', 'getBlame', 'compareCommits',
-    'searchCode', 'searchRepositories',
+    'searchCode', 'searchRepositories', 'searchIssues',
     'listGists', 'getGist', 'listGistComments',
     'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs', 'listCheckRuns', 'getCombinedStatus', 'getCiFailureContext',
     'listReleases', 'getLatestRelease', 'getRelease', 'getReleaseContext',
@@ -74,7 +74,7 @@ export const PRESET_TOOLS = {
   /**
    * **Security audit** — review repositories for security risks and report findings.
    *
-   * Tools: read-only exploration (`getFileContent`, `getRepositoryTree`, `searchCode`, `listCommits`, `getCommit`,
+   * Tools: read-only exploration (`getFileContent`, `getRepositoryTree`, `searchCode`, `searchIssues`, `listCommits`, `getCommit`,
    * `getBlame`, `compareCommits`), PR and CI visibility (`listPullRequests`, `getPullRequest`, `listPullRequestFiles`,
    * `getPullRequestContext`, `listCheckRuns`, `getCombinedStatus`, `getCiFailureContext`, `listWorkflows`, `listWorkflowRuns`,
    * `getWorkflowRun`, `listWorkflowJobs`), plus `createIssue`, `addIssueComment`, and `addLabels` to report findings.
@@ -85,7 +85,7 @@ export const PRESET_TOOLS = {
   'security-audit': [
     'getRepository', 'listBranches', 'getFileContent', 'getRepositoryTree',
     'listCommits', 'getCommit', 'getBlame', 'compareCommits',
-    'searchCode', 'searchRepositories',
+    'searchCode', 'searchRepositories', 'searchIssues',
     'listPullRequests', 'getPullRequest', 'listPullRequestFiles', 'getPullRequestContext',
     'listCheckRuns', 'getCombinedStatus', 'getCiFailureContext',
     'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs',
@@ -120,7 +120,7 @@ export const PRESET_TOOLS = {
     'listIssues', 'getIssue', 'getIssueContext', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
     'listLabels', 'addLabels', 'removeLabel', 'addAssignees', 'removeAssignees',
     'listCommits', 'getCommit', 'getBlame', 'compareCommits',
-    'searchCode', 'searchRepositories',
+    'searchCode', 'searchRepositories', 'searchIssues',
     'listGists', 'getGist', 'listGistComments', 'createGist', 'updateGist', 'deleteGist', 'createGistComment',
     'listWorkflows', 'listWorkflowRuns', 'getWorkflowRun', 'listWorkflowJobs', 'triggerWorkflow', 'cancelWorkflowRun', 'rerunWorkflowRun',
     'listCheckRuns', 'getCombinedStatus', 'getCiFailureContext',

--- a/packages/github-tools/src/core/search.ts
+++ b/packages/github-tools/src/core/search.ts
@@ -1,16 +1,27 @@
 import { z } from 'zod'
 import { createOctokit } from '../client'
 
+const MAX_FRAGMENT_LENGTH = 300
+
+function truncateFragment(fragment: string): string {
+  if (fragment.length <= MAX_FRAGMENT_LENGTH) return fragment
+  return `${fragment.slice(0, MAX_FRAGMENT_LENGTH)}…`
+}
+
 export const searchCodeInputSchema = z.object({
   query: z.string().describe('Search query. Supports GitHub search qualifiers, e.g. "useState repo:facebook/react"'),
   perPage: z.number().optional().default(10).describe('Number of results to return (max 30)'),
 })
 
-export const searchCodeDescription = 'Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search.'
+export const searchCodeDescription = 'Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search. Results include matching text snippets when GitHub returns them.'
 
 export async function searchCodeCore({ token, query, perPage }: { token: string, query: string, perPage: number }) {
   const octokit = createOctokit(token)
-  const { data } = await octokit.rest.search.code({ q: query, per_page: perPage })
+  const { data } = await octokit.rest.search.code({
+    q: query,
+    per_page: perPage,
+    mediaType: { format: 'text-match' },
+  })
   return {
     totalCount: data.total_count,
     items: data.items.map(item => ({
@@ -19,6 +30,9 @@ export async function searchCodeCore({ token, query, perPage }: { token: string,
       url: item.html_url,
       repository: item.repository.full_name,
       sha: item.sha,
+      textMatches: item.text_matches?.map(match => ({
+        fragment: truncateFragment(match.fragment ?? ''),
+      })),
     })),
   }
 }
@@ -46,6 +60,36 @@ export async function searchRepositoriesCore({ token, query, perPage, sort, orde
       forks: repo.forks_count,
       language: repo.language,
       topics: repo.topics,
+    })),
+  }
+}
+
+export const searchIssuesInputSchema = z.object({
+  query: z.string().describe('Search query. Supports GitHub search qualifiers, e.g. "repo:owner/name is:open label:bug". Returns both issues and pull requests by default — use type:pr or is:pr to scope to pull requests, or type:issue / is:issue to exclude them'),
+  perPage: z.number().optional().default(10).describe('Number of results to return (max 30)'),
+  sort: z.enum(['comments', 'reactions', 'created', 'updated', 'interactions']).optional().describe('Sort field'),
+  order: z.enum(['asc', 'desc']).optional().default('desc').describe('Sort order'),
+})
+
+export const searchIssuesDescription = 'Search for issues and pull requests across GitHub using search qualifiers like "repo:owner/name is:open"'
+
+export async function searchIssuesCore({ token, query, perPage, sort, order }: { token: string, query: string, perPage: number, sort?: 'comments' | 'reactions' | 'created' | 'updated' | 'interactions', order: 'asc' | 'desc' }) {
+  const octokit = createOctokit(token)
+  const { data } = await octokit.rest.search.issuesAndPullRequests({ q: query, per_page: perPage, sort, order })
+  return {
+    totalCount: data.total_count,
+    items: data.items.map(item => ({
+      number: item.number,
+      title: item.title,
+      state: item.state,
+      url: item.html_url,
+      repository: item.repository_url.split('/repos/').at(-1),
+      author: item.user?.login,
+      labels: item.labels.map(l => (typeof l === 'string' ? l : l.name)),
+      comments: item.comments,
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
+      isPullRequest: Boolean(item.pull_request),
     })),
   }
 }

--- a/packages/github-tools/src/core/tool-names.ts
+++ b/packages/github-tools/src/core/tool-names.ts
@@ -73,10 +73,12 @@ export const GITHUB_TOOL_NAMES = {
   addAssignees: 'addAssignees',
   /** Remove assignees from an issue or pull request. Requires approval by default. */
   removeAssignees: 'removeAssignees',
-  /** Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search. */
+  /** Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search. Results include matching text snippets when GitHub returns them. */
   searchCode: 'searchCode',
   /** Search for GitHub repositories by keyword, topic, language, or other qualifiers. */
   searchRepositories: 'searchRepositories',
+  /** Search for issues and pull requests across GitHub using search qualifiers like "repo:owner/name is:open". */
+  searchIssues: 'searchIssues',
   /** List commits for a GitHub repository. Filter by file path to see commits that touched a file. For line-by-line attribution at a given ref, use getBlame instead. */
   listCommits: 'listCommits',
   /** Get detailed information about a specific commit, including the list of files changed. Patches omitted by default. */

--- a/packages/github-tools/src/eve/registry.ts
+++ b/packages/github-tools/src/eve/registry.ts
@@ -315,6 +315,12 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       execute: withToken(search.searchRepositoriesCore, ctx),
     },
     {
+      name: 'searchIssues',
+      description: search.searchIssuesDescription,
+      inputSchema: search.searchIssuesInputSchema,
+      execute: withToken(search.searchIssuesCore, ctx),
+    },
+    {
       name: 'listCommits',
       description: commits.listCommitsDescription,
       inputSchema: commits.listCommitsInputSchema,

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -2,7 +2,7 @@ import type { ToolSet } from 'ai'
 import { getRepository, listBranches, getFileContent, getRepositoryTree, createBranch, forkRepository, createRepository, createOrUpdateFile } from './tools/repository'
 import { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, updatePullRequest, addPullRequestComment, updatePullRequestComment, deletePullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
 import { listIssues, getIssue, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, addAssignees, removeAssignees } from './tools/issues'
-import { searchCode, searchRepositories } from './tools/search'
+import { searchCode, searchRepositories, searchIssues } from './tools/search'
 import { listCommits, getCommit, getBlame, compareCommits } from './tools/commits'
 import { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 import { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'
@@ -117,6 +117,7 @@ export function createGithubTools({
     getIssue: getIssue(resolveToken),
     searchCode: searchCode(resolveToken),
     searchRepositories: searchRepositories(resolveToken),
+    searchIssues: searchIssues(resolveToken),
     listCommits: listCommits(resolveToken),
     getCommit: getCommit(resolveToken),
     getBlame: getBlame(resolveToken),
@@ -199,7 +200,7 @@ export { createOctokit } from './client'
 export { getRepository, listBranches, getFileContent, getRepositoryTree, createBranch, forkRepository, createRepository, createOrUpdateFile } from './tools/repository'
 export { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, updatePullRequest, addPullRequestComment, updatePullRequestComment, deletePullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
 export { listIssues, getIssue, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, addAssignees, removeAssignees } from './tools/issues'
-export { searchCode, searchRepositories } from './tools/search'
+export { searchCode, searchRepositories, searchIssues } from './tools/search'
 export { listCommits, getCommit, getBlame, compareCommits } from './tools/commits'
 export { listGists, getGist, listGistComments, createGist, updateGist, deleteGist, createGistComment } from './tools/gists'
 export { listWorkflows, listWorkflowRuns, getWorkflowRun, listWorkflowJobs, triggerWorkflow, cancelWorkflowRun, rerunWorkflowRun } from './tools/workflows'

--- a/packages/github-tools/src/tools/search.ts
+++ b/packages/github-tools/src/tools/search.ts
@@ -8,6 +8,9 @@ import {
   searchRepositoriesInputSchema,
   searchRepositoriesDescription,
   searchRepositoriesCore,
+  searchIssuesInputSchema,
+  searchIssuesDescription,
+  searchIssuesCore,
 } from '../core/search'
 
 async function searchCodeStep(args: Parameters<typeof searchCodeCore>[0]) {
@@ -15,7 +18,7 @@ async function searchCodeStep(args: Parameters<typeof searchCodeCore>[0]) {
   return searchCodeCore(args)
 }
 
-/** Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search. */
+/** Search for code in GitHub repositories. Use qualifiers like "repo:owner/name" to scope the search. Results include matching text snippets when GitHub returns them. */
 export const searchCode = (token: GithubTokenInput): GithubTool =>
   tool({
     description: searchCodeDescription,
@@ -34,4 +37,17 @@ export const searchRepositories = (token: GithubTokenInput): GithubTool =>
     description: searchRepositoriesDescription,
     inputSchema: searchRepositoriesInputSchema,
     execute: async args => searchRepositoriesStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function searchIssuesStep(args: Parameters<typeof searchIssuesCore>[0]) {
+  "use step"
+  return searchIssuesCore(args)
+}
+
+/** Search for issues and pull requests across GitHub using search qualifiers like "repo:owner/name is:open". */
+export const searchIssues = (token: GithubTokenInput): GithubTool =>
+  tool({
+    description: searchIssuesDescription,
+    inputSchema: searchIssuesInputSchema,
+    execute: async args => searchIssuesStep({ token: await resolveGithubToken(token), ...args }),
   })


### PR DESCRIPTION
## Summary
- Add `searchIssues` (issues + PRs via GitHub search qualifiers)
- Return truncated text-match fragments from `searchCode` when the API provides them
- Wire presets (`issue-triage`, `repo-explorer`, `security-audit`, `maintainer`), docs, and skill
- Tool count 65 → 66

Rebased onto `main` after #62 merged.

## Test plan
- [ ] `pnpm build && pnpm lint && pnpm typecheck`
- [ ] `searchIssues` with `is:issue` / `is:pr` qualifiers
- [ ] `searchCode` returns `textMatches` fragments when available