### PR TITLE
fix(eve): durable registration

### DIFF
--- a/.changeset/eve-extension-durable-registration.md
+++ b/.changeset/eve-extension-durable-registration.md
@@ -1,0 +1,6 @@
+---
+'@github-tools/sdk': patch
+'@github-tools/eve-extension': patch
+---
+
+Fix eve durable tool registration so consumers can drop pnpm patches: rebuild options per execute (no module-level race), resolve tools on `step.started`, and omit the `approval` field for `false` / `'never'` instead of attaching `never()`. Also map `listIssueComments` in Connect tool scopes.

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -191,7 +191,7 @@ export default githubExtension({
 
 ## Durable multi-turn sessions
 
-The extension registers each tool with an **authored inline** `execute` that only closes over a serializable tool `name`, then dispatches via `@github-tools/sdk/eve-runtime`. That pattern survives multi-turn eve Workflow replay (see [#51](https://github.com/vercel-labs/github-tools/issues/51)). Prefer this mount over the deprecated [`createGithubTools`](/deprecated/eve) / [`connectGithubTools`](/deprecated/eve) paths for Slack / multi-turn durable agents — those register tools from inside `node_modules` and are skipped on replay.
+The extension registers each tool with an **authored inline** `execute` that only closes over a serializable tool `name`, then rebuilds session options from the extension config on every call via `@github-tools/sdk/eve-runtime`. Tools resolve on `step.started` so registration stays fresh across durable steps. That pattern survives multi-turn eve Workflow replay (see [#51](https://github.com/vercel-labs/github-tools/issues/51)). Prefer this mount over the deprecated [`createGithubTools`](/deprecated/eve) / [`connectGithubTools`](/deprecated/eve) paths for Slack / multi-turn durable agents — those register tools from inside `node_modules` and are skipped on replay.
 
 ## Durable approval, done right
 
@@ -200,7 +200,7 @@ Approval **pauses the session durably** until a human responds, and policies are
 | Value | Maps to | Behavior |
 |---|---|---|
 | `true` / `'always'` | `always()` | Require approval on every call |
-| `false` / `'never'` | `never()` | Skip approval |
+| `false` / `'never'` | omit `approval` | Skip approval (eve default) |
 | `'once'` | `once()` | Approve once per session, then auto-allow |
 | predicate | custom `Approval` | Input-dependent gate (`toolInput`, session context) |
 

--- a/apps/docs/content/docs/6.deprecated/1.eve.md
+++ b/apps/docs/content/docs/6.deprecated/1.eve.md
@@ -117,7 +117,7 @@ For Vercel Connect, use [`connectGithubTools` from `@github-tools/sdk/connect/ev
 
 ## One file, all tools
 
-`createGithubTools()` returns a `defineDynamic` value: eve resolves the tool set on `session.started`, so a single default export registers every tool. Scope and gate as needed:
+`createGithubTools()` returns a `defineDynamic` value: eve resolves the tool set on `step.started`, so a single default export registers every tool. Scope and gate as needed:
 
 ```ts [agent/tools/github.ts]
 import { createGithubTools } from '@github-tools/sdk/eve'
@@ -142,7 +142,7 @@ This is eve's headline advantage over the boolean `needsApproval` on the AI SDK 
 | Value | Maps to | Behavior |
 |---|---|---|
 | `true` / `'always'` | `always()` | Require approval on every call |
-| `false` / `'never'` | `never()` | Skip approval |
+| `false` / `'never'` | omit `approval` | Skip approval (eve default) |
 | `'once'` | `once()` | Approve once per session, then auto-allow |
 | predicate | custom `Approval` | Input-dependent gate (`toolInput`, session context) |
 | `always()` / `once()` / `never()` | passthrough | Import helpers from `eve/tools/approval` |

--- a/packages/github-tools-eve-extension/extension/tools/github.ts
+++ b/packages/github-tools-eve-extension/extension/tools/github.ts
@@ -1,70 +1,91 @@
 import { connectGithubToken } from '@github-tools/sdk/connect'
 import {
   executeGithubEveTool,
+  isEveApprovalDisabled,
   listEveToolDescriptors,
   mapEveApprovalValue,
   resolveEveApproval,
   type EveApprovalConfig,
+  type EveApprovalValue,
   type EveGithubToolsOptions,
   type EveToolOverrides,
   type GithubToolName,
+  type GithubWriteToolName,
 } from '@github-tools/sdk/eve-runtime'
 import { defineDynamic, defineTool, type ToolDefinition } from 'eve/tools'
 import extension from '../extension'
 
 /**
- * Session options stored at module level so durable `execute` closures only capture
- * a serializable tool `name` (see https://github.com/vercel-labs/github-tools/issues/51).
+ * Rebuild options from extension config on every call.
+ * Durable `execute` only closes over a serializable tool `name` (#51); reading
+ * config here avoids a module-level store that races across concurrent sessions.
  */
-let sessionOptions: EveGithubToolsOptions = {}
+function buildSessionOptions(): EveGithubToolsOptions {
+  const {
+    token,
+    connector,
+    connect,
+    preset,
+    include,
+    exclude,
+    requireApproval,
+    overrides,
+    context,
+    author,
+    committer,
+    coAuthors,
+  } = extension.config
+
+  const includeNames = include as GithubToolName[] | undefined
+  const excludeNames = exclude as GithubToolName[] | undefined
+
+  const resolvedToken = connector
+    ? connectGithubToken(connector, {
+        preset,
+        include: includeNames,
+        exclude: excludeNames,
+        params: connect,
+      })
+    : token
+
+  return {
+    token: resolvedToken,
+    preset,
+    include: includeNames,
+    exclude: excludeNames,
+    requireApproval: requireApproval as EveApprovalConfig | undefined,
+    overrides: overrides as EveToolOverrides | undefined,
+    context,
+    author,
+    committer,
+    coAuthors,
+  }
+}
+
+function approvalDisabled(
+  writeTool: GithubWriteToolName | undefined,
+  requireApproval: EveApprovalConfig | undefined,
+  override: EveApprovalValue | undefined,
+): boolean {
+  if (override !== undefined) return isEveApprovalDisabled(override)
+  if (!writeTool) return true
+  if (requireApproval === false) return true
+  if (typeof requireApproval === 'object' && requireApproval !== null) {
+    return isEveApprovalDisabled(requireApproval[writeTool])
+  }
+  return false
+}
 
 async function runGithubEveTool(name: GithubToolName, input: unknown) {
-  return executeGithubEveTool(name, input as Record<string, unknown>, sessionOptions)
+  return executeGithubEveTool(name, input as Record<string, unknown>, buildSessionOptions())
 }
 
 export default defineDynamic({
   events: {
-    'session.started': async () => {
-      const {
-        token,
-        connector,
-        connect,
-        preset,
-        include,
-        exclude,
-        requireApproval,
-        overrides,
-        context,
-        author,
-        committer,
-        coAuthors,
-      } = extension.config
-
-      const includeNames = include as GithubToolName[] | undefined
-      const excludeNames = exclude as GithubToolName[] | undefined
-
-      const resolvedToken = connector
-        ? connectGithubToken(connector, {
-            preset,
-            include: includeNames,
-            exclude: excludeNames,
-            params: connect,
-          })
-        : token
-
-      sessionOptions = {
-        token: resolvedToken,
-        preset,
-        include: includeNames,
-        exclude: excludeNames,
-        requireApproval: requireApproval as EveApprovalConfig | undefined,
-        overrides: overrides as EveToolOverrides | undefined,
-        context,
-        author,
-        committer,
-        coAuthors,
-      }
-
+    // Re-resolve each model step (not once per session) so tool registration
+    // stays fresh across durable steps; execute still rebuilds options above.
+    'step.started': async () => {
+      const sessionOptions = buildSessionOptions()
       const descriptors = listEveToolDescriptors(sessionOptions)
       const tools: Record<string, ToolDefinition> = {}
       const toolOverrides = sessionOptions.overrides
@@ -72,14 +93,19 @@ export default defineDynamic({
       for (const entry of descriptors) {
         const name = entry.name
         const override = toolOverrides?.[name]
+        const skipApproval = approvalDisabled(
+          entry.writeTool,
+          sessionOptions.requireApproval,
+          override?.approval,
+        )
 
         tools[name] = defineTool({
           description: override?.description ?? entry.description,
           inputSchema: entry.inputSchema,
-          ...(entry.writeTool && {
+          ...(entry.writeTool && !skipApproval && {
             approval: resolveEveApproval(entry.writeTool, sessionOptions.requireApproval),
           }),
-          ...(override?.approval !== undefined && {
+          ...(override?.approval !== undefined && !skipApproval && {
             approval: mapEveApprovalValue(override.approval),
           }),
           ...(override?.toModelOutput !== undefined

--- a/packages/github-tools/README.md
+++ b/packages/github-tools/README.md
@@ -402,7 +402,7 @@ Dynamic tools are named by their **bare map key**: the model sees `listPullReque
 | Value | Maps to | Behavior |
 |---|---|---|
 | `true` / `'always'` | `always()` | Require approval on every call |
-| `false` / `'never'` | `never()` | Skip approval |
+| `false` / `'never'` | omit `approval` | Skip approval (eve default) |
 | `'once'` | `once()` | Approve once per session, then auto-allow |
 | predicate | custom `Approval` | Input-dependent gate; booleans map to `user-approval` / `not-applicable` |
 | `always()` / `once()` / `never()` | passthrough | Use eve helpers directly |

--- a/packages/github-tools/src/connect/scopes.ts
+++ b/packages/github-tools/src/connect/scopes.ts
@@ -187,6 +187,7 @@ export const TOOL_CONNECT_SCOPES = {
   listIssues: ISSUES_READ,
   getIssue: ISSUES_READ,
   getIssueContext: ISSUES_READ,
+  listIssueComments: ISSUES_READ,
   createIssue: ISSUES_WRITE,
   addIssueComment: ISSUES_WRITE,
   updateIssueComment: ISSUES_WRITE,

--- a/packages/github-tools/src/eve-runtime.ts
+++ b/packages/github-tools/src/eve-runtime.ts
@@ -13,7 +13,7 @@ export {
   listEveToolDescriptors,
   executeGithubEveTool,
 } from './eve/build'
-export { mapEveApprovalValue, resolveEveApproval } from './eve/approval'
+export { mapEveApprovalValue, resolveEveApproval, resolveEveToolApproval, isEveApprovalDisabled } from './eve/approval'
 export type {
   EveApprovalConfig,
   EveApprovalValue,

--- a/packages/github-tools/src/eve.ts
+++ b/packages/github-tools/src/eve.ts
@@ -18,6 +18,8 @@ export {
   executeGithubEveTool,
   mapEveApprovalValue,
   resolveEveApproval,
+  resolveEveToolApproval,
+  isEveApprovalDisabled,
   PRESET_TOOLS,
   GITHUB_TOOL_NAMES,
   GITHUB_WRITE_TOOLS,

--- a/packages/github-tools/src/eve/approval.test.ts
+++ b/packages/github-tools/src/eve/approval.test.ts
@@ -1,7 +1,12 @@
 import type { ApprovalContext } from 'eve/tools'
 import { describe, expect, it } from 'vitest'
 import { always, never, once } from 'eve/tools/approval'
-import { mapEveApprovalValue, resolveEveApproval } from './approval'
+import {
+  isEveApprovalDisabled,
+  mapEveApprovalValue,
+  resolveEveApproval,
+  resolveEveToolApproval,
+} from './approval'
 
 const approvalCtx = {
   session: { id: 's1', auth: {}, turn: 1 },
@@ -11,6 +16,16 @@ const approvalCtx = {
   getSandbox: () => { throw new Error('not implemented') },
   getSkill: () => { throw new Error('not implemented') },
 } as unknown as ApprovalContext
+
+describe('isEveApprovalDisabled', () => {
+  it('treats false and never as disabled', () => {
+    expect(isEveApprovalDisabled(false)).toBe(true)
+    expect(isEveApprovalDisabled('never')).toBe(true)
+    expect(isEveApprovalDisabled(true)).toBe(false)
+    expect(isEveApprovalDisabled('always')).toBe(false)
+    expect(isEveApprovalDisabled(undefined)).toBe(false)
+  })
+})
 
 describe('resolveEveApproval', () => {
   it('defaults write tools to always()', () => {
@@ -49,5 +64,21 @@ describe('resolveEveApproval', () => {
 
   it('keeps unlisted write tools on always() fail-safe default', () => {
     expect(resolveEveApproval('deleteGist', { mergePullRequest: false })!(approvalCtx)).toBe('user-approval')
+  })
+})
+
+describe('resolveEveToolApproval', () => {
+  it('omits approval when false or never', () => {
+    expect(resolveEveToolApproval('createIssue', false)).toBeUndefined()
+    expect(resolveEveToolApproval('createIssue', { createIssue: false })).toBeUndefined()
+    expect(resolveEveToolApproval('createIssue', { createIssue: 'never' })).toBeUndefined()
+    expect(resolveEveToolApproval('createIssue', undefined, false)).toBeUndefined()
+    expect(resolveEveToolApproval('createIssue', undefined, 'never')).toBeUndefined()
+  })
+
+  it('still attaches always/once and predicates', () => {
+    expect(resolveEveToolApproval('createIssue', undefined)).toBeDefined()
+    expect(resolveEveToolApproval('createIssue', { createIssue: 'once' })).toBeDefined()
+    expect(resolveEveToolApproval('createIssue', undefined, () => 'not-applicable')).toBeDefined()
   })
 })

--- a/packages/github-tools/src/eve/approval.ts
+++ b/packages/github-tools/src/eve/approval.ts
@@ -3,6 +3,15 @@ import type { GithubWriteToolName } from '../core/write-tools'
 import { getEveApprovalHelpers } from './load-eve'
 import type { EveApprovalConfig, EveApprovalValue } from './types'
 
+/**
+ * `false` / `'never'` should omit the tool `approval` field entirely.
+ * eve treats a missing `approval` like `never()`; attaching `never()` is
+ * redundant and has caused approval UI noise on some channels.
+ */
+export function isEveApprovalDisabled(value: EveApprovalValue | undefined): boolean {
+  return value === false || value === 'never'
+}
+
 export function mapEveApprovalValue(value: EveApprovalValue): Approval {
   if (typeof value === 'function') return value
 
@@ -27,4 +36,25 @@ export function resolveEveApproval(
   if (value === undefined) return getEveApprovalHelpers().always()
 
   return mapEveApprovalValue(value)
+}
+
+/**
+ * Approval to attach on a write tool, or `undefined` to omit the field.
+ * Prefer this when building `defineTool` values so `false` / `'never'` do not
+ * attach a redundant `never()` handler.
+ */
+export function resolveEveToolApproval(
+  toolName: GithubWriteToolName,
+  config: EveApprovalConfig | undefined,
+  override?: EveApprovalValue,
+): Approval | undefined {
+  if (override !== undefined) {
+    if (isEveApprovalDisabled(override)) return undefined
+    return mapEveApprovalValue(override)
+  }
+  if (config === false) return undefined
+  if (typeof config === 'object' && config !== null && isEveApprovalDisabled(config[toolName])) {
+    return undefined
+  }
+  return resolveEveApproval(toolName, config)
 }

--- a/packages/github-tools/src/eve/build.test.ts
+++ b/packages/github-tools/src/eve/build.test.ts
@@ -11,11 +11,11 @@ describe('createGithubTools eve integration', () => {
     }
   })
 
-  it('returns a defineDynamic wrapper with session.started resolver', async () => {
+  it('returns a defineDynamic wrapper with step.started resolver', async () => {
     const dynamic = createEveGithubToolsDynamic({ token: 'ghp_test', preset: 'code-review' })
-    expect(dynamic).toMatchObject({ kind: expect.any(String), events: { 'session.started': expect.any(Function) } })
+    expect(dynamic).toMatchObject({ kind: expect.any(String), events: { 'step.started': expect.any(Function) } })
 
-    const tools = await dynamic.events['session.started']!({}, {} as never)
+    const tools = await dynamic.events['step.started']!({}, {} as never)
     expect(Object.keys(tools!).sort()).toEqual([...PRESET_TOOLS['code-review']].sort())
   })
 
@@ -123,7 +123,7 @@ describe('createGithubTools eve integration', () => {
     })
 
     expect(tools.createIssue?.approval).toBeDefined()
-    expect(tools.addIssueComment?.approval).toBeDefined()
+    expect(tools.addIssueComment?.approval).toBeUndefined()
     expect(tools.listIssues?.approval).toBeUndefined()
   })
 })

--- a/packages/github-tools/src/eve/build.ts
+++ b/packages/github-tools/src/eve/build.ts
@@ -1,7 +1,7 @@
 import type { ToolDefinition } from 'eve/tools'
 import { resolvePresetTools, type CombinedPresetToolNames, type GithubToolPreset, type PresetToolName } from '../core/presets'
 import { createGithubTokenResolver } from '../core/token'
-import { mapEveApprovalValue, resolveEveApproval } from './approval'
+import { isEveApprovalDisabled, mapEveApprovalValue, resolveEveToolApproval } from './approval'
 import { getEveTools } from './load-eve'
 import { ALL_GITHUB_TOOL_NAMES, createToolRegistry, type GithubToolName, type ToolBuildContext } from './registry'
 import { runGithubToolStep } from './steps'
@@ -33,13 +33,21 @@ function applyOverrides<T extends ToolDefinition>(
 ): T {
   const override = overrides?.[name]
   if (!override) return tool
-  return {
+
+  const next: T = {
     ...tool,
     ...override.description !== undefined && { description: override.description },
-    ...override.approval !== undefined && { approval: mapEveApprovalValue(override.approval) },
     ...override.toModelOutput !== undefined && { toModelOutput: override.toModelOutput },
     ...override.outputSchema !== undefined && { outputSchema: override.outputSchema },
   }
+
+  if (override.approval === undefined) return next
+  if (isEveApprovalDisabled(override.approval)) {
+    const rest = { ...next }
+    delete (rest as { approval?: unknown }).approval
+    return rest
+  }
+  return { ...next, approval: mapEveApprovalValue(override.approval) }
 }
 
 export function buildEveToolDefinition(
@@ -60,12 +68,14 @@ export function buildEveToolDefinition(
     throw new Error(`Unknown GitHub tool: ${name}`)
   }
 
+  const approval = entry.writeTool
+    ? resolveEveToolApproval(entry.writeTool, options.requireApproval)
+    : undefined
+
   const tool = defineTool({
     description: entry.description,
     inputSchema: entry.inputSchema,
-    ...(entry.writeTool && {
-      approval: resolveEveApproval(entry.writeTool, options.requireApproval),
-    }),
+    ...(approval && { approval }),
     ...(entry.toModelOutput && { toModelOutput: entry.toModelOutput }),
     execute: async (input) => runGithubToolStep(name, input as Record<string, unknown>, ctx),
   })
@@ -90,12 +100,14 @@ export function buildEveToolMap(options: EveGithubToolsOptions = {}): EveToolMap
   for (const entry of registry) {
     if (!isAllowed(entry.name)) continue
 
+    const approval = entry.writeTool
+      ? resolveEveToolApproval(entry.writeTool, options.requireApproval)
+      : undefined
+
     const tool = defineTool({
       description: entry.description,
       inputSchema: entry.inputSchema,
-      ...(entry.writeTool && {
-        approval: resolveEveApproval(entry.writeTool, options.requireApproval),
-      }),
+      ...(approval && { approval }),
       ...(entry.toModelOutput && { toModelOutput: entry.toModelOutput }),
       execute: async (input) => runGithubToolStep(entry.name, input as Record<string, unknown>, ctx),
     })
@@ -113,7 +125,7 @@ export function createEveGithubToolsDynamic(options: EveGithubToolsOptions = {})
   // Deferred — eve does not yet expose managed GitHub tokens on the session context.
   return defineDynamic({
     events: {
-      'session.started': async () => buildEveToolMap(options),
+      'step.started': async () => buildEveToolMap(options),
     },
   })
 }


### PR DESCRIPTION
## Summary
- Port the behaviors Evi was carrying as a pnpm patch into `@github-tools/eve-extension` / `@github-tools/sdk`:
  - rebuild options from extension config on every `execute` (no module-level `sessionOptions` race across concurrent sessions)
  - resolve dynamic tools on `step.started` instead of once on `session.started`
  - omit the `approval` field for `false` / `'never'` (eve’s default) instead of attaching `never()`
- Map `listIssueComments` in `TOOL_CONNECT_SCOPES` (missed in #75; unblocked typecheck)

## Follow-up
After release (`eve-extension` patch + `sdk` patch), [HugoRCD/evlog#527](https://github.com/HugoRCD/evlog/pull/527) can stay patch-free and bump to the new versions. The remaining `eve@0.30.6` patch in evlog is unrelated (workflow step-id scoping) and stays until eve ships that fix.

## Test plan
- [x] `vitest` eve approval + build tests
- [x] `pnpm --filter @github-tools/sdk --filter @github-tools/eve-extension` lint / typecheck / build
- [ ] Smoke: mount extension with `requireApproval: { createIssue: false }` → tool has no `approval` property
- [ ] Smoke: concurrent sessions do not share Connect token / context via module state