### PR TITLE
feat(sdk): expose listIssueComments as a public tool

### DIFF
--- a/.changeset/list-issue-comments.md
+++ b/.changeset/list-issue-comments.md
@@ -1,0 +1,5 @@
+---
+"@github-tools/sdk": minor
+---
+
+Expose `listIssueComments` as a public tool for paginating issue comments beyond `getIssueContext`. Included in the `issue-triage`, `repo-explorer`, and `maintainer` presets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ## Overview
 
-`@github-tools/sdk` wraps GitHub's REST API as 78 AI SDK-compatible tools for agents and `generateText`/`streamText` calls — with presets, approval control, and integrations for eve, Vercel Workflow, and Chat SDK. Docs: [github-tools.com](https://github-tools.com).
+`@github-tools/sdk` wraps GitHub's REST API as 79 AI SDK-compatible tools for agents and `generateText`/`streamText` calls — with presets, approval control, and integrations for eve, Vercel Workflow, and Chat SDK. Docs: [github-tools.com](https://github-tools.com).
 
 ## Commands
 

--- a/apps/chat/shared/utils/tools/github.ts
+++ b/apps/chat/shared/utils/tools/github.ts
@@ -35,6 +35,7 @@ export const GITHUB_TOOL_META: Record<GithubToolName, GithubToolMeta> = {
   listIssues: { title: 'List Issues', label: 'Issues listed', labelActive: 'Listing issues', icon: 'i-lucide-circle-dot' },
   getIssue: { title: 'Get Issue', label: 'Issue fetched', labelActive: 'Fetching issue', icon: 'i-lucide-circle-dot' },
   getIssueContext: { title: 'Issue Context', label: 'Issue context loaded', labelActive: 'Loading issue context', icon: 'i-lucide-layers' },
+  listIssueComments: { title: 'List Issue Comments', label: 'Comments listed', labelActive: 'Listing comments', icon: 'i-lucide-messages-square' },
   createIssue: { title: 'Create Issue', label: 'Issue created', labelActive: 'Creating issue', icon: 'i-lucide-circle-plus' },
   addIssueComment: { title: 'Comment on Issue', label: 'Comment posted', labelActive: 'Posting issue comment', icon: 'i-lucide-message-square-plus' },
   updateIssueComment: { title: 'Update Issue Comment', label: 'Comment updated', labelActive: 'Updating issue comment', icon: 'i-lucide-message-square-text' },

--- a/apps/docs/content/docs/1.getting-started/1.introduction.md
+++ b/apps/docs/content/docs/1.getting-started/1.introduction.md
@@ -117,7 +117,7 @@ The direct [`@github-tools/sdk/eve`](/deprecated/eve) import is deprecated in fa
 
 ## Explore the tools
 
-The SDK covers repositories, branches, pull requests, issues, reactions, discussions, notifications, commits, releases, checks and statuses, code search, gists, and workflows: 78 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame and the discussion tools use GraphQL) and is fully typed with [Zod](https://zod.dev) schemas.
+The SDK covers repositories, branches, pull requests, issues, reactions, discussions, notifications, commits, releases, checks and statuses, code search, gists, and workflows: 79 tools in total. Each tool wraps a GitHub API operation (mostly REST; line-level blame and the discussion tools use GraphQL) and is fully typed with [Zod](https://zod.dev) schemas.
 
 Browse the full list in the [Tools Catalog](/api/tools-catalog).
 

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with the eve extension
-description: Mount @github-tools/eve-extension under agent/extensions/ to add all 78 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
+description: Mount @github-tools/eve-extension under agent/extensions/ to add all 79 GitHub tools to an eve agent, the recommended way to wire GitHub into eve, with durable approval and Vercel Connect support.
 seo:
   title: Build a GitHub agent with the eve extension
   description: Mount @github-tools/eve-extension under agent/extensions/, the recommended way to add GitHub tools to an eve agent.
@@ -28,7 +28,7 @@ links:
     variant: subtle
 ---
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 78 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. `@github-tools/eve-extension` packages all 79 GitHub tools as a mountable [eve extension](https://eve.dev/docs/extensions): a single `pnpm add` and a one-line mount under `agent/extensions/`, no CLI setup, and no direct SDK import in `agent/tools/`.
 
 ::callout{icon="i-custom:eve"}
 This is the **recommended way** to add GitHub tools to an eve agent. The legacy direct registration APIs (`createGithubTools` and per-tool factories from [`@github-tools/sdk/eve`](/deprecated/eve)) are **deprecated** in its favor. They keep working for existing `agent/tools/` setups, but new agents should mount the extension instead. Shared runtime helpers used by this extension live on `@github-tools/sdk/eve-runtime` (not deprecated).
@@ -169,7 +169,7 @@ export default githubExtension({
 
 ```ts [agent/extensions/github.ts]
 export default githubExtension({
-  preset: 'maintainer', // all 78 tools
+  preset: 'maintainer', // all 79 tools
   exclude: ['createRepository', 'deleteGist'], // minus these two
 })
 ```

--- a/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
+++ b/apps/docs/content/docs/2.frameworks/2.ai-sdk.md
@@ -118,7 +118,7 @@ Full policy options (including `overrides.needsApproval`): [Control write safety
 
 ## Trim tool context with toolpick
 
-With all 78 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
+With all 79 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant tools per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'
@@ -153,7 +153,7 @@ const tools = {
 }
 ```
 
-See the [Tools Catalog](/api/tools-catalog) for all 78 factories.
+See the [Tools Catalog](/api/tools-catalog) for all 79 factories.
 
 ## When to level up
 

--- a/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
+++ b/apps/docs/content/docs/3.examples/6.manager-agent-with-subagents.md
@@ -46,7 +46,7 @@ Build an eve manager agent that delegates GitHub work to specialist sub-agents i
 
 ::
 
-Instead of one agent holding all 78 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
+Instead of one agent holding all 79 tools, this manager holds none. It reads the request, picks the right specialist, and calls it. Each specialist is a normal `@github-tools/eve-extension` mount scoped to a single [preset](/guide/presets), isolated in its own [declared subagent](https://eve.dev/docs/subagents) directory with its own tools, instructions, and approval policy.
 
 ::callout{icon="i-lucide-layers"}
 **Recommended for multi-role products.** Prefer this composition over putting `maintainer` (or omitting `preset`) on a single agent when the product has several distinct jobs — review, triage, release, and so on. Each specialist stays small in context and scoped in token permissions.

--- a/apps/docs/content/docs/3.examples/7.recipes.md
+++ b/apps/docs/content/docs/3.examples/7.recipes.md
@@ -124,7 +124,7 @@ See the [full eve version of this task](/examples/eve-stale-issue-triager) for a
 
 ## Reduce tool context with toolpick
 
-With all 78 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
+With all 79 tools visible on every step, tool definitions eat tokens. [toolpick](https://github.com/pontusab/toolpick) selects only the most relevant ones per step:
 
 ```ts [with-toolpick.ts]
 import { createGithubTools } from '@github-tools/sdk'

--- a/apps/docs/content/docs/4.guide/6.working-context.md
+++ b/apps/docs/content/docs/4.guide/6.working-context.md
@@ -63,7 +63,7 @@ Call independent follow-up reads **in the same step** when you already know the 
 | Default | Behavior | Override |
 |---|---|---|
 | `detail: 'summary'` | Truncates long bodies (~500 chars) on `getPullRequest`, `getIssue`, `getDiscussion`, and release getters | `detail: 'full'` |
-| `getIssueContext` | Defaults to `detail: 'full'` (one-shot) and returns `labelNames` (strings), not full label objects | `detail: 'summary'`; use `listLabels` for descriptions |
+| `getIssueContext` | Defaults to `detail: 'full'` (one-shot) and returns `labelNames` (strings), not full label objects | `detail: 'summary'`; use `listLabels` for descriptions; use `listIssueComments` to paginate beyond the embedded comments |
 | `includePatch: false` | Omits diff patches on `listPullRequestFiles`, `getCommit`, `compareCommits` | `includePatch: true`; optionally `filenames` on `listPullRequestFiles` |
 | File ranges | Prefer `startLine` / `endLine` / `maxLines` on `getFileContent` | Omit ranges only for small files |
 | `maxPages` | List tools fetch one page by default | Set `maxPages` to combine sequential pages in one call |

--- a/apps/docs/content/docs/5.api/1.tools-catalog.md
+++ b/apps/docs/content/docs/5.api/1.tools-catalog.md
@@ -87,6 +87,7 @@ Available in `issue-triage` and `maintainer` presets:
 | `listIssues` | list issues filtered by state and labels | No |
 | `getIssue` | read issue details (body truncated by default; set `detail: full` for complete text) | No |
 | `getIssueContext` | fetch an issue plus label names and recent comments in one call | No |
+| `listIssueComments` | list comments on an issue (paginated; prefer getIssueContext first) | No |
 | `createIssue` | create a new issue | Yes |
 | `addIssueComment` | post a comment on an issue | Yes |
 | `updateIssueComment` | edit the body of an issue comment | Yes |

--- a/apps/docs/content/docs/6.deprecated/1.eve.md
+++ b/apps/docs/content/docs/6.deprecated/1.eve.md
@@ -1,6 +1,6 @@
 ---
 title: Build a GitHub agent with eve (direct import)
-description: Deprecated. The direct @github-tools/sdk/eve import registers all 78 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
+description: Deprecated. The direct @github-tools/sdk/eve import registers all 79 tools via defineDynamic with durable human-in-the-loop approval. Prefer the eve extension for new agents.
 seo:
   title: Build a GitHub agent with eve (direct import, deprecated)
   description: Deprecated direct-import path for eve agents. See the eve extension for the recommended approach.
@@ -36,7 +36,7 @@ links:
 **Deprecated.** The **direct registration APIs** on this page — `createGithubTools`, the per-tool factories, and `connectGithubTools` from `@github-tools/sdk/connect/eve` — are deprecated in favor of [`@github-tools/eve-extension`](/frameworks/eve-extension). They keep working for existing `agent/tools/` agents and aren't being removed, but new agents should [mount the extension](/frameworks/eve-extension) instead. Shared runtime helpers used by the extension (`listEveToolDescriptors`, `executeGithubEveTool`, approval mappers, …) live on **`@github-tools/sdk/eve-runtime`** and are **not** deprecated.
 ::
 
-[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 78 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
+[eve](https://eve.dev) is Vercel's filesystem-first agent framework: an agent is a folder with instructions, a model config, and tools. With `@github-tools/sdk/eve`, that folder becomes a **complete GitHub agent in 3 files**: all 79 tools registered from a single file, with durable human-in-the-loop approval that actually pauses the session until a person approves. This page documents the legacy direct-import path; for new agents, see the [eve extension](/frameworks/eve-extension) guide instead.
 
 ::prompt
 ---

--- a/apps/docs/skills/github-tools-agents/SKILL.md
+++ b/apps/docs/skills/github-tools-agents/SKILL.md
@@ -119,7 +119,7 @@ See `./references/eve-agents.md` and `/deprecated/eve`.
 | `discussion-moderator` | Discussions list/get/comment plus light issue context |
 | `notification-inbox` | User notification triage (needs Notifications PAT) |
 | `pr-author` | Branches, file edits, open/update PRs |
-| `maintainer` | All 78 tools |
+| `maintainer` | All 79 tools |
 
 Array presets merge: `preset: ['code-review', 'issue-triage']`. Start with the smallest preset that fits; use `maintainer` when you need the full catalog. Multi-role: manager + sub-agents each with one preset.
 

--- a/examples/pr-review-agent/README.md
+++ b/examples/pr-review-agent/README.md
@@ -4,7 +4,7 @@ A durable PR review agent in **~60 lines of code**. Tag it on any pull request, 
 
 Built with:
 
-- **[@github-tools/sdk](https://github-tools.com)**: 78 AI-callable GitHub tools (PRs, commits, issues, discussions, releases, code search...)
+- **[@github-tools/sdk](https://github-tools.com)**: 79 AI-callable GitHub tools (PRs, commits, issues, discussions, releases, code search...)
 - **[Chat SDK](https://chat-sdk.dev)**: multi-platform agent framework with the GitHub adapter
 - **[Vercel Workflow](https://useworkflow.dev)**: durable execution that survives timeouts and restarts
 - **[evlog](https://evlog.dev)**: AI observability (token usage, tool calls, cost, timing)

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -33,7 +33,7 @@ They all reach the GitHub API, but none of them were built as an agent's tool la
 | Production agents that must survive restarts and timeouts | [Durable Agents](#durable-agents-vercel-workflow-sdk) |
 | A GitHub, Slack, or Discord bot | [Chat SDK docs](https://github-tools.com/frameworks/chat-sdk) |
 
-78 tools cover repositories, branches, pull requests, issues, reactions, discussions, notifications, commits, releases, checks and statuses, search, gists, and workflows. See the full [Tools Catalog](https://github-tools.com/api/tools-catalog). Write operations support granular approval control out of the box.
+79 tools cover repositories, branches, pull requests, issues, reactions, discussions, notifications, commits, releases, checks and statuses, search, gists, and workflows. See the full [Tools Catalog](https://github-tools.com/api/tools-catalog). Write operations support granular approval control out of the box.
 
 ## Installation
 
@@ -103,7 +103,7 @@ createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
 | Preset | Tools included |
 |---|---|
 | `code-review` | `getPullRequest`, `listPullRequests`, `listPullRequestFiles`, `listPullRequestReviews`, `getPullRequestContext`, `getFileContent`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`, `getRepository`, `listBranches`, `searchCode`, `listCheckRuns`, `getCombinedStatus`, `updatePullRequest`, `addPullRequestComment`, `updatePullRequestComment`, `deletePullRequestComment`, `createPullRequestReview`, `requestReviewers` |
-| `issue-triage` | `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createLabel`, `updateLabel`, `deleteLabel`, `addAssignees`, `removeAssignees`, `listIssueReactions`, `addIssueReaction`, `listCommentReactions`, `addCommentReaction`, `getRepository`, `searchRepositories`, `searchCode`, `searchIssues` |
+| `issue-triage` | `listIssues`, `getIssueContext`, `listIssueComments`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createLabel`, `updateLabel`, `deleteLabel`, `addAssignees`, `removeAssignees`, `listIssueReactions`, `addIssueReaction`, `listCommentReactions`, `addCommentReaction`, `getRepository`, `searchRepositories`, `searchCode`, `searchIssues` |
 | `repo-explorer` | All read-only tools including discussions, gists, workflows, checks/statuses, and releases (no write operations) |
 | `ci-ops` | `listWorkflows`, `listWorkflowRuns`, `getWorkflowRun`, `listWorkflowJobs`, `listCheckRuns`, `getCombinedStatus`, `getCiFailureContext`, `triggerWorkflow`, `cancelWorkflowRun`, `rerunWorkflowRun`, `getRepository`, `listBranches`, `listCommits`, `getCommit` |
 | `security-audit` | Read-only exploration (`getFileContent`, `getRepositoryTree`, `searchCode`, `listCommits`, `getCommit`, `getBlame`, `compareCommits`), PR and CI visibility, plus `createIssue`, `addIssueComment`, `addLabels` to report findings (no destructive writes) |
@@ -111,7 +111,7 @@ createGithubTools({ token, preset: ['code-review', 'issue-triage'] })
 | `discussion-moderator` | `listDiscussions`, `getDiscussion`, `addDiscussionComment`, `getRepository`, `searchIssues`, `getIssueContext`, `addIssueComment` |
 | `notification-inbox` | `listNotifications`, `markNotificationRead`, `getIssue`, `getPullRequest`, `getRepository` (requires a Notifications PAT) |
 | `pr-author` | `getRepository`, `listBranches`, `getFileContent`, `createBranch`, `createOrUpdateFile`, `createPullRequest`, `updatePullRequest`, `getPullRequest`, `listPullRequestFiles`, `compareCommits`, `getCommit` |
-| `maintainer` | All 78 tools |
+| `maintainer` | All 79 tools |
 
 Start with the smallest preset that fits. Use `maintainer` or omit `preset` when you need the full catalog. Full breakdown: [Tools Catalog](https://github-tools.com/api/tools-catalog).
 
@@ -499,6 +499,7 @@ List tools (`listCommits`, `listPullRequests`, `listIssues`, `listWorkflowRuns`,
 | `listIssues` | List issues filtered by state and labels |
 | `getIssue` | Get an issue's details (body truncated by default; set `detail: full` for complete text) |
 | `getIssueContext` | Fetch an issue plus label names and recent comments in one call |
+| `listIssueComments` | List comments on an issue (paginated; prefer `getIssueContext` for the first page) |
 | `createIssue` | Open a new issue |
 | `addIssueComment` | Post a comment on an issue |
 | `updateIssueComment` | Edit the body of an issue comment |
@@ -617,7 +618,7 @@ Create one at **GitHub → Settings → Developer settings → Personal access t
 | **Administration** | Read and write | `forkRepository`, `createRepository` |
 | **Pull requests** | Read-only | `listPullRequests`, `getPullRequest`, `listPullRequestFiles`, `listPullRequestReviews`, `getPullRequestContext` |
 | **Pull requests** | Read and write | `createPullRequest`, `mergePullRequest`, `updatePullRequest`, `addPullRequestComment`, `updatePullRequestComment`, `deletePullRequestComment`, `createPullRequestReview`, `requestReviewers` |
-| **Issues** | Read-only | `listIssues`, `getIssue`, `getIssueContext`, `listLabels`, `listIssueReactions`, `listCommentReactions` |
+| **Issues** | Read-only | `listIssues`, `getIssue`, `getIssueContext`, `listIssueComments`, `listLabels`, `listIssueReactions`, `listCommentReactions` |
 | **Issues** | Read and write | `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`, `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createLabel`, `updateLabel`, `deleteLabel`, `addAssignees`, `removeAssignees`, `addIssueReaction`, `addCommentReaction` |
 | **Discussions** | Read-only | `listDiscussions`, `getDiscussion` |
 | **Discussions** | Read and write | `addDiscussionComment` |

--- a/packages/github-tools/src/agents.ts
+++ b/packages/github-tools/src/agents.ts
@@ -34,6 +34,7 @@ ${SHARED_RULES}`,
 When triaging issues:
 - Call getIssueContext exactly once (full body + labelNames + recent comments). In that same step, call listIssues or searchIssues if you need duplicate checks
 - Never re-call getIssueContext for the same issue
+- Use listIssueComments to paginate beyond the comments returned by getIssueContext
 - Pick labels from labelNames; use addLabels / removeLabel to apply them. Use createLabel / updateLabel / deleteLabel when the repository taxonomy itself needs changing
 - Create issues with clear titles and descriptions when asked
 - Use updateIssue to edit title, body, labels, milestone, or assignees, and to reopen a closed issue (state: 'open') — there is no separate reopen tool

--- a/packages/github-tools/src/core/presets.ts
+++ b/packages/github-tools/src/core/presets.ts
@@ -24,19 +24,20 @@ export const PRESET_TOOLS = {
   /**
    * **Issue triage** — manage and organize GitHub issues.
    *
-   * Tools: `listIssues`, `getIssueContext`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`,
+   * Tools: `listIssues`, `getIssueContext`, `listIssueComments`, `createIssue`, `addIssueComment`, `updateIssueComment`, `deleteIssueComment`,
    * `closeIssue`, `updateIssue`, `addLabels`, `removeLabel`, `createLabel`, `updateLabel`, `deleteLabel`,
    * `addAssignees`, `removeAssignees`,
    * `listIssueReactions`, `addIssueReaction`, `listCommentReactions`, `addCommentReaction`, `getRepository`,
    * `searchRepositories`, `searchCode`, `searchIssues`.
    *
    * Prefer `getIssueContext` (issue + `labelNames` + recent comments) over separate get/list calls.
+   * Use `listIssueComments` to paginate beyond the comments returned by `getIssueContext`.
    * Reopen a closed issue with `updateIssue` (`state: 'open'`) — there is no separate reopen tool.
    * Acknowledge a report with `addIssueReaction` / `addCommentReaction` instead of a comment when no reply is needed.
    * Agent prompt: optimized for categorizing, labeling, and responding to issues.
    */
   'issue-triage': [
-    'listIssues', 'getIssueContext', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
+    'listIssues', 'getIssueContext', 'listIssueComments', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
     'addLabels', 'removeLabel', 'createLabel', 'updateLabel', 'deleteLabel', 'addAssignees', 'removeAssignees',
     'listIssueReactions', 'addIssueReaction', 'listCommentReactions', 'addCommentReaction',
     'getRepository', 'searchRepositories', 'searchCode', 'searchIssues',
@@ -67,7 +68,7 @@ export const PRESET_TOOLS = {
   'repo-explorer': [
     'getRepository', 'listBranches', 'getFileContent', 'getRepositoryTree',
     'listPullRequests', 'getPullRequest', 'listPullRequestFiles', 'listPullRequestReviews', 'getPullRequestContext',
-    'listIssues', 'getIssue', 'getIssueContext',
+    'listIssues', 'getIssue', 'getIssueContext', 'listIssueComments',
     'listDiscussions', 'getDiscussion',
     'listLabels',
     'listCommits', 'getCommit', 'getBlame', 'compareCommits',
@@ -161,7 +162,7 @@ export const PRESET_TOOLS = {
   'maintainer': [
     'getRepository', 'listBranches', 'getFileContent', 'getRepositoryTree', 'createBranch', 'forkRepository', 'createRepository', 'createOrUpdateFile',
     'listPullRequests', 'getPullRequest', 'listPullRequestFiles', 'listPullRequestReviews', 'getPullRequestContext', 'createPullRequest', 'mergePullRequest', 'updatePullRequest', 'addPullRequestComment', 'updatePullRequestComment', 'deletePullRequestComment', 'createPullRequestReview', 'requestReviewers',
-    'listIssues', 'getIssue', 'getIssueContext', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
+    'listIssues', 'getIssue', 'getIssueContext', 'listIssueComments', 'createIssue', 'addIssueComment', 'updateIssueComment', 'deleteIssueComment', 'closeIssue', 'updateIssue',
     'listLabels', 'addLabels', 'removeLabel', 'createLabel', 'updateLabel', 'deleteLabel', 'addAssignees', 'removeAssignees',
     'listIssueReactions', 'addIssueReaction', 'listCommentReactions', 'addCommentReaction',
     'listDiscussions', 'getDiscussion', 'addDiscussionComment',

--- a/packages/github-tools/src/core/tool-names.ts
+++ b/packages/github-tools/src/core/tool-names.ts
@@ -51,6 +51,8 @@ export const GITHUB_TOOL_NAMES = {
   getIssue: 'getIssue',
   /** Fetch an issue plus available label names and recent comments in one call. */
   getIssueContext: 'getIssueContext',
+  /** List comments on a GitHub issue. Bodies are truncated by default (detail: summary). Prefer getIssueContext for the first page when triaging. */
+  listIssueComments: 'listIssueComments',
   /** Create a new issue in a GitHub repository. Requires approval by default. */
   createIssue: 'createIssue',
   /** Add a comment to a GitHub issue. Requires approval by default. */

--- a/packages/github-tools/src/eve.ts
+++ b/packages/github-tools/src/eve.ts
@@ -196,6 +196,13 @@ export const listIssues = factory('listIssues')
  */
 export const getIssue = factory('getIssue')
 /**
+ * List comments on a GitHub issue. Prefer getIssueContext for the first page when triaging.
+ *
+ * @deprecated Cherry-picking eve tool factories directly is deprecated — mount `@github-tools/eve-extension`
+ * instead. See https://github-tools.com/frameworks/eve-extension.
+ */
+export const listIssueComments = factory('listIssueComments')
+/**
  * Create a new issue in a GitHub repository. Requires approval by default.
  *
  * @deprecated Cherry-picking eve tool factories directly is deprecated — mount `@github-tools/eve-extension`

--- a/packages/github-tools/src/eve/registry.ts
+++ b/packages/github-tools/src/eve/registry.ts
@@ -230,6 +230,12 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       execute: withToken(issues.getIssueCore, ctx),
     },
     {
+      name: 'listIssueComments',
+      description: issues.listIssueCommentsDescription,
+      inputSchema: issues.listIssueCommentsInputSchema,
+      execute: withToken(issues.listIssueCommentsCore, ctx),
+    },
+    {
       name: 'createIssue',
       writeTool: 'createIssue',
       description: issues.createIssueDescription,

--- a/packages/github-tools/src/index.ts
+++ b/packages/github-tools/src/index.ts
@@ -1,7 +1,7 @@
 import type { ToolSet } from 'ai'
 import { getRepository, listBranches, getFileContent, getRepositoryTree, createBranch, forkRepository, createRepository, createOrUpdateFile } from './tools/repository'
 import { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, updatePullRequest, addPullRequestComment, updatePullRequestComment, deletePullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
-import { listIssues, getIssue, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, createLabel, updateLabel, deleteLabel, addAssignees, removeAssignees } from './tools/issues'
+import { listIssues, getIssue, listIssueComments, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, createLabel, updateLabel, deleteLabel, addAssignees, removeAssignees } from './tools/issues'
 import { listIssueReactions, addIssueReaction, listCommentReactions, addCommentReaction } from './tools/reactions'
 import { listDiscussions, getDiscussion, addDiscussionComment } from './tools/discussions'
 import { listNotifications, markNotificationRead } from './tools/notifications'
@@ -144,6 +144,7 @@ export function createGithubTools({
     requestReviewers: requestReviewers(resolveToken, approval('requestReviewers')),
     getPullRequestContext: getPullRequestContext(resolveToken),
     getIssueContext: getIssueContext(resolveToken),
+    listIssueComments: listIssueComments(resolveToken),
     createIssue: createIssue(resolveToken, approval('createIssue')),
     addIssueComment: addIssueComment(resolveToken, approval('addIssueComment')),
     updateIssueComment: updateIssueComment(resolveToken, approval('updateIssueComment')),
@@ -217,7 +218,7 @@ export type GithubTools = AllGithubTools & ToolSet
 export { createOctokit } from './client'
 export { getRepository, listBranches, getFileContent, getRepositoryTree, createBranch, forkRepository, createRepository, createOrUpdateFile } from './tools/repository'
 export { listPullRequests, getPullRequest, createPullRequest, mergePullRequest, updatePullRequest, addPullRequestComment, updatePullRequestComment, deletePullRequestComment, listPullRequestFiles, listPullRequestReviews, createPullRequestReview, requestReviewers } from './tools/pull-requests'
-export { listIssues, getIssue, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, createLabel, updateLabel, deleteLabel, addAssignees, removeAssignees } from './tools/issues'
+export { listIssues, getIssue, listIssueComments, createIssue, addIssueComment, updateIssueComment, deleteIssueComment, closeIssue, updateIssue, listLabels, addLabels, removeLabel, createLabel, updateLabel, deleteLabel, addAssignees, removeAssignees } from './tools/issues'
 export { listIssueReactions, addIssueReaction, listCommentReactions, addCommentReaction } from './tools/reactions'
 export { listDiscussions, getDiscussion, addDiscussionComment } from './tools/discussions'
 export { listNotifications, markNotificationRead } from './tools/notifications'

--- a/packages/github-tools/src/tools/issues.ts
+++ b/packages/github-tools/src/tools/issues.ts
@@ -6,6 +6,9 @@ import {
   getIssueInputSchema,
   getIssueDescription,
   getIssueCore,
+  listIssueCommentsInputSchema,
+  listIssueCommentsDescription,
+  listIssueCommentsCore,
   createIssueInputSchema,
   createIssueDescription,
   createIssueCore,
@@ -76,6 +79,19 @@ export const getIssue = (token: GithubTokenInput): GithubTool =>
     description: getIssueDescription,
     inputSchema: getIssueInputSchema,
     execute: async args => getIssueStep({ token: await resolveGithubToken(token), ...args }),
+  })
+
+async function listIssueCommentsStep(args: Parameters<typeof listIssueCommentsCore>[0]) {
+  "use step"
+  return listIssueCommentsCore(args)
+}
+
+/** List comments on a GitHub issue. Prefer getIssueContext for the first page when triaging. */
+export const listIssueComments = (token: GithubTokenInput): GithubTool =>
+  tool({
+    description: listIssueCommentsDescription,
+    inputSchema: listIssueCommentsInputSchema,
+    execute: async args => listIssueCommentsStep({ token: await resolveGithubToken(token), ...args }),
   })
 
 async function createIssueStep(args: Parameters<typeof createIssueCore>[0]) {


### PR DESCRIPTION
## Summary
- Promote `listIssueComments` (core already existed for `getIssueContext`) to a public read tool with pagination (`perPage` / `page`).
- Include it in `issue-triage`, `repo-explorer`, and `maintainer`.
- Prefer `getIssueContext` for the first page when triaging; use this tool to page further.

## Test plan
- [x] `pnpm --filter @github-tools/sdk build && lint && typecheck && test`
- [x] `pnpm --filter @github-tools/eve-extension build && typecheck`
- [ ] Call `listIssueComments` with `page: 2` on a busy issue and confirm pagination

**Merge note:** Tool count docs say 76 here; [#74](https://github.com/vercel-labs/github-tools/pull/74) says 78. After both land the total is **79** — reconcile the count on the second merge. If [#73](https://github.com/vercel-labs/github-tools/pull/73) merges first, add `listIssueComments: ISSUES_READ` to `TOOL_CONNECT_SCOPES`.