### PR TITLE
feat(sdk): add focused presets and lead with composition

### DIFF
--- a/.changeset/presets-first-subagents.md
+++ b/.changeset/presets-first-subagents.md
@@ -1,0 +1,6 @@
+---
+"@github-tools/sdk": minor
+"@github-tools/eve-extension": minor
+---
+
+Add three focused presets: `discussion-moderator`, `notification-inbox`, and `pr-author`. Prefer a preset for most agents; use `maintainer` or omit `preset` when you need the full catalog. Docs and the agent skill lead with presets and the manager/sub-agents composition pattern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ export const myTool = (token: GithubTokenInput, { needsApproval = true }: ToolOp
 
 ### Presets
 
-Seven presets (`code-review`, `issue-triage`, `repo-explorer`, `ci-ops`, `security-audit`, `release-manager`, `maintainer`) defined in `src/core/presets.ts` as tool name arrays, with matching system prompts in `src/agents.ts`. Composable via arrays.
+Ten presets (`code-review`, `issue-triage`, `repo-explorer`, `ci-ops`, `security-audit`, `release-manager`, `discussion-moderator`, `notification-inbox`, `pr-author`, `maintainer`) defined in `src/core/presets.ts` as tool name arrays, with matching system prompts in `src/agents.ts`. Composable via arrays.
 
 ## Chat App Architecture (`apps/chat`)
 

--- a/apps/docs/content/docs/1.getting-started/1.introduction.md
+++ b/apps/docs/content/docs/1.getting-started/1.introduction.md
@@ -8,9 +8,19 @@ navigation:
   title: Introduction
 path: /getting-started/introduction
 links:
+  - label: Scope with presets
+    icon: i-lucide-layers
+    to: /guide/presets
+    color: neutral
+    variant: subtle
   - label: Build a GitHub agent with eve
     icon: i-custom:eve
     to: /frameworks/eve-extension
+    color: neutral
+    variant: subtle
+  - label: Manager & sub-agents
+    icon: i-custom:eve
+    to: /examples/manager-agent-with-subagents
     color: neutral
     variant: subtle
   - label: Quick Start
@@ -18,14 +28,9 @@ links:
     to: /getting-started/quick-start
     color: neutral
     variant: subtle
-  - label: Browse all tools
-    icon: i-lucide-list-tree
-    to: /api/tools-catalog
-    color: neutral
-    variant: subtle
 ---
 
-`@github-tools/sdk` is a typed tool layer that gives an AI agent GitHub access. Mount it as an [eve](https://eve.dev) extension in one file for a complete, durable GitHub agent, or drop it into any [AI SDK](https://ai-sdk.dev) app.
+`@github-tools/sdk` is a typed tool layer that gives an AI agent GitHub access. The catalog is large on purpose — so you can build almost any GitHub agent — and **presets** (or [manager + sub-agents](/examples/manager-agent-with-subagents) for multi-role products) keep that catalog out of the context window. Mount it as an [eve](https://eve.dev) extension in one file for a complete, durable GitHub agent, or drop it into any [AI SDK](https://ai-sdk.dev) app.
 
 The GitHub REST API isn't an agent tool layer on its own: an agent still needs a schema it can fill reliably, a safety gate before it merges a PR, output shaped to fit a context window, and a way to survive a crash mid-task. `@github-tools/sdk` does all four: **presets** scope what an agent can touch, **human approval** gates every write by default, outputs are **shaped and truncated** for token economy, and every tool runs as a **durable workflow step**.
 
@@ -41,7 +46,8 @@ actions:
 
 Help me integrate @github-tools/sdk into this project.
 
-- Summarize which preset fits my use case (repo-explorer, code-review, issue-triage, ci-ops, security-audit, release-manager, maintainer)
+- Summarize which preset fits my use case (repo-explorer, code-review, issue-triage, ci-ops, security-audit, release-manager, discussion-moderator, notification-inbox, pr-author, maintainer)
+- Prefer a focused preset; for multi-role products point to https://github-tools.com/examples/manager-agent-with-subagents
 - Point to https://github-tools.com/getting-started/installation and https://github-tools.com/getting-started/quick-start
 - Recommend a framework entry point: eve extension (https://github-tools.com/frameworks/eve-extension), AI SDK (https://github-tools.com/frameworks/ai-sdk), or Vercel Workflow (https://github-tools.com/frameworks/vercel-workflow)
 
@@ -56,7 +62,7 @@ They all reach the GitHub API, but none of them were built as an agent's tool la
 | Integration | Native AI SDK `tool()` objects | MCP wire protocol via a separate process | Shell-out from the agent | Hand-written per call |
 | Human approval | Built in, on by default | Host-dependent, inconsistent | None | You build it |
 | Durable / retryable | Every call is a `"use step"` | No | No | No |
-| Scoped by task | [Presets](/guide/presets) (7 built-in) | Full server surface, or manual filtering | Full CLI surface | You build it |
+| Scoped by task | [Presets](/guide/presets) (10 built-in) | Full server surface, or manual filtering | Full CLI surface | You build it |
 | Token-efficient output | Shaped and truncated by design | Raw API responses | Raw text, needs parsing | Raw API responses |
 | Native eve / Workflow / Chat SDK | Yes | No | No | No |
 
@@ -89,12 +95,12 @@ export default defineAgent({
 import githubExtension from '@github-tools/eve-extension'
 
 export default githubExtension({
-  preset: 'maintainer',
+  preset: 'code-review',
 })
 ```
 ::
 
-Run `npx eve dev` and you have a GitHub agent with durable human-in-the-loop approval on every write. Full walkthrough: [Build a GitHub agent with the eve extension](/frameworks/eve-extension).
+Run `npx eve dev` and you have a GitHub agent with durable human-in-the-loop approval on every write. Full walkthrough: [Build a GitHub agent with the eve extension](/frameworks/eve-extension). For several roles in one product, see [Manager agent with scoped sub-agents](/examples/manager-agent-with-subagents).
 
 ## Works with your framework
 
@@ -127,9 +133,12 @@ Instead of wiring tools individually, use a **preset** to get a curated subset f
 | `ci-ops` | workflows, runs, jobs, checks/statuses, commits, repository context | CI monitoring, build ops |
 | `security-audit` | read-only exploration, PR/CI visibility, plus issue creation to report findings | vulnerability scanning, risk reporting |
 | `release-manager` | releases, compare diff, commits, workflow runs, pull requests | changelog generation, release cutting |
+| `discussion-moderator` | discussions plus light issue context | forum / Q&A bots |
+| `notification-inbox` | notifications plus get issue/PR | inbox triage (Notifications PAT) |
+| `pr-author` | branches, file edits, create/update PRs | open focused PRs |
 | `maintainer` | all tool families | full operator workflows |
 
-Presets compose as arrays: `preset: ['code-review', 'issue-triage']`. Learn more in [Scope with Presets](/guide/presets).
+Presets compose as arrays: `preset: ['code-review', 'issue-triage']`. Multi-role products often work better as a [manager with preset-scoped sub-agents](/examples/manager-agent-with-subagents). Learn more in [Scope with Presets](/guide/presets).
 
 ## Safety is not an afterthought
 

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -181,7 +181,7 @@ export default githubExtension({
 | `token` | `string?` | Falls back to `GITHUB_TOKEN` when omitted and `connector` is not set |
 | `connector` | `string \| (() => string \| Promise<string>)` | Vercel Connect connector name, or a resolver to pick one dynamically (e.g. per environment/tenant); takes priority over `token` |
 | `connect` | `record?` | Passed through to `getToken` when `connector` is set |
-| `preset` | preset name or array | `code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `security-audit`, `release-manager`, `maintainer`, see [Presets](/guide/presets) |
+| `preset` | preset name or array | `code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `security-audit`, `release-manager`, `discussion-moderator`, `notification-inbox`, `pr-author`, `maintainer`, see [Presets](/guide/presets) |
 | `include` | `string[]?` | Tool names to add on top of `preset` (union), or the full set standalone, see [Pick exact tools](#pick-exact-tools) |
 | `exclude` | `string[]?` | Tool names to remove from the resolved `preset` + `include` set |
 | `context` | `{ owner?, repo?, pullNumber?, issueNumber?, ref? }?` | Default owner/repo/number/ref for tool inputs — matching fields become optional and fill from context when omitted, see [Working context](/guide/working-context) |

--- a/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
+++ b/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
@@ -48,6 +48,10 @@ Build an eve manager agent that delegates GitHub work to specialist sub-agents i
 
 Instead of one agent holding all 75 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
 
+::callout{icon="i-lucide-layers"}
+**Recommended for multi-role products.** Prefer this composition over putting `maintainer` (or omitting `preset`) on a single agent when the product has several distinct jobs — review, triage, release, and so on. Each specialist stays small in context and scoped in token permissions.
+::
+
 ## Why declared subagents
 
 eve ships two ways to delegate: the built-in `agent` tool (spins up a fresh copy of the *same* agent) and **declared subagents** (specialists with their own directory, tools, and prompt). A manager that routes between a reviewer, a triager, and a release manager needs the second kind, three different roles with three different tool surfaces, not three copies of the same agent.

--- a/apps/docs/content/docs/3.examples/7.recipes.md
+++ b/apps/docs/content/docs/3.examples/7.recipes.md
@@ -188,6 +188,6 @@ log.emit()
 | **eve** agent | `githubExtension` from `@github-tools/eve-extension` | standalone agents in 3 files, durable HITL approval (`once`, predicates) |
 | **Durable** agent + streaming | `createDurableGithubAgent` + `"use workflow"` | hosted chat, crash-safe tool loops, Nuxt/Next APIs on Vercel |
 | **Platform bot** | `createGithubTools` + Chat SDK + Workflow | GitHub/Slack/Discord bots with durable multi-turn sessions |
-| **Multi-agent** | eve subagents or agent-as-tool | one entry point routing to preset-scoped specialists |
+| **Multi-agent** | [eve manager + sub-agents](/examples/manager-agent-with-subagents) | one entry point routing to preset-scoped specialists |
 
 See [API Reference](/api/reference) for the full type signatures and [Tools Catalog](/api/tools-catalog) for every available tool.

--- a/apps/docs/content/docs/4.guide/1.presets.md
+++ b/apps/docs/content/docs/4.guide/1.presets.md
@@ -3,6 +3,11 @@ title: Scope with Presets
 description: Expose only the tools your workflow needs using presets.
 path: /guide/presets
 links:
+  - label: Manager & sub-agents
+    icon: i-custom:eve
+    to: /examples/manager-agent-with-subagents
+    color: neutral
+    variant: subtle
   - label: Browse all tools
     icon: i-lucide-list-tree
     to: /api/tools-catalog
@@ -15,7 +20,7 @@ links:
     variant: subtle
 ---
 
-Presets limit the tools your agent can access to a specific workflow. This reduces the attack surface and keeps prompts focused.
+The SDK ships a large tool catalog so you can build almost any GitHub agent. **Presets** are how you keep that catalog out of the model's context: each preset exposes only the tools for one workflow. Start with the smallest preset that fits; use `maintainer` or omit `preset` when you need the full surface.
 
 ::prompt
 ---
@@ -30,9 +35,19 @@ actions:
 Tighten GitHub tool scope for this assistant using @github-tools/sdk.
 
 - Switch to the smallest preset that still satisfies the feature; use an array to combine presets if needed (see https://github-tools.com/guide/presets)
+- For multi-role products, prefer a manager agent with preset-scoped sub-agents (https://github-tools.com/examples/manager-agent-with-subagents)
 - Align the GitHub PAT with https://github-tools.com/guide/tokens-and-auth
 
 ::
+
+## Compose agents around presets
+
+| Shape | When to use |
+|---|---|
+| **One preset** | A single job (review PRs, triage issues, cut releases) |
+| **Array of presets** | One agent that spans a few related domains |
+| **Manager + sub-agents** | Several distinct roles — each specialist mounts one preset ([example](/examples/manager-agent-with-subagents)) |
+| **`maintainer` / omit preset** | Prototyping or a genuine need for the full catalog |
 
 ## Apply a single preset
 
@@ -46,7 +61,7 @@ const tools = createGithubTools({
 })
 ```
 
-Two more presets target focused operator workflows:
+Focused operator workflows:
 
 ```ts [security-audit-agent.ts]
 import { createGithubTools } from '@github-tools/sdk'
@@ -56,11 +71,11 @@ const tools = createGithubTools({
 })
 ```
 
-```ts [release-manager-agent.ts]
+```ts [pr-author-agent.ts]
 import { createGithubTools } from '@github-tools/sdk'
 
 const tools = createGithubTools({
-  preset: 'release-manager',
+  preset: 'pr-author',
 })
 ```
 
@@ -86,7 +101,10 @@ const tools = createGithubTools({
 | `issue-triage` | issues, issue search, labels, comments, reactions, assignees, close/create/update/reopen | support triage, backlog bots |
 | `security-audit` | read-only exploration, code and issue search, PR/CI visibility, checks/statuses, compare diff, plus issue creation to report findings | vulnerability scanning, risk reporting |
 | `release-manager` | releases, compare diff, commits, workflow runs, pull requests, update/delete releases | changelog generation, release cutting |
-| `maintainer` | all tool families including branch creation, forking, repo creation, discussions, notifications, gists, and workflows | operator workflows with strict approvals |
+| `discussion-moderator` | discussions list/get/comment, plus light issue context | forum / Q&A bots |
+| `notification-inbox` | notifications list/mark-read, plus get issue/PR/repo | inbox triage (needs a Notifications PAT) |
+| `pr-author` | branches, file edits, create/update pull requests, compare | open focused PRs without full maintainer |
+| `maintainer` | all tool families including branch creation, forking, repo creation, discussions, notifications, gists, and workflows | full operator workflows with [approval control](/guide/approval-control) |
 
 ## Pair presets with token scopes
 
@@ -98,6 +116,9 @@ Each preset maps to specific [GitHub token permissions](/guide/tokens-and-auth):
 - `ci-ops`: add `actions: write` for triggering, cancelling, and re-running workflows
 - `security-audit`: read-only token, plus `issues: write` to report findings
 - `release-manager`: add `contents: write` for creating releases, `actions: write` if triggering release pipelines
+- `discussion-moderator`: add `discussions: write` and `issues: write` for cross-linking replies
+- `notification-inbox`: repository read scopes plus a user PAT with the "Notifications" account permission (not available on Connect installation tokens)
+- `pr-author`: add `contents: write` and `pull_requests: write`
 - `maintainer`: all write scopes, always paired with [approval control](/guide/approval-control); notification tools additionally need a PAT with the "Notifications" account permission
 
 ::tip
@@ -107,3 +128,4 @@ Default to the smallest preset that can complete the task. Add more capabilities
 ## External references
 
 - [Principle of least privilege (OWASP)](https://owasp.org/www-community/controls/Least_Privilege_Principle)
+- [Manager agent with scoped sub-agents](/examples/manager-agent-with-subagents)

--- a/apps/docs/content/docs/4.guide/4.tokens-and-auth.md
+++ b/apps/docs/content/docs/4.guide/4.tokens-and-auth.md
@@ -31,7 +31,7 @@ actions:
 
 Review GitHub token permissions for this @github-tools/sdk integration.
 
-- Match the PAT scopes to the preset in use (repo-explorer, code-review, issue-triage, ci-ops, security-audit, release-manager, maintainer)
+- Match the PAT scopes to the preset in use (repo-explorer, code-review, issue-triage, ci-ops, security-audit, release-manager, discussion-moderator, notification-inbox, pr-author, maintainer)
 - Apply least privilege per repository; follow https://github-tools.com/guide/tokens-and-auth
 - Cross-check write safety with https://github-tools.com/guide/approval-control
 
@@ -55,13 +55,16 @@ Fine-grained personal access tokens let you restrict access per repository and p
 | `ci-ops` | selected repos | `read` | none | none | none | `write` | `read` | none |
 | `security-audit` | selected repos | `read` | `read` | `write` (to report findings) | none | `read` | `read` | none |
 | `release-manager` | selected repos | `write` (for release creation) | `read` | none | none | `write` (if triggering pipelines) | none | none |
+| `discussion-moderator` | selected repos | `read` | none | `write` (when linking issues) | `write` | none | none | none |
+| `notification-inbox` | selected repos | `read` | `read` | `read` | none | none | none | none |
+| `pr-author` | selected repos | `write` | `write` | none | none | none | none | none |
 | `maintainer` | selected repos | `write` | `write` | `write` | `write` | `write` | `read` | `write` (for repo creation and forking) |
 
 Reactions (`listIssueReactions`, `addIssueReaction`, `listCommentReactions`, `addCommentReaction`) are covered by the **Issues** permission and need no scope of their own.
 
 `repo-explorer` and `maintainer` also include gist read (and, for `maintainer`, write) tools. Gists aren't tied to a repository. GitHub only grants gist access to GitHub App *user* access tokens, never installation tokens, so give the PAT the "Gists" account permission separately, and expect gist tools to fail over Vercel Connect (see below).
 
-`maintainer` includes `listNotifications` and `markNotificationRead`. Notifications belong to a user rather than a repository, so they need the "Notifications" account permission on the PAT and, like gists, fail with a Connect-minted installation token.
+`notification-inbox` and `maintainer` include `listNotifications` and `markNotificationRead`. Notifications belong to a user rather than a repository, so they need the "Notifications" account permission on the PAT and, like gists, fail with a Connect-minted installation token.
 
 Releases are covered by the **Contents** permission on GitHub Apps: `repo-explorer`, `release-manager`, and `maintainer` need no separate scope for `listReleases`, `getLatestRelease`, or `getRelease`.
 

--- a/apps/docs/content/docs/5.api/2.reference.md
+++ b/apps/docs/content/docs/5.api/2.reference.md
@@ -69,6 +69,9 @@ type GithubToolPreset =
   | 'ci-ops'
   | 'security-audit'
   | 'release-manager'
+  | 'discussion-moderator'
+  | 'notification-inbox'
+  | 'pr-author'
   | 'maintainer'
 ```
 

--- a/apps/docs/content/docs/6.deprecated/1.eve.md
+++ b/apps/docs/content/docs/6.deprecated/1.eve.md
@@ -165,7 +165,7 @@ Each factory returns a `defineTool` value. The filename slug becomes the tool na
 
 ## Presets and options
 
-All presets (`code-review`, `issue-triage`, `repo-explorer`, `ci-ops`, `security-audit`, `release-manager`, `maintainer`) work with `createGithubTools`. Options mirror the AI SDK surface:
+All presets (`code-review`, `issue-triage`, `repo-explorer`, `ci-ops`, `security-audit`, `release-manager`, `discussion-moderator`, `notification-inbox`, `pr-author`, `maintainer`) work with `createGithubTools`. Options mirror the AI SDK surface:
 
 | Option | Description |
 |---|---|

--- a/apps/docs/skills/github-tools-agents/SKILL.md
+++ b/apps/docs/skills/github-tools-agents/SKILL.md
@@ -6,7 +6,7 @@ metadata:
   author: "HugoRCD"
   repository: "https://github.com/vercel-labs/github-tools"
   url: "https://github-tools.com/.well-known/skills"
-  version: "1.2.0"
+  version: "1.3.0"
   keywords: "ai, agent, skill, vercel, ai sdk, github, tools, octokit, durable, workflow"
 ---
 
@@ -24,7 +24,7 @@ Official docs: **https://github-tools.com**, with paths such as `/getting-starte
 - **Reusable agent**: "Use `createGithubAgent` with a preset" / custom system instructions.
 - **Durable**: "Run the agent inside Vercel Workflow" / `"use workflow"` / crash-safe tool steps.
 - **Safety**: "Gate merges / file writes with approval" / fine-grained PAT scopes.
-- **Narrow scope**: Presets (`code-review`, `issue-triage`, `repo-explorer`, `ci-ops`, `security-audit`, `release-manager`, `maintainer`) or cherry-picked tool factories.
+- **Narrow scope**: Prefer a preset (`code-review`, `issue-triage`, `repo-explorer`, `ci-ops`, `security-audit`, `release-manager`, `discussion-moderator`, `notification-inbox`, `pr-author`, `maintainer`) or cherry-picked tool factories. For multi-role products, use a manager with preset-scoped sub-agents (`/examples/manager-agent-with-subagents`).
 
 ## Install (required)
 
@@ -116,9 +116,12 @@ See `./references/eve-agents.md` and `/deprecated/eve`.
 | `ci-ops` | Actions workflows, runs, trigger/cancel/rerun |
 | `security-audit` | Vulnerability scanning, risk reporting |
 | `release-manager` | Changelog generation, release cutting |
+| `discussion-moderator` | Discussions list/get/comment plus light issue context |
+| `notification-inbox` | User notification triage (needs Notifications PAT) |
+| `pr-author` | Branches, file edits, open/update PRs |
 | `maintainer` | All 75 tools |
 
-Array presets merge: `preset: ['code-review', 'issue-triage']`.
+Array presets merge: `preset: ['code-review', 'issue-triage']`. Start with the smallest preset that fits; use `maintainer` when you need the full catalog. Multi-role: manager + sub-agents each with one preset.
 
 ## Working context
 

--- a/apps/docs/skills/github-tools-agents/references/existing-project-integration.md
+++ b/apps/docs/skills/github-tools-agents/references/existing-project-integration.md
@@ -33,8 +33,9 @@ pnpm add workflow @ai-sdk/workflow
 
 ## 4. Scope tools
 
-- Start with a **preset** to limit reachable GitHub APIs (`code-review`, `issue-triage`, …).
-- Expand to `maintainer` or omit preset only when the app must perform every operation.
+- Start with a **preset** to limit reachable GitHub APIs (`code-review`, `issue-triage`, `discussion-moderator`, `pr-author`, …).
+- Use `maintainer` or omit preset when the app needs the full catalog.
+- Multi-role products: manager + sub-agents each with one preset (`/examples/manager-agent-with-subagents`).
 
 ## 5. Token permissions
 

--- a/packages/github-tools-eve-extension/README.md
+++ b/packages/github-tools-eve-extension/README.md
@@ -91,7 +91,7 @@ extension/
 | `token` | `string?` | Falls back to `GITHUB_TOKEN` when omitted and `connector` is not set |
 | `connector` | `string \| (() => string \| Promise<string>)` (optional) | Vercel Connect connector name, or a resolver to pick one dynamically (e.g. per environment/tenant); takes priority over `token` |
 | `connect` | `record?` | Passed through to `getToken` when `connector` is set |
-| `preset` | preset name or array | `code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `security-audit`, `release-manager`, `maintainer` |
+| `preset` | preset name or array | `code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `security-audit`, `release-manager`, `discussion-moderator`, `notification-inbox`, `pr-author`, `maintainer` |
 | `include` | `string[]?` | Tool names to add on top of `preset` (union), or the full set standalone |
 | `exclude` | `string[]?` | Tool names to remove from the resolved `preset` + `include` set |
 | `context` | `{ owner?, repo?, pullNumber?, issueNumber?, ref? }?` | Default working context for tool inputs and schemas |

--- a/packages/github-tools-eve-extension/extension/extension.ts
+++ b/packages/github-tools-eve-extension/extension/extension.ts
@@ -42,7 +42,7 @@ export interface GithubExtensionConfig {
   connector?: GithubConnectorInput
   /** Vercel Connect token params passed through to `getToken` when `connector` is set. */
   connect?: Record<string, unknown>
-  /** Restrict tools to a preset (or array of presets). Omit for all tools. */
+  /** Restrict tools to a preset (or array of presets). Prefer a focused preset; omit or use `maintainer` for the full catalog. */
   preset?: GithubToolPreset | GithubToolPreset[]
   /**
    * Hand-pick tool names to add on top of `preset` (or standalone, without `preset`).
@@ -71,7 +71,18 @@ export interface GithubExtensionConfig {
   coAuthors?: CommitIdentity[]
 }
 
-const presetNameSchema = z.enum(['code-review', 'issue-triage', 'ci-ops', 'repo-explorer', 'security-audit', 'release-manager', 'maintainer'])
+const presetNameSchema = z.enum([
+  'code-review',
+  'issue-triage',
+  'ci-ops',
+  'repo-explorer',
+  'security-audit',
+  'release-manager',
+  'discussion-moderator',
+  'notification-inbox',
+  'pr-author',
+  'maintainer',
+])
 const toolNameSchema = z.enum(Object.values(GITHUB_TOOL_NAMES) as [GithubToolName, ...GithubToolName[]])
 
 const commitIdentitySchema = z.object({

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -81,7 +81,16 @@ createGithubTools({ token, preset: 'security-audit' })
 // Release manager: releases, compare diff, commits, workflow runs, pull requests
 createGithubTools({ token, preset: 'release-manager' })
 
-// Full maintenance: all tools
+// Discussion moderator: Discussions plus light issue context
+createGithubTools({ token, preset: 'discussion-moderator' })
+
+// Notification inbox: triage user notifications (needs a Notifications PAT)
+createGithubTools({ token, preset: 'notification-inbox' })
+
+// PR author: branches, file edits, and opening PRs
+createGithubTools({ token, preset: 'pr-author' })
+
+// Full catalog: all tools (same as omitting preset)
 createGithubTools({ token, preset: 'maintainer' })
 ```
 
@@ -99,9 +108,12 @@ createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
 | `ci-ops` | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `listCheckRuns`, `getCombinedStatus`, `getCiFailureContext`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `getRepository`, `listBranches`, `listCommits`, `getCommit` |
 | `security-audit` | Read-only exploration (`getFileContent`, `getRepositoryTree`, `searchCode`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`), PR and CI visibility, plus `createIssue`, `addIssueComment`, `addLabels` to report findings (no destructive writes) |
 | `release-manager` | `listReleases`, `getLatestRelease`, `getRelease`, `getReleaseContext`, `createRelease`, `updateRelease`, `deleteRelease`, `compareCommits`, `listCommits`, `getCommit`, `listWorkflowRuns`, `getWorkflowRun`, `listPullRequests`, `getPullRequest`, `getRepository`, `listBranches` |
+| `discussion-moderator` | `listDiscussions`, `getDiscussion`, `addDiscussionComment`, `getRepository`, `searchIssues`, `getIssueContext`, `addIssueComment` |
+| `notification-inbox` | `listNotifications`, `markNotificationRead`, `getIssue`, `getPullRequest`, `getRepository` (requires a Notifications PAT) |
+| `pr-author` | `getRepository`, `listBranches`, `getFileContent`, `createBranch`, `createOrUpdateFile`, `createPullRequest`, `updatePullRequest`, `getPullRequest`, `listPullRequestFiles`, `compareCommits`, `getCommit` |
 | `maintainer` | All 75 tools |
 
-Omit `preset` to get all tools (same as `maintainer`). Full breakdown: [Tools Catalog](https://github-tools.com/api/tools-catalog).
+Start with the smallest preset that fits. Use `maintainer` or omit `preset` when you need the full catalog. Full breakdown: [Tools Catalog](https://github-tools.com/api/tools-catalog).
 
 ### Cherry-Picking Tools
 
@@ -639,7 +651,7 @@ type GithubToolsOptions = {
 
 type GithubTokenInput = string | (() => Promise<string>)
 
-type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'ci-ops' | 'security-audit' | 'release-manager' | 'maintainer'
+type GithubToolPreset = 'code-review' | 'issue-triage' | 'repo-explorer' | 'ci-ops' | 'security-audit' | 'release-manager' | 'discussion-moderator' | 'notification-inbox' | 'pr-author' | 'maintainer'
 ```
 
 ### `createGithubAgent(options)`
@@ -649,13 +661,7 @@ Returns a `ToolLoopAgent` instance with `.generate()` and `.stream()` methods, p
 ```ts
 import { createGithubAgent } from '@github-tools/sdk'
 
-// Minimal: all tools, generic prompt
-const agent = createGithubAgent({
-  model: 'anthropic/claude-sonnet-4.6',
-  token: process.env.GITHUB_TOKEN!,
-})
-
-// With preset: scoped tools + tailored prompt
+// Prefer a preset: scoped tools + tailored prompt
 const reviewer = createGithubAgent({
   model: 'anthropic/claude-sonnet-4.6',
   token: process.env.GITHUB_TOKEN!,
@@ -669,6 +675,13 @@ const triager = createGithubAgent({
   token: process.env.GITHUB_TOKEN!,
   preset: 'issue-triage',
   additionalInstructions: 'Focus on the nuxt/ui repository. Always respond in French.',
+})
+
+// Full catalog (omit preset or use maintainer)
+const agent = createGithubAgent({
+  model: 'anthropic/claude-sonnet-4.6',
+  token: process.env.GITHUB_TOKEN!,
+  preset: 'maintainer',
 })
 
 // Full override: replace the built-in prompt entirely
@@ -747,7 +760,7 @@ async function agentTurn(prompt: string) {
 
 > See [`examples/pr-review-agent`](../../examples/pr-review-agent) for a complete PR review agent built with Chat SDK and Vercel Workflow.
 
-All presets (`code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `security-audit`, `release-manager`, `maintainer`) work with `createDurableGithubAgent`. Options mirror `createGithubAgent` with additional pass-through for `WorkflowAgentOptions` fields like `experimental_telemetry`, `onStepEnd`, `onEnd`, and `prepareStep`. Write tools honor `requireApproval` via `needsApproval`.
+All presets (`code-review`, `issue-triage`, `ci-ops`, `repo-explorer`, `security-audit`, `release-manager`, `discussion-moderator`, `notification-inbox`, `pr-author`, `maintainer`) work with `createDurableGithubAgent`. Options mirror `createGithubAgent` with additional pass-through for `WorkflowAgentOptions` fields like `experimental_telemetry`, `onStepEnd`, `onEnd`, and `prepareStep`. Write tools honor `requireApproval` via `needsApproval`.
 
 ### `resolveGithubToken(token?)`
 

--- a/packages/github-tools/src/agents.ts
+++ b/packages/github-tools/src/agents.ts
@@ -87,6 +87,37 @@ When preparing a release:
 
 ${SHARED_RULES}`,
 
+  'discussion-moderator': `You are a discussion moderator. Your job is to answer and guide repository Discussions clearly and on-topic.
+
+When working in discussions:
+- Use listDiscussions / getDiscussion to load the thread before replying
+- Prefer addDiscussionComment for answers that belong in Discussions
+- Use searchIssues / getIssueContext when the question overlaps an existing issue; addIssueComment only when the follow-up belongs on that issue
+- Keep replies concise and point to docs or code when helpful
+
+${SHARED_RULES}`,
+
+  'notification-inbox': `You are a notification inbox assistant. Your job is to help triage GitHub notification threads for the authenticated user.
+
+When clearing the inbox:
+- Use listNotifications to see unread threads (set all true only when asked)
+- Open the related getIssue or getPullRequest when you need context before acting
+- Use markNotificationRead once a thread is handled or is noise
+- These tools need a user PAT with Notifications access — say so if calls fail for that reason
+
+${SHARED_RULES}`,
+
+  'pr-author': `You are a pull request authoring assistant. Your job is to prepare branches, edit files, and open focused PRs.
+
+When opening a PR:
+- Inspect the repo with getRepository / listBranches / getFileContent before editing
+- createBranch from a sensible base, then createOrUpdateFile for the change set
+- createPullRequest with a clear title and body; updatePullRequest if the draft or description needs a fix
+- Use listPullRequestFiles / compareCommits / getCommit to verify what will land
+- Stay scoped to authoring — you do not review, merge, or manage issues
+
+${SHARED_RULES}`,
+
   'maintainer': `You are a repository maintainer assistant. You have full access to manage repositories, issues, pull requests, discussions, notifications, gists, and workflows.
 
 When maintaining repos:

--- a/packages/github-tools/src/connect/scopes.test.ts
+++ b/packages/github-tools/src/connect/scopes.test.ts
@@ -43,4 +43,17 @@ describe('connectGithubScopesForPreset', () => {
       expect.arrayContaining(['administration:read', 'administration:write']),
     )
   })
+
+  it('maps discussion-moderator and pr-author scopes', () => {
+    expect(connectGithubScopesForPreset('discussion-moderator')).toEqual(
+      expect.arrayContaining(['discussions:read', 'discussions:write', 'issues:write']),
+    )
+    expect(connectGithubScopesForPreset('pr-author')).toEqual([
+      'contents:read',
+      'contents:write',
+      'metadata:read',
+      'pull_requests:read',
+      'pull_requests:write',
+    ])
+  })
 })

--- a/packages/github-tools/src/connect/scopes.ts
+++ b/packages/github-tools/src/connect/scopes.ts
@@ -16,10 +16,10 @@ import type { GithubToolPreset } from '../core/presets'
  * regardless of requested scopes — use a fine-grained PAT with the "Gists"
  * account permission for those tools instead.
  *
- * Notification tools in `maintainer` are unscoped for the same reason:
- * `notifications` is an account-level GitHub App permission that only applies
- * to user access tokens, so `listNotifications` / `markNotificationRead` need
- * a PAT with the "Notifications" account permission.
+ * Notification tools in `maintainer` and `notification-inbox` are unscoped for
+ * the same reason: `notifications` is an account-level GitHub App permission
+ * that only applies to user access tokens, so `listNotifications` /
+ * `markNotificationRead` need a PAT with the "Notifications" account permission.
  */
 export const PRESET_CONNECT_SCOPES = {
   'repo-explorer': [
@@ -71,6 +71,27 @@ export const PRESET_CONNECT_SCOPES = {
     'pull_requests:read',
     'actions:read',
     'actions:write',
+  ],
+  'discussion-moderator': [
+    'contents:read',
+    'metadata:read',
+    'issues:read',
+    'issues:write',
+    'discussions:read',
+    'discussions:write',
+  ],
+  'notification-inbox': [
+    'contents:read',
+    'metadata:read',
+    'pull_requests:read',
+    'issues:read',
+  ],
+  'pr-author': [
+    'contents:read',
+    'contents:write',
+    'metadata:read',
+    'pull_requests:read',
+    'pull_requests:write',
   ],
   'maintainer': [
     'contents:read',

--- a/packages/github-tools/src/core/presets.ts
+++ b/packages/github-tools/src/core/presets.ts
@@ -112,6 +112,45 @@ export const PRESET_TOOLS = {
     'listPullRequests', 'getPullRequest',
   ],
   /**
+   * **Discussion moderator** — answer and moderate repository Discussions.
+   *
+   * Tools: `listDiscussions`, `getDiscussion`, `addDiscussionComment`,
+   * `getRepository`, `searchIssues`, `getIssueContext`, `addIssueComment`.
+   *
+   * Prefer discussions for Q&A; link related issues with `getIssueContext` / `addIssueComment` when needed.
+   * Agent prompt: optimized for clear, on-topic discussion replies.
+   */
+  'discussion-moderator': [
+    'listDiscussions', 'getDiscussion', 'addDiscussionComment',
+    'getRepository', 'searchIssues', 'getIssueContext', 'addIssueComment',
+  ],
+  /**
+   * **Notification inbox** — triage authenticated-user notification threads.
+   *
+   * Tools: `listNotifications`, `markNotificationRead`, `getIssue`, `getPullRequest`, `getRepository`.
+   *
+   * Requires a user PAT with the Notifications account permission — not available on Connect installation tokens.
+   * Agent prompt: optimized for clearing inbox noise and following up on actionable threads.
+   */
+  'notification-inbox': [
+    'listNotifications', 'markNotificationRead',
+    'getIssue', 'getPullRequest', 'getRepository',
+  ],
+  /**
+   * **PR author** — open pull requests without the full write surface.
+   *
+   * Tools: `getRepository`, `listBranches`, `getFileContent`, `createBranch`, `createOrUpdateFile`,
+   * `createPullRequest`, `updatePullRequest`, `getPullRequest`, `listPullRequestFiles`,
+   * `compareCommits`, `getCommit`.
+   *
+   * Agent prompt: optimized for branching, editing files, and opening focused PRs.
+   */
+  'pr-author': [
+    'getRepository', 'listBranches', 'getFileContent', 'createBranch', 'createOrUpdateFile',
+    'createPullRequest', 'updatePullRequest', 'getPullRequest', 'listPullRequestFiles',
+    'compareCommits', 'getCommit',
+  ],
+  /**
    * **Maintainer** — full repository maintenance with all read and write tools.
    *
    * Tools: all tools (same as omitting `preset`).

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -33,7 +33,7 @@ export { GITHUB_WRITE_TOOLS } from './core/write-tools'
 export type GithubToolsOptions = GithubToolsBaseOptions & {
   /**
    * Restrict the returned tools to a predefined preset.
-   * Omit to get all tools.
+   * Prefer a focused preset for most agents. Omit or use `maintainer` for the full catalog.
    *
    * @see {@link GithubToolPreset} for available presets and included tools.
    *
@@ -44,6 +44,9 @@ export type GithubToolsOptions = GithubToolsBaseOptions & {
    *
    * // Combine presets
    * createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
+   *
+   * // Full catalog
+   * createGithubTools({ token, preset: 'maintainer' })
    * ```
    */
   preset?: GithubToolPreset | GithubToolPreset[]
@@ -62,14 +65,11 @@ export function createGithubTools(options?: GithubToolsOptions): AllGithubTools 
  *
  * Write operations require user approval by default.
  * Control this globally or per-tool via `requireApproval`.
- * Use `preset` to get only the tools you need.
+ * Prefer `preset` to expose only the tools your agent needs.
  * Pass `context` to default owner/repo/PR/issue/ref on tool inputs.
  *
  * @example
  * ```ts
- * // All tools (default)
- * createGithubTools({ token })
- *
  * // Code-review agent — only PR & commit tools
  * createGithubTools({ token, preset: 'code-review' })
  *
@@ -82,6 +82,9 @@ export function createGithubTools(options?: GithubToolsOptions): AllGithubTools 
  *
  * // Combine presets
  * createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
+ *
+ * // Full catalog (same as omitting preset)
+ * createGithubTools({ token, preset: 'maintainer' })
  *
  * // Granular approval
  * createGithubTools({


### PR DESCRIPTION
## Summary
- Add three focused presets: `discussion-moderator`, `notification-inbox`, and `pr-author` (tools, Connect scopes, agent prompts, eve extension schema)
- Lead docs, README, JSDoc, and the agent skill with presets and manager/sub-agents composition; keep `maintainer` / omit `preset` as full-catalog options
- Minor changeset for `@github-tools/sdk` and `@github-tools/eve-extension`

## Test plan
- [ ] `pnpm build && pnpm lint && pnpm typecheck`
- [ ] `pnpm --filter @github-tools/sdk exec vitest run src/connect/scopes.test.ts`
- [ ] Spot-check `/guide/presets` and intro for the new presets and composition section
- [ ] Confirm `githubExtension({ preset: 'pr-author' })` typechecks against the eve schema enum