### PR TITLE
fix(sdk): derive Connect scopes from include/exclude

### DIFF
--- a/.changeset/connect-scopes-from-include.md
+++ b/.changeset/connect-scopes-from-include.md
@@ -1,0 +1,6 @@
+---
+"@github-tools/sdk": patch
+"@github-tools/eve-extension": patch
+---
+
+Derive Connect scopes from the resolved `include` / `exclude` tool set instead of minting the full preset union (including `administration:write`) when `preset` is omitted.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Every tool splits into a **core** function (pure logic) and a **tool factory** (
    - `packages/github-tools/src/core/presets.ts` — add to every preset it belongs in (update each preset's JSDoc tool list too)
    - `packages/github-tools/src/index.ts` — add to `allTools` in `createGithubTools()`, re-export the factory at the bottom
    - `packages/github-tools/src/eve/registry.ts` — add an entry so the tool is reachable from `defineDynamic` (direct eve import) and the eve extension
-   - `packages/github-tools/src/connect/scopes.ts` — add any new Vercel Connect scope the tool needs to `PRESET_CONNECT_SCOPES` for every preset that includes it
+   - `packages/github-tools/src/connect/scopes.ts` — add any new Vercel Connect scope the tool needs to `PRESET_CONNECT_SCOPES` for every preset that includes it, and to `TOOL_CONNECT_SCOPES` for the tool itself (used when `include` / `exclude` derive scopes)
    - `packages/github-tools/src/agents.ts` — mention the tool in `PRESET_INSTRUCTIONS` for presets where it changes the agent's behavior
 4. **Chat app metadata** — add a `GITHUB_TOOL_META` entry in `apps/chat/shared/utils/tools/github.ts`
 5. **Documentation**:

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -156,7 +156,7 @@ export default githubExtension({
 })
 ```
 
-`include` **adds** to `preset`. The effective set is the **union** of both, so you can pull in a tool a preset is missing without switching to a bigger preset:
+`include` **adds** to `preset`. The effective set is the **union** of both, so you can pull in a tool a preset is missing without switching to a bigger preset. When `connector` is set and `connect.scopes` is omitted, Connect scopes follow that same resolved tool set — a standalone `include` does not mint the full admin union:
 
 ```ts [agent/extensions/github.ts]
 export default githubExtension({

--- a/apps/docs/content/docs/4.guide/5.vercel-connect.md
+++ b/apps/docs/content/docs/4.guide/5.vercel-connect.md
@@ -107,7 +107,7 @@ const tools = createGithubTools({
 })
 ```
 
-Pass the same `preset` to both calls. `connectGithubToken` derives Connect scopes from its own `preset` option, independently of the one you give `createGithubTools`. Omitting it mints a token scoped to the union of every preset instead of just `ci-ops`.
+Pass the same `preset` (and the same `include` / `exclude`, when you use them) to both calls. `connectGithubToken` derives Connect scopes from its own selection options, independently of the ones you give `createGithubTools`. Omitting `preset` with no `include` mints a token scoped to the union of every preset. Passing `include` alone derives scopes from that tool set — it does **not** mint the full admin union.
 
 ## Multi-tenant and repository scoping
 

--- a/apps/docs/content/docs/5.api/2.reference.md
+++ b/apps/docs/content/docs/5.api/2.reference.md
@@ -388,11 +388,19 @@ const tools = createGithubTools({
 })
 ```
 
-Pass the same `preset` to `connectGithubToken`: it derives Connect scopes independently of the `preset` given to `createGithubTools`.
+Pass the same `preset` (and the same `include` / `exclude`, when you use them) to `connectGithubToken`: it derives Connect scopes independently of the selection given to `createGithubTools`. With `include` alone, scopes follow the selected tools rather than the full preset union.
 
 ## `connectGithubScopesForPreset(preset?)`
 
 Returns Vercel Connect scope strings for a preset or combined presets. Without a preset, returns the union of all preset scopes.
+
+## `connectGithubScopesForSelection({ preset?, include?, exclude? })`
+
+Same mapping as `connectGithubToken` uses when `params.scopes` is omitted. With no `include` / `exclude`, identical to `connectGithubScopesForPreset`. When either is set, scopes are derived from the resolved tool names via `connectGithubScopesForTools`.
+
+## `connectGithubScopesForTools(names)`
+
+Returns the Connect scopes covering exactly the given tool names. Always includes `metadata:read`. Gist and notification tools contribute no scopes (installation tokens cannot call those APIs).
 
 ## `resolveGithubToken(token?)`
 

--- a/packages/github-tools-eve-extension/extension/tools/github.ts
+++ b/packages/github-tools-eve-extension/extension/tools/github.ts
@@ -40,15 +40,23 @@ export default defineDynamic({
         coAuthors,
       } = extension.config
 
+      const includeNames = include as GithubToolName[] | undefined
+      const excludeNames = exclude as GithubToolName[] | undefined
+
       const resolvedToken = connector
-        ? connectGithubToken(connector, { preset, params: connect })
+        ? connectGithubToken(connector, {
+            preset,
+            include: includeNames,
+            exclude: excludeNames,
+            params: connect,
+          })
         : token
 
       sessionOptions = {
         token: resolvedToken,
         preset,
-        include: include as GithubToolName[] | undefined,
-        exclude: exclude as GithubToolName[] | undefined,
+        include: includeNames,
+        exclude: excludeNames,
         requireApproval: requireApproval as EveApprovalConfig | undefined,
         overrides: overrides as EveToolOverrides | undefined,
         context,

--- a/packages/github-tools/src/connect/eve.ts
+++ b/packages/github-tools/src/connect/eve.ts
@@ -5,7 +5,8 @@ import type { ConnectGithubEveToolsOptions } from './types'
 
 /**
  * Register eve GitHub tools backed by a Vercel Connect connector.
- * Scopes are derived from `preset` unless overridden in `connect.scopes`.
+ * Scopes are derived from `preset`, or from the resolved `include`/`exclude`
+ * tool set when those are set, unless overridden in `connect.scopes`.
  *
  * `connector` may be a static name or a resolver function — e.g. to pick a
  * different connector per environment (production vs. preview) or tenant.
@@ -29,11 +30,13 @@ export function connectGithubTools(
   connector: GithubConnectorInput,
   options: ConnectGithubEveToolsOptions = {},
 ) {
-  const { connect, preset, ...rest } = options
+  const { connect, preset, include, exclude, ...rest } = options
 
   return createEveGithubTools({
     ...rest,
     preset,
-    token: connectGithubToken(connector, { preset, params: connect }),
+    include,
+    exclude,
+    token: connectGithubToken(connector, { preset, include, exclude, params: connect }),
   })
 }

--- a/packages/github-tools/src/connect/index.ts
+++ b/packages/github-tools/src/connect/index.ts
@@ -1,6 +1,13 @@
 export { resolveGithubConnector } from './connector'
 export type { GithubConnectorInput } from './connector'
-export { PRESET_CONNECT_SCOPES, connectGithubScopesForPreset } from './scopes'
+export {
+  PRESET_CONNECT_SCOPES,
+  TOOL_CONNECT_SCOPES,
+  connectGithubScopesForPreset,
+  connectGithubScopesForSelection,
+  connectGithubScopesForTools,
+} from './scopes'
+export type { ConnectScopeSelection } from './scopes'
 export { connectGithubToken } from './token'
 export { connectGithubTools } from './tools'
 export type {

--- a/packages/github-tools/src/connect/params.ts
+++ b/packages/github-tools/src/connect/params.ts
@@ -1,12 +1,12 @@
 import type { ConnectTokenParams } from '@vercel/connect'
-import { connectGithubScopesForPreset } from './scopes'
+import { connectGithubScopesForSelection } from './scopes'
 import type { ConnectGithubTokenOptions, GithubConnectParams } from './types'
 
 export function resolveGithubConnectTokenParams(
   options: ConnectGithubTokenOptions = {},
 ): ConnectTokenParams {
-  const { preset, params } = options
-  const scopes = params?.scopes ?? connectGithubScopesForPreset(preset)
+  const { preset, include, exclude, params } = options
+  const scopes = params?.scopes ?? connectGithubScopesForSelection({ preset, include, exclude })
   return buildConnectTokenParams(scopes, params)
 }
 

--- a/packages/github-tools/src/connect/scopes.test.ts
+++ b/packages/github-tools/src/connect/scopes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { PRESET_CONNECT_SCOPES, connectGithubScopesForPreset } from './scopes'
+import {
+  PRESET_CONNECT_SCOPES,
+  connectGithubScopesForPreset,
+  connectGithubScopesForSelection,
+  connectGithubScopesForTools,
+} from './scopes'
 
 describe('connectGithubScopesForPreset', () => {
   it('returns scopes for a single preset', () => {
@@ -55,5 +60,64 @@ describe('connectGithubScopesForPreset', () => {
       'pull_requests:read',
       'pull_requests:write',
     ])
+  })
+})
+
+describe('connectGithubScopesForTools', () => {
+  it('always includes metadata:read', () => {
+    expect(connectGithubScopesForTools(['getRepository'])).toEqual([
+      'contents:read',
+      'metadata:read',
+    ])
+  })
+
+  it('does not request administration for a hand-picked read set', () => {
+    const scopes = connectGithubScopesForTools(['getRepository', 'listIssues', 'addLabels'])
+    expect(scopes).toEqual([
+      'contents:read',
+      'metadata:read',
+      'issues:read',
+      'issues:write',
+    ])
+    expect(scopes).not.toEqual(expect.arrayContaining(['administration:write']))
+  })
+
+  it('requests administration only when createRepository is selected', () => {
+    expect(connectGithubScopesForTools(['createRepository'])).toEqual([
+      'metadata:read',
+      'administration:read',
+      'administration:write',
+    ])
+  })
+})
+
+describe('connectGithubScopesForSelection', () => {
+  it('falls back to preset mapping when include/exclude are omitted', () => {
+    expect(connectGithubScopesForSelection({ preset: 'code-review' })).toEqual(
+      connectGithubScopesForPreset('code-review'),
+    )
+  })
+
+  it('derives scopes from include without minting the full union', () => {
+    const scopes = connectGithubScopesForSelection({
+      include: ['getRepository', 'listIssues', 'addLabels'],
+    })
+    expect(scopes).toEqual([
+      'contents:read',
+      'metadata:read',
+      'issues:read',
+      'issues:write',
+    ])
+    expect(scopes).not.toContain('administration:write')
+  })
+
+  it('drops administration when createRepository is excluded from maintainer', () => {
+    const scopes = connectGithubScopesForSelection({
+      preset: 'maintainer',
+      exclude: ['createRepository'],
+    })
+    expect(scopes).not.toContain('administration:write')
+    expect(scopes).not.toContain('administration:read')
+    expect(scopes).toEqual(expect.arrayContaining(['issues:write', 'pull_requests:write']))
   })
 })

--- a/packages/github-tools/src/connect/scopes.test.ts
+++ b/packages/github-tools/src/connect/scopes.test.ts
@@ -89,6 +89,16 @@ describe('connectGithubScopesForTools', () => {
       'administration:write',
     ])
   })
+
+  it('does not request pull_requests:write for getPullRequestContext', () => {
+    expect(connectGithubScopesForTools(['getPullRequestContext'])).toEqual([
+      'contents:read',
+      'metadata:read',
+      'pull_requests:read',
+      'checks:read',
+      'statuses:read',
+    ])
+  })
 })
 
 describe('connectGithubScopesForSelection', () => {

--- a/packages/github-tools/src/connect/scopes.ts
+++ b/packages/github-tools/src/connect/scopes.ts
@@ -141,7 +141,8 @@ const CONTENTS_READ = ['contents:read', 'metadata:read'] as const
 const CONTENTS_WRITE = ['contents:read', 'contents:write', 'metadata:read'] as const
 const PR_READ = ['contents:read', 'metadata:read', 'pull_requests:read'] as const
 const PR_WRITE = ['contents:read', 'metadata:read', 'pull_requests:read', 'pull_requests:write'] as const
-const PR_REVIEW = ['contents:read', 'metadata:read', 'pull_requests:read', 'pull_requests:write', 'checks:read', 'statuses:read'] as const
+/** Read-only PR context (details, files, reviews) plus optional CI checks. */
+const PR_CONTEXT = ['contents:read', 'metadata:read', 'pull_requests:read', 'checks:read', 'statuses:read'] as const
 const ISSUES_READ = ['contents:read', 'metadata:read', 'issues:read'] as const
 const ISSUES_WRITE = ['contents:read', 'metadata:read', 'issues:read', 'issues:write'] as const
 const DISCUSSIONS_READ = ['contents:read', 'metadata:read', 'discussions:read'] as const
@@ -181,7 +182,7 @@ export const TOOL_CONNECT_SCOPES = {
   listPullRequestReviews: PR_READ,
   createPullRequestReview: PR_WRITE,
   requestReviewers: PR_WRITE,
-  getPullRequestContext: PR_REVIEW,
+  getPullRequestContext: PR_CONTEXT,
 
   listIssues: ISSUES_READ,
   getIssue: ISSUES_READ,
@@ -195,6 +196,9 @@ export const TOOL_CONNECT_SCOPES = {
   listLabels: ISSUES_READ,
   addLabels: ISSUES_WRITE,
   removeLabel: ISSUES_WRITE,
+  createLabel: ISSUES_WRITE,
+  updateLabel: ISSUES_WRITE,
+  deleteLabel: ISSUES_WRITE,
   addAssignees: ISSUES_WRITE,
   removeAssignees: ISSUES_WRITE,
 

--- a/packages/github-tools/src/connect/scopes.ts
+++ b/packages/github-tools/src/connect/scopes.ts
@@ -1,4 +1,5 @@
-import type { GithubToolPreset } from '../core/presets'
+import { resolvePresetTools, type GithubToolPreset } from '../core/presets'
+import { ALL_GITHUB_TOOL_NAMES, type GithubToolName } from '../core/tool-names'
 
 /**
  * Vercel Connect scope strings mapped to each {@link GithubToolPreset}.
@@ -117,6 +118,140 @@ const ALL_CONNECT_SCOPES = [
   ...new Set(Object.values(PRESET_CONNECT_SCOPES).flat()),
 ] as string[]
 
+/** Stable scope order for tool-derived unions (tests + Connect payloads). */
+const SCOPE_ORDER = [
+  'contents:read',
+  'contents:write',
+  'metadata:read',
+  'pull_requests:read',
+  'pull_requests:write',
+  'issues:read',
+  'issues:write',
+  'discussions:read',
+  'discussions:write',
+  'actions:read',
+  'actions:write',
+  'checks:read',
+  'statuses:read',
+  'administration:read',
+  'administration:write',
+] as const
+
+const CONTENTS_READ = ['contents:read', 'metadata:read'] as const
+const CONTENTS_WRITE = ['contents:read', 'contents:write', 'metadata:read'] as const
+const PR_READ = ['contents:read', 'metadata:read', 'pull_requests:read'] as const
+const PR_WRITE = ['contents:read', 'metadata:read', 'pull_requests:read', 'pull_requests:write'] as const
+const PR_REVIEW = ['contents:read', 'metadata:read', 'pull_requests:read', 'pull_requests:write', 'checks:read', 'statuses:read'] as const
+const ISSUES_READ = ['contents:read', 'metadata:read', 'issues:read'] as const
+const ISSUES_WRITE = ['contents:read', 'metadata:read', 'issues:read', 'issues:write'] as const
+const DISCUSSIONS_READ = ['contents:read', 'metadata:read', 'discussions:read'] as const
+const DISCUSSIONS_WRITE = ['contents:read', 'metadata:read', 'discussions:read', 'discussions:write'] as const
+const ACTIONS_READ = ['contents:read', 'metadata:read', 'actions:read'] as const
+const ACTIONS_WRITE = ['contents:read', 'metadata:read', 'actions:read', 'actions:write'] as const
+const CHECKS = ['contents:read', 'metadata:read', 'checks:read', 'statuses:read'] as const
+const CI_CONTEXT = ['contents:read', 'metadata:read', 'actions:read', 'checks:read', 'statuses:read'] as const
+const ADMIN = ['metadata:read', 'administration:read', 'administration:write'] as const
+const SEARCH_REPOS = ['metadata:read'] as const
+const SEARCH_ISSUES = ['metadata:read', 'issues:read', 'pull_requests:read'] as const
+const UNSCOPED = [] as const
+
+/**
+ * Per-tool Connect scopes. Empty arrays are intentional for gist and
+ * notification tools (installation tokens cannot satisfy those APIs).
+ */
+export const TOOL_CONNECT_SCOPES = {
+  getRepository: CONTENTS_READ,
+  listBranches: CONTENTS_READ,
+  getFileContent: CONTENTS_READ,
+  getRepositoryTree: CONTENTS_READ,
+  createBranch: CONTENTS_WRITE,
+  forkRepository: CONTENTS_READ,
+  createRepository: ADMIN,
+  createOrUpdateFile: CONTENTS_WRITE,
+
+  listPullRequests: PR_READ,
+  getPullRequest: PR_READ,
+  createPullRequest: PR_WRITE,
+  mergePullRequest: PR_WRITE,
+  updatePullRequest: PR_WRITE,
+  addPullRequestComment: PR_WRITE,
+  updatePullRequestComment: PR_WRITE,
+  deletePullRequestComment: PR_WRITE,
+  listPullRequestFiles: PR_READ,
+  listPullRequestReviews: PR_READ,
+  createPullRequestReview: PR_WRITE,
+  requestReviewers: PR_WRITE,
+  getPullRequestContext: PR_REVIEW,
+
+  listIssues: ISSUES_READ,
+  getIssue: ISSUES_READ,
+  getIssueContext: ISSUES_READ,
+  createIssue: ISSUES_WRITE,
+  addIssueComment: ISSUES_WRITE,
+  updateIssueComment: ISSUES_WRITE,
+  deleteIssueComment: ISSUES_WRITE,
+  closeIssue: ISSUES_WRITE,
+  updateIssue: ISSUES_WRITE,
+  listLabels: ISSUES_READ,
+  addLabels: ISSUES_WRITE,
+  removeLabel: ISSUES_WRITE,
+  addAssignees: ISSUES_WRITE,
+  removeAssignees: ISSUES_WRITE,
+
+  searchCode: CONTENTS_READ,
+  searchRepositories: SEARCH_REPOS,
+  searchIssues: SEARCH_ISSUES,
+
+  listCommits: CONTENTS_READ,
+  getCommit: CONTENTS_READ,
+  getBlame: CONTENTS_READ,
+  compareCommits: CONTENTS_READ,
+
+  listGists: UNSCOPED,
+  getGist: UNSCOPED,
+  listGistComments: UNSCOPED,
+  createGist: UNSCOPED,
+  updateGist: UNSCOPED,
+  deleteGist: UNSCOPED,
+  createGistComment: UNSCOPED,
+
+  listWorkflows: ACTIONS_READ,
+  listWorkflowRuns: ACTIONS_READ,
+  getWorkflowRun: ACTIONS_READ,
+  listWorkflowJobs: ACTIONS_READ,
+  triggerWorkflow: ACTIONS_WRITE,
+  cancelWorkflowRun: ACTIONS_WRITE,
+  rerunWorkflowRun: ACTIONS_WRITE,
+
+  listCheckRuns: CHECKS,
+  getCombinedStatus: CHECKS,
+  getCiFailureContext: CI_CONTEXT,
+
+  listDiscussions: DISCUSSIONS_READ,
+  getDiscussion: DISCUSSIONS_READ,
+  addDiscussionComment: DISCUSSIONS_WRITE,
+
+  listNotifications: UNSCOPED,
+  markNotificationRead: UNSCOPED,
+
+  listIssueReactions: ISSUES_READ,
+  addIssueReaction: ISSUES_WRITE,
+  listCommentReactions: ISSUES_READ,
+  addCommentReaction: ISSUES_WRITE,
+
+  listReleases: CONTENTS_READ,
+  getLatestRelease: CONTENTS_READ,
+  getRelease: CONTENTS_READ,
+  getReleaseContext: CONTENTS_READ,
+  createRelease: CONTENTS_WRITE,
+  updateRelease: CONTENTS_WRITE,
+  deleteRelease: CONTENTS_WRITE,
+} as const satisfies Record<GithubToolName, readonly string[]>
+
+function orderScopes(scopes: Set<string>): string[] {
+  return SCOPE_ORDER.filter(scope => scopes.has(scope))
+}
+
 /**
  * Returns Vercel Connect scopes for a preset or combined presets.
  * Without a preset, returns the union of all preset scopes (full tool set).
@@ -130,4 +265,58 @@ export function connectGithubScopesForPreset(
   return [
     ...new Set(presets.flatMap(p => PRESET_CONNECT_SCOPES[p])),
   ]
+}
+
+/**
+ * Returns Connect scopes covering exactly the given tools.
+ * Always includes `metadata:read`. Gist and notification tools contribute nothing.
+ */
+export function connectGithubScopesForTools(names: readonly GithubToolName[]): string[] {
+  const scopes = new Set<string>(['metadata:read'])
+  for (const name of names) {
+    for (const scope of TOOL_CONNECT_SCOPES[name]) {
+      scopes.add(scope)
+    }
+  }
+  return orderScopes(scopes)
+}
+
+export type ConnectScopeSelection = {
+  preset?: GithubToolPreset | GithubToolPreset[]
+  include?: readonly GithubToolName[]
+  exclude?: readonly GithubToolName[]
+}
+
+function resolveSelectedToolNames({
+  preset,
+  include,
+  exclude,
+}: ConnectScopeSelection): GithubToolName[] {
+  const presetAllowed = preset ? resolvePresetTools(preset) : null
+  const includeAllowed = include ? new Set(include) : null
+  const excluded = exclude ? new Set(exclude) : null
+
+  const allowed = presetAllowed && includeAllowed
+    ? new Set([...presetAllowed, ...includeAllowed])
+    : presetAllowed ?? includeAllowed
+
+  return ALL_GITHUB_TOOL_NAMES.filter(
+    name => (!allowed || allowed.has(name)) && !excluded?.has(name),
+  )
+}
+
+/**
+ * Resolves Connect scopes for the effective tool set.
+ *
+ * - No `include` / `exclude`: same as {@link connectGithubScopesForPreset}
+ *   (omitted preset → full union, including `administration:write`).
+ * - With `include` and/or `exclude`: scopes are derived from the resolved tools
+ *   so a hand-picked `include` list does not mint the full admin surface.
+ */
+export function connectGithubScopesForSelection(selection: ConnectScopeSelection = {}): string[] {
+  const { preset, include, exclude } = selection
+  if (!include && !exclude) {
+    return connectGithubScopesForPreset(preset)
+  }
+  return connectGithubScopesForTools(resolveSelectedToolNames(selection))
 }

--- a/packages/github-tools/src/connect/token.test.ts
+++ b/packages/github-tools/src/connect/token.test.ts
@@ -58,6 +58,23 @@ describe('connectGithubToken', () => {
     }, undefined)
   })
 
+  it('derives scopes from include without requesting administration', async () => {
+    const resolve = resolveConnectToken('github/my-connector', {
+      include: ['getRepository', 'listIssues', 'addLabels'],
+    })
+
+    await resolve()
+    expect(getToken).toHaveBeenCalledWith('github/my-connector', {
+      subject: { type: 'app' },
+      scopes: [
+        'contents:read',
+        'metadata:read',
+        'issues:read',
+        'issues:write',
+      ],
+    }, undefined)
+  })
+
   it('maps repositories to github_app_installation authorization details', async () => {
     const resolve = resolveConnectToken('github/my-connector', {
       preset: 'issue-triage',

--- a/packages/github-tools/src/connect/token.ts
+++ b/packages/github-tools/src/connect/token.ts
@@ -6,7 +6,8 @@ import type { ConnectGithubTokenOptions } from './types'
 
 /**
  * Returns a lazy GitHub token provider backed by a Vercel Connect connector.
- * Scopes are derived from `preset` unless overridden in `params.scopes`.
+ * Scopes are derived from `preset`, or from the resolved `include`/`exclude`
+ * tool set when those are set, unless overridden in `params.scopes`.
  *
  * `connector` may be a static name or a resolver function — e.g. to pick a
  * different connector per environment (production vs. preview) or tenant.

--- a/packages/github-tools/src/connect/types.ts
+++ b/packages/github-tools/src/connect/types.ts
@@ -1,5 +1,6 @@
 import type { ConnectOptions, ConnectTokenParams } from '@vercel/connect'
 import type { GithubToolPreset } from '../core/presets'
+import type { GithubToolName } from '../core/tool-names'
 import type { GithubToolsBaseOptions } from '../core/tool-types'
 import type { EveGithubToolsOptions } from '../eve/types'
 
@@ -23,6 +24,10 @@ export type ConnectGithubEveToolsOptions = Omit<EveGithubToolsOptions, 'token'> 
 
 export type ConnectGithubTokenOptions = {
   preset?: GithubToolPreset | GithubToolPreset[]
+  /** Same allow-list semantics as eve `include` — scopes derive from the resolved tools when set. */
+  include?: readonly GithubToolName[]
+  /** Same deny-list semantics as eve `exclude` — scopes derive from the resolved tools when set. */
+  exclude?: readonly GithubToolName[]
   params?: GithubConnectParams
   connectOptions?: ConnectOptions
 }


### PR DESCRIPTION
## Summary
- When `include` / `exclude` are set, Connect scopes are derived from the resolved tool set via a per-tool scope map, instead of minting the union of every preset (including `administration:write`) whenever `preset` is omitted.
- `connect.scopes` still overrides. Preset-only selection keeps the existing `PRESET_CONNECT_SCOPES` mapping.
- Eve extension and deprecated `connect/eve` pass `include` / `exclude` through to `connectGithubToken`.

## Test plan
- [x] `pnpm --filter @github-tools/sdk test` (scopes + token tests)
- [x] `pnpm --filter @github-tools/sdk build && lint && typecheck`
- [x] `pnpm --filter @github-tools/eve-extension build && typecheck`
- [ ] Confirm an eve agent with `include: [...]` and no `preset` / no `connect.scopes` no longer requests `administration:write`