### PR TITLE
fix(eve): apply built-in toModelOutput through an inline name lookup

### DIFF
--- a/.changeset/eve-tomodeloutput-durable.md
+++ b/.changeset/eve-tomodeloutput-durable.md
@@ -1,0 +1,6 @@
+---
+'@github-tools/eve-extension': patch
+'@github-tools/sdk': patch
+---
+
+Apply built-in eve `toModelOutput` formatters through an inline callback that only closes over the tool name. On eve 0.44.x this keeps tools like `getFileContent` from failing durable-descriptor validation and dropping the whole GitHub toolset.

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -14,9 +14,9 @@
     "db:migrate": "nuxt db migrate"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "^4.0.41",
-    "@ai-sdk/vue": "^4.0.52",
-    "@ai-sdk/workflow": "^1.0.52",
+    "@ai-sdk/gateway": "^4.0.56",
+    "@ai-sdk/vue": "^4.0.70",
+    "@ai-sdk/workflow": "^1.0.70",
     "@github-tools/sdk": "workspace:*",
     "@iconify-json/logos": "^1.2.12",
     "@iconify-json/lucide": "^1.2.121",
@@ -31,7 +31,7 @@
     "@workflow/ai": "^4.2.0",
     "@workflow/nitro": "4.1.6",
     "@workflow/nuxt": "^4.0.16",
-    "ai": "^7.0.52",
+    "ai": "^7.0.70",
     "date-fns": "^4.4.0",
     "drizzle-orm": "^0.45.2",
     "h3": "^1.15.11",

--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -191,7 +191,7 @@ export default githubExtension({
 
 ## Durable multi-turn sessions
 
-The extension registers each tool with an **authored inline** `execute` that only closes over a serializable tool `name`, then rebuilds session options from the extension config on every call via `@github-tools/sdk/eve-runtime`. Tools resolve on `step.started` so registration stays fresh across durable steps. That pattern survives multi-turn eve Workflow replay (see [#51](https://github.com/vercel-labs/github-tools/issues/51)). Prefer this mount over the deprecated [`createGithubTools`](/deprecated/eve) / [`connectGithubTools`](/deprecated/eve) paths for Slack / multi-turn durable agents — those register tools from inside `node_modules` and are skipped on replay.
+The extension registers each tool with an **authored inline** `execute` and `toModelOutput` that only close over a serializable tool `name`, then rebuilds session options from the extension config on every call via `@github-tools/sdk/eve-runtime`. Tools resolve on `step.started` so registration stays fresh across durable steps. That pattern survives multi-turn eve Workflow replay (see [#51](https://github.com/vercel-labs/github-tools/issues/51), [#99](https://github.com/vercel-labs/github-tools/issues/99)). Prefer this mount over the deprecated [`createGithubTools`](/deprecated/eve) / [`connectGithubTools`](/deprecated/eve) paths for Slack / multi-turn durable agents — those register tools from inside `node_modules` and are skipped on replay. Author `overrides.toModelOutput` inline in the agent; a function imported from a library will not get a durable descriptor.
 
 ## Durable approval, done right
 

--- a/apps/docs/content/docs/5.api/2.reference.md
+++ b/apps/docs/content/docs/5.api/2.reference.md
@@ -294,12 +294,14 @@ export default createGithubTools({
 
 ## `@github-tools/sdk/eve-runtime`
 
-Shared eve primitives for `@github-tools/eve-extension` and advanced integrations: tool descriptors, `executeGithubEveTool`, approval helpers (`mapEveApprovalValue`, `resolveEveApproval`), and related types. **Not deprecated** — this is the supported low-level surface the extension imports. Prefer the extension mount for agents; use this subpath only when building on top of the same runtime.
+Shared eve primitives for `@github-tools/eve-extension` and advanced integrations: tool descriptors, `executeGithubEveTool`, `formatGithubEveToolOutput` / `hasGithubEveToolModelOutput` (built-in `toModelOutput` lookup by tool name), approval helpers (`mapEveApprovalValue`, `resolveEveApproval`), and related types. **Not deprecated** — this is the supported low-level surface the extension imports. Prefer the extension mount for agents; use this subpath only when building on top of the same runtime.
 
 ```ts [import-eve-runtime.ts]
 import {
   listEveToolDescriptors,
   executeGithubEveTool,
+  formatGithubEveToolOutput,
+  hasGithubEveToolModelOutput,
   mapEveApprovalValue,
   resolveEveApproval,
 } from '@github-tools/sdk/eve-runtime'

--- a/apps/docs/skills/github-tools-agents/references/eve-extension.md
+++ b/apps/docs/skills/github-tools-agents/references/eve-extension.md
@@ -53,6 +53,8 @@ export default githubExtension({
 })
 ```
 
+Built-in `toModelOutput` formatters are applied via an inline callback that only closes over the tool name. Author `overrides.toModelOutput` inline in the agent — a library function will not get a durable descriptor on eve 0.44+.
+
 ## Approval
 
 - Default: write tools → `always()`

--- a/packages/github-tools-eve-extension/README.md
+++ b/packages/github-tools-eve-extension/README.md
@@ -43,7 +43,7 @@ export default githubExtension({
 
 > `code-review` pairs cleanly with a Connect `connector`. `maintainer` and `repo-explorer` include gist tools, and GitHub only grants gist access to user access tokens, never the installation tokens Connect mints, so gist calls 403 over Connect. Write tools already require approval via `always()` by default, so a plain `{ someTool: true }` is a no-op, use a predicate (as above) when you actually want to narrow or loosen the default.
 
-Tools are registered with **inline** `execute` handlers in the extension package so they survive multi-turn durable eve Workflow replay (see [#51](https://github.com/vercel-labs/github-tools/issues/51)). Do not use the deprecated `@github-tools/sdk/connect/eve` one-liner for durable Slack/multi-turn agents.
+Tools are registered with **inline** `execute` and `toModelOutput` handlers in the extension package so they survive multi-turn durable eve Workflow replay (see [#51](https://github.com/vercel-labs/github-tools/issues/51), [#99](https://github.com/vercel-labs/github-tools/issues/99)). Do not use the deprecated `@github-tools/sdk/connect/eve` one-liner for durable Slack/multi-turn agents.
 
 `connector` also accepts a `() => string | Promise<string>` resolver, so the same config can pick a connector dynamically (e.g. by environment):
 

--- a/packages/github-tools-eve-extension/extension/tools/github.ts
+++ b/packages/github-tools-eve-extension/extension/tools/github.ts
@@ -1,6 +1,8 @@
 import { connectGithubToken } from '@github-tools/sdk/connect'
 import {
   executeGithubEveTool,
+  formatGithubEveToolOutput,
+  hasGithubEveToolModelOutput,
   isEveApprovalDisabled,
   listEveToolDescriptors,
   mapEveApprovalValue,
@@ -17,8 +19,9 @@ import extension from '../extension'
 
 /**
  * Rebuild options from extension config on every call.
- * Durable `execute` only closes over a serializable tool `name` (#51); reading
- * config here avoids a module-level store that races across concurrent sessions.
+ * Durable `execute` / `toModelOutput` only close over a serializable tool `name`
+ * (#51, #99); reading config here avoids a module-level store that races across
+ * concurrent sessions.
  */
 function buildSessionOptions(): EveGithubToolsOptions {
   const {
@@ -110,7 +113,9 @@ export default defineDynamic({
           }),
           ...(override?.toModelOutput !== undefined
             ? { toModelOutput: override.toModelOutput }
-            : entry.toModelOutput ? { toModelOutput: entry.toModelOutput } : {}),
+            : hasGithubEveToolModelOutput(name)
+              ? { toModelOutput: (output: unknown) => formatGithubEveToolOutput(name, output) }
+              : {}),
           ...(override?.outputSchema !== undefined && {
             outputSchema: override.outputSchema,
           }),

--- a/packages/github-tools/src/eve-runtime.ts
+++ b/packages/github-tools/src/eve-runtime.ts
@@ -12,6 +12,8 @@ export {
   listResolvedEveToolNames,
   listEveToolDescriptors,
   executeGithubEveTool,
+  formatGithubEveToolOutput,
+  hasGithubEveToolModelOutput,
 } from './eve/build'
 export { mapEveApprovalValue, resolveEveApproval, resolveEveToolApproval, isEveApprovalDisabled } from './eve/approval'
 export type {

--- a/packages/github-tools/src/eve/build.test.ts
+++ b/packages/github-tools/src/eve/build.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { PRESET_TOOLS } from '../core/presets'
 import * as repositoryCore from '../core/repository'
-import { buildEveToolDefinition, buildEveToolMap, createEveGithubToolsDynamic, listResolvedEveToolNames } from './build'
+import { buildEveToolDefinition, buildEveToolMap, createEveGithubToolsDynamic, formatGithubEveToolOutput, hasGithubEveToolModelOutput, listResolvedEveToolNames } from './build'
 import { getEveTools } from './load-eve'
 
 describe('createGithubTools eve integration', () => {
@@ -125,5 +125,26 @@ describe('createGithubTools eve integration', () => {
     expect(tools.createIssue?.approval).toBeDefined()
     expect(tools.addIssueComment?.approval).toBeUndefined()
     expect(tools.listIssues?.approval).toBeUndefined()
+  })
+
+  it('looks up built-in toModelOutput formatters by tool name', () => {
+    expect(hasGithubEveToolModelOutput('getFileContent')).toBe(true)
+    expect(hasGithubEveToolModelOutput('listIssues')).toBe(false)
+    expect(formatGithubEveToolOutput('getFileContent', {
+      type: 'file',
+      path: 'README.md',
+      sha: 'abc',
+      size: 5,
+      content: 'hello',
+    })).toEqual({
+      type: 'json',
+      value: {
+        type: 'file',
+        path: 'README.md',
+        sha: 'abc',
+        size: 5,
+        content: 'hello',
+      },
+    })
   })
 })

--- a/packages/github-tools/src/eve/build.ts
+++ b/packages/github-tools/src/eve/build.ts
@@ -3,7 +3,7 @@ import { resolvePresetTools, type CombinedPresetToolNames, type GithubToolPreset
 import { createGithubTokenResolver } from '../core/token'
 import { isEveApprovalDisabled, mapEveApprovalValue, resolveEveToolApproval } from './approval'
 import { getEveTools } from './load-eve'
-import { ALL_GITHUB_TOOL_NAMES, createToolRegistry, type GithubToolName, type ToolBuildContext } from './registry'
+import { ALL_GITHUB_TOOL_NAMES, createToolRegistry, formatGithubEveToolOutput, hasGithubEveToolModelOutput, type GithubToolName, type ToolBuildContext } from './registry'
 import { runGithubToolStep } from './steps'
 import type { EveGithubToolsOptions, EveToolFactoryOptions, EveToolOverrides } from './types'
 
@@ -163,6 +163,8 @@ export function listEveToolDescriptors(options: EveGithubToolsOptions = {}) {
       toModelOutput: entry.toModelOutput,
     }))
 }
+
+export { formatGithubEveToolOutput, hasGithubEveToolModelOutput }
 
 /**
  * Execute a GitHub tool by name with the given eve options (token/context/attribution).

--- a/packages/github-tools/src/eve/registry.ts
+++ b/packages/github-tools/src/eve/registry.ts
@@ -64,6 +64,31 @@ function modelOutputAdapter(
   return (output: unknown) => fn({ toolCallId: '', input: {}, output }) as ToolModelOutput
 }
 
+const GITHUB_EVE_TOOL_MODEL_OUTPUT = {
+  getFileContent: modelOutputAdapter(getFileContentToModelOutput),
+  listPullRequestFiles: modelOutputAdapter(listPullRequestFilesToModelOutput),
+  getPullRequestContext: modelOutputAdapter(getPullRequestContextToModelOutput),
+  getCommit: modelOutputAdapter(getCommitToModelOutput),
+  compareCommits: modelOutputAdapter(compareCommitsToModelOutput),
+} satisfies Partial<Record<GithubToolName, (output: unknown) => ToolModelOutput>>
+
+/** Whether a GitHub tool has a built-in eve `toModelOutput` projection. */
+export function hasGithubEveToolModelOutput(name: GithubToolName): boolean {
+  return Object.hasOwn(GITHUB_EVE_TOOL_MODEL_OUTPUT, name)
+}
+
+/**
+ * Apply the built-in eve `toModelOutput` projection for a tool.
+ * Used by `@github-tools/eve-extension` so the callback only closes over a serializable tool name.
+ */
+export function formatGithubEveToolOutput(name: GithubToolName, output: unknown): ToolModelOutput {
+  const format = GITHUB_EVE_TOOL_MODEL_OUTPUT[name as keyof typeof GITHUB_EVE_TOOL_MODEL_OUTPUT]
+  if (!format) {
+    throw new Error(`No toModelOutput formatter for GitHub tool: ${name}`)
+  }
+  return format(output)
+}
+
 export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
   const entries: ToolRegistryEntry[] = [
     {
@@ -83,7 +108,7 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       description: repository.getFileContentDescription,
       inputSchema: repository.getFileContentInputSchema,
       execute: withToken(repository.getFileContentCore, ctx),
-      toModelOutput: modelOutputAdapter(getFileContentToModelOutput),
+      toModelOutput: GITHUB_EVE_TOOL_MODEL_OUTPUT.getFileContent,
     },
     {
       name: 'getRepositoryTree',
@@ -182,7 +207,7 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       description: pullRequests.listPullRequestFilesDescription,
       inputSchema: pullRequests.listPullRequestFilesInputSchema,
       execute: withToken(pullRequests.listPullRequestFilesCore, ctx),
-      toModelOutput: modelOutputAdapter(listPullRequestFilesToModelOutput),
+      toModelOutput: GITHUB_EVE_TOOL_MODEL_OUTPUT.listPullRequestFiles,
     },
     {
       name: 'listPullRequestReviews',
@@ -209,7 +234,7 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       description: bundles.getPullRequestContextDescription,
       inputSchema: bundles.getPullRequestContextInputSchema,
       execute: withToken(bundles.getPullRequestContextCore, ctx),
-      toModelOutput: modelOutputAdapter(getPullRequestContextToModelOutput),
+      toModelOutput: GITHUB_EVE_TOOL_MODEL_OUTPUT.getPullRequestContext,
     },
     {
       name: 'getIssueContext',
@@ -419,7 +444,7 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       description: commits.getCommitDescription,
       inputSchema: commits.getCommitInputSchema,
       execute: withToken(commits.getCommitCore, ctx),
-      toModelOutput: modelOutputAdapter(getCommitToModelOutput),
+      toModelOutput: GITHUB_EVE_TOOL_MODEL_OUTPUT.getCommit,
     },
     {
       name: 'getBlame',
@@ -432,7 +457,7 @@ export function createToolRegistry(ctx: ToolBuildContext): ToolRegistryEntry[] {
       description: commits.compareCommitsDescription,
       inputSchema: commits.compareCommitsInputSchema,
       execute: withToken(commits.compareCommitsCore, ctx),
-      toModelOutput: modelOutputAdapter(compareCommitsToModelOutput),
+      toModelOutput: GITHUB_EVE_TOOL_MODEL_OUTPUT.compareCommits,
     },
     {
       name: 'listGists',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@ai-sdk/provider-utils': 5.0.28
+  '@ai-sdk/vue>ai': 7.0.70
+  '@ai-sdk/workflow>ai': 7.0.70
 
 importers:
 
@@ -19,19 +20,19 @@ importers:
         version: 2.31.1(@types/node@26.1.2)
       turbo:
         specifier: latest
-        version: 2.10.10
+        version: 2.10.11
 
   apps/chat:
     dependencies:
       '@ai-sdk/gateway':
-        specifier: ^4.0.41
-        version: 4.0.41(zod@4.4.3)
+        specifier: ^4.0.56
+        version: 4.0.56(zod@4.4.3)
       '@ai-sdk/vue':
-        specifier: ^4.0.52
-        version: 4.0.52(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+        specifier: ^4.0.70
+        version: 4.0.77(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       '@ai-sdk/workflow':
-        specifier: ^1.0.52
-        version: 1.0.52(zod@4.4.3)
+        specifier: ^1.0.70
+        version: 1.0.70(zod@4.4.3)
       '@github-tools/sdk':
         specifier: workspace:*
         version: link:../../packages/github-tools
@@ -52,7 +53,7 @@ importers:
         version: 0.14.0(@vercel/blob@2.6.1)(@vercel/functions@3.7.7(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1))(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.11.1)(pg@8.22.0)))(esbuild@0.28.1)(ioredis@5.11.1)(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.2)(rollup@4.62.4)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@nuxt/ui':
         specifier: ^4.10.0
-        version: 4.10.0(8265228d6fdebdaad844c7635a7fae23)
+        version: 4.10.0(840a2fc52df9989e23eb9278fa885470)
       '@nuxthub/core':
         specifier: ^0.10.8
         version: 0.10.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@vercel/blob@2.6.1)(@vercel/functions@3.7.7(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1))(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.11.1)(pg@8.22.0)))(ioredis@5.11.1)(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.2)(typescript@6.0.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)))(vue-tsc@3.3.9(typescript@6.0.3))
@@ -67,7 +68,7 @@ importers:
         version: 14.4.0(vue@3.5.40(typescript@6.0.3))
       '@workflow/ai':
         specifier: ^4.2.0
-        version: 4.2.0(@opentelemetry/api@1.9.0)(ai@7.0.52(zod@4.4.3))(workflow@4.8.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))
+        version: 4.2.0(@opentelemetry/api@1.9.0)(ai@7.0.70(zod@4.4.3))(workflow@4.8.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))
       '@workflow/nitro':
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
@@ -75,8 +76,8 @@ importers:
         specifier: ^4.0.16
         version: 4.0.16(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(magicast@0.5.4)(ws@8.21.1)
       ai:
-        specifier: ^7.0.52
-        version: 7.0.52(zod@4.4.3)
+        specifier: ^7.0.70
+        version: 7.0.70(zod@4.4.3)
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -207,28 +208,28 @@ importers:
     dependencies:
       '@chat-adapter/github':
         specifier: latest
-        version: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
+        version: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
       '@chat-adapter/state-memory':
         specifier: latest
-        version: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
+        version: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
       '@github-tools/sdk':
         specifier: workspace:*
         version: link:../../packages/github-tools
       '@workflow/ai':
         specifier: latest
-        version: 4.2.0(@opentelemetry/api@1.9.0)(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))
+        version: 4.2.0(@opentelemetry/api@1.9.0)(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))
       ai:
         specifier: ^6.0.242
         version: 6.0.242(zod@4.4.3)
       chat:
         specifier: latest
-        version: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
+        version: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
       evlog:
         specifier: latest
         version: 2.26.0(1fc26c9dcfa818e98f465c169d03510a)
       workflow:
         specifier: latest
-        version: 4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1)
+        version: 4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -262,7 +263,7 @@ importers:
         specifier: ^4.0.5
         version: 4.0.5
       '@ai-sdk/provider-utils':
-        specifier: 5.0.28
+        specifier: ^5.0.28
         version: 5.0.28(zod@4.4.3)
       '@ai-sdk/workflow':
         specifier: ^1.0.52
@@ -349,21 +350,9 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.143':
-    resolution: {integrity: sha512-RCH60KsUaNiZkI/fBuyau4yvYrVBIEgAcN+Ain94QpL1kVm28GduQzFKfGffAiJU2We0ZrmN4BHkoCZzACK96Q==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/gateway@3.0.164':
     resolution: {integrity: sha512-l+hRFegLWJzio3qj5kNiMWDnFgF4SqOWPk4qkERVbpTmjss2LKj+UBQX8UCDGpy40r6xYu94+it70mZWbTDx+A==}
     engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@4.0.41':
-    resolution: {integrity: sha512-DPkDmmA336kqmIp62on550/6Q6JHvldsnvN1SmkwU8QGrVt1PzFxqyKUn0C5EGGmSBpvF1ohZNtvWNl8gEVugA==}
-    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -415,8 +404,44 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.26':
+    resolution: {integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.35':
+    resolution: {integrity: sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.41':
+    resolution: {integrity: sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.21':
+    resolution: {integrity: sha512-Q4z27c5vqKuXZN65QuF7FVm+uvm3qxEioiQ+8c3s5xXlhbE1Y/SLGBB4BuF+UWia4KaDu2HmNpdR1RGW02/eGg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.28':
     resolution: {integrity: sha512-TnHUyd/rCYQqHg5RuiOaz/hUql6U+kbUaBW0Rp+0N5UhnAInA9CzzV0HXvuAAPwppDsK6fAx9Rd+tRawpJ/3pg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.29':
+    resolution: {integrity: sha512-7EIbwXiXKGa7EFk6tDZpuZBs6lxhEJpOuHeqrDb3Vd85uYdjwkdRuHnZDVDIIb2+QTSRmyph2NrXcbvuO/KAjQ==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -447,14 +472,20 @@ packages:
     peerDependencies:
       vue: ^3.3.4
 
-  '@ai-sdk/vue@4.0.52':
-    resolution: {integrity: sha512-LDISv+7SFiHST81o43RHFKGmpbSvBMtA2bce3U516NfZhuJscH8bnggaeSSQ7a9FtBEgRVtizKPO+glYQ+5Mjg==}
+  '@ai-sdk/vue@4.0.77':
+    resolution: {integrity: sha512-Yd6hjkUA+n0QtUgUr+aX0tquKNplp27r3W1vFshx4pYpJnFWuls5TAi4pzmPNZ2ssvM3QNIFhnruSr+q0nPnPg==}
     engines: {node: '>=22'}
     peerDependencies:
       vue: ^3.3.4
 
   '@ai-sdk/workflow@1.0.52':
     resolution: {integrity: sha512-8ySyyVjK23613atH4iAyGOOGo6K4ZTE7OTDUOKk8gJqVIo4K03DehAle3Ew1oXlfe9ABe0DN/QoNz8XHBwsCGQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/workflow@1.0.70':
+    resolution: {integrity: sha512-hszHoSKG4cJijdk/FOtge+hU8UhPp0mYNWhdFy3H7ywu1PucmglRUS3N7PpMaCId+jDPN3XZmrQnSu47h5Njig==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1557,6 +1588,10 @@ packages:
 
   '@fastify/accept-negotiator@2.0.1':
     resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@fingerprintjs/botd@2.0.0':
     resolution: {integrity: sha512-yhuz23NKEcBDTHmGz/ULrXlGnbHenO+xZmVwuBkuqHUkqvaZ5TAA0kAgcRy4Wyo5dIBdkIf57UXX8/c9UlMLJg==}
@@ -4453,33 +4488,33 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@turbo/darwin-64@2.10.10':
-    resolution: {integrity: sha512-gFDD+wRP5hWxBRghGyEbjpbLOY7aIU/wvsnKdMM7odQcp/wHMrnI83p0FyxxMRZnFH9ZD+S59MvcpOC5b+nrCA==}
+  '@turbo/darwin-64@2.10.11':
+    resolution: {integrity: sha512-v3R+1R/Ysozyo+p7Ri8MCIbndOvYt3DgPFrGLhrhQHfvyvbxyH3WyJj+A/2JTNmNleuAlh3JUyCV0iSVHIONTA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.10':
-    resolution: {integrity: sha512-VZYsxZ6yjyDosUqtiroAVSXPLmx/qBxdHJgIxdMH9RyNmLdOLOWtJnYMnI4qckwCgQMK85G3fu94/xk5+iBCgw==}
+  '@turbo/darwin-arm64@2.10.11':
+    resolution: {integrity: sha512-R0a0CvGAeYYsBgPIgFNB3agGXh6qukjduNhFlwVVX1Ss2IdBJLXmgjytNGmo084bLKS0B6UdLRwKhXMHKKaObQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.10':
-    resolution: {integrity: sha512-lAvW+yEnmsCKMEIwNugjozawvYytHKPhU0kfLBizu83MIs8OUb9KobYvkZ56L5akSM6K7+gBFLEIfQkaceh90g==}
+  '@turbo/linux-64@2.10.11':
+    resolution: {integrity: sha512-dGlY2vg7jpsLjGS1bf9sD/cw1sGMAYbeHGQKGRFxd5Zaj+Ufbj8cNXl/vIit8ueCU97zhL/znn60ZV5iSfZAxw==}
     cpu: [x64]
     os: [android, linux]
 
-  '@turbo/linux-arm64@2.10.10':
-    resolution: {integrity: sha512-MSJ+NkRTd79Z9+YEZpUV9VOWVOOigFhE+v/ETNYJEuTJp3r00y9YgFvDXrmM+DP8Kal6tk3U6xSugD2/Ojh+Jg==}
+  '@turbo/linux-arm64@2.10.11':
+    resolution: {integrity: sha512-eSP9+jjsSCBs2x0QpJZlp49dSD1EIMwXH7PsMIhdWk7w6IThhuKJ+jL95JQ2IW7tRjRmdh8gKcKQtrHLD5R5lA==}
     cpu: [arm64]
     os: [android, linux]
 
-  '@turbo/windows-64@2.10.10':
-    resolution: {integrity: sha512-ycWpXDkUfnDFDY9d+4Qna/UZotDB0wj+s9agrlmNt0Q7a3XHORhK8GPKJdzgzeutXu9EW5P/jyabTEHlohuDXw==}
+  '@turbo/windows-64@2.10.11':
+    resolution: {integrity: sha512-4aD7edogJ8arK8DOyvjTI2KKwmchD5M/WM4BZgidrtFf7aSgn8Ce2rJnDwmriw980c2cKlHnhXtlGy38VtKB8g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.10':
-    resolution: {integrity: sha512-PMk6zQN0csUFklLe+1hz/5G9uU1YmV0cEIey2R/bSeA6o69qcBTlN4A3jOqkgenOO5dOpMHmq2sEUZo8r1+Ssg==}
+  '@turbo/windows-arm64@2.10.11':
+    resolution: {integrity: sha512-m8tJkIrTrbQ9O1uHxV0GUq623Zg1678xGna8eMsy4KbygUX/wVFgdZDYV/AxyoyaW/U7nyKoBvaDVwm22p9xqA==}
     cpu: [arm64]
     os: [win32]
 
@@ -5401,8 +5436,8 @@ packages:
   '@workflow/astro@4.0.15':
     resolution: {integrity: sha512-SI07J10espfpVWlcwEZ8Wnc4D96nkwvKVRC6FshASkBM2iyWc58R+nRRHwuymgXRld3brP5Mt7avW5ta8BWPOQ==}
 
-  '@workflow/astro@4.0.18':
-    resolution: {integrity: sha512-d9y2JhdG2osj7WkubSKrHqRpAx9OoVY7A7atF3ZXIjWJtupBndigSvUdNwxTNPKonGPfB3vb29WeYA8n7og6wQ==}
+  '@workflow/astro@4.0.19':
+    resolution: {integrity: sha512-Ep1jLR061wOFfTHHP+LvrWR9XQHpi7coXjIDw+161fFBd4SVpc/UXXNdqdlBdhI5EJgy7WtcHE4QytvvXJjzQA==}
 
   '@workflow/builders@4.1.0':
     resolution: {integrity: sha512-9Y8jchPlFR0Iz2wELXA3u/K8lq4vhdSuSLDu0fL5sQfmXrjJe0mK08zjyyA4mRwB8In9ysUrZSlK4/qEnbRbzw==}
@@ -5410,8 +5445,8 @@ packages:
   '@workflow/builders@4.1.5':
     resolution: {integrity: sha512-1rI2kBjpF3kMJu4RX53ZQ5erV9239CnXETuRKR6XV9e7y5vjLFobDkPSplnH4jlbERcPKNhx+zfW1wzMpZCwSA==}
 
-  '@workflow/builders@4.1.8':
-    resolution: {integrity: sha512-QJbI4m88nFKNV1FnTI4TCNS1sElB47t53MOByKNL1h9oKYBHwBNJyrjAh9l6Yh6FCxOmTMu+x0nClwJT1D5nPg==}
+  '@workflow/builders@4.1.9':
+    resolution: {integrity: sha512-1i/CJMINcHm98WOrHt3O2R/mClNRXW9UPz79d3xpnHtCl6cKkb7wuS7DlK6YietuTupd0DxrDL/smPt6ONZQeg==}
 
   '@workflow/cli@4.2.10':
     resolution: {integrity: sha512-3k4q3bbo6y7KyzRoxAIPEwwBzQ32piTIWn9WeAVIcO+lOFn2t3sOfhhdGF4INJZtcmlcK/CpGd/MQU010xkU4w==}
@@ -5421,8 +5456,8 @@ packages:
     resolution: {integrity: sha512-tHJ6H3/X9JGP3E+28GioVZWsjagh17aig6yOH3OKR2kBTpUqThWaADr6gK/HJ6/ZHTVCWwGBE3zCTCKbwaHV+g==}
     hasBin: true
 
-  '@workflow/cli@4.3.7':
-    resolution: {integrity: sha512-KPhK8m63bcxWTVWziYrjSqP3IhKufUTS8zXFQ3Mc1T3QSr38iWOYz19vwITAcZsvHOBP8qGw31/Eu0atdXukPw==}
+  '@workflow/cli@4.3.8':
+    resolution: {integrity: sha512-YF68vDAuVwDrJtjNgjvn08a8JDp1CcnFS0weRj097AZSpCx38MzXev1nOYuVhP+emmB14YhYv83+9CBemm5gSg==}
     hasBin: true
 
   '@workflow/core@4.5.0':
@@ -5441,8 +5476,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/core@4.8.3':
-    resolution: {integrity: sha512-xb7iFrlXDlsBVL9jE4l/C9vSb/hxo1Im5hDZK3czJyhd4CaCnlVe6DfaBzueXo5E0rDaLG69qOopfDXHFuGFrQ==}
+  '@workflow/core@4.8.4':
+    resolution: {integrity: sha512-9Hz/klReyHETyENHQ9EBIbRqGhAaQHovOmvE3O091QuO3RBzwaVQzOwhv50335/WVEKgfGJkUFd+ZUn1D6nB1A==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -5473,8 +5508,8 @@ packages:
       '@swc/cli': '>=0.4.0'
       '@swc/core': '>=1.5.0'
 
-  '@workflow/nest@4.0.19':
-    resolution: {integrity: sha512-u3mJs6CHg5yo3PSU7l84d48tijktc5lEQw7xFllihiO4VlcTZHai44OmFUyDsE9XaJ9QYxZz4hR91dGXKTUSAg==}
+  '@workflow/nest@4.0.20':
+    resolution: {integrity: sha512-nz9+8q6FnZm2Ym3NGY8gIB1jfC3hJU9iGoso1HnUuUsAPSYFr6a8mMG/6RjzJm2MeSe/X6suYW2NTyqbZ2UkgA==}
     hasBin: true
     peerDependencies:
       '@nestjs/common': '>=10.0.0'
@@ -5498,8 +5533,8 @@ packages:
       next:
         optional: true
 
-  '@workflow/next@4.1.7':
-    resolution: {integrity: sha512-lvcF0bQ6hLQ4/Af7OlHkLX+EwuJ4F72JOpEONPPz43p/wvJM1nQyay7nU9trnbuK7S/lZQhz5Capc/a7vFNOHg==}
+  '@workflow/next@4.1.8':
+    resolution: {integrity: sha512-Ku7n+B4fc0S7gS0E5xLncyJ5oxYqouLR2ec1heZX6QZec7M+VU78IVSpHyzh2YJoNrkqqKqKNkkDTavSLLqqsA==}
     peerDependencies:
       next: '>13'
     peerDependenciesMeta:
@@ -5509,11 +5544,11 @@ packages:
   '@workflow/nitro@4.1.1':
     resolution: {integrity: sha512-HO8Og8OwnnTWU93/KrqlldktiUjhU7TXk3lC8b0WEKhajGd8HVLvXDEb+4DIp3JoaNo8j5L+4dpBxPhwfcIiFg==}
 
+  '@workflow/nitro@4.1.10':
+    resolution: {integrity: sha512-s5Fhn3SPluCNXif+lzuvRKnNrYBkKT8cSRfr2PzhSaa/PBu8dGJ+zVMnoSKDlD5UkhJKVh8ALLbH6sPY5wo4JA==}
+
   '@workflow/nitro@4.1.6':
     resolution: {integrity: sha512-RwV75yJilTz3CbI6oGUsmZ+kjIEzogk/JQmFWCPBeKupqxoS2QapWNNG0mFUtb88MFFDzZ/U6shhnzFunXx1zA==}
-
-  '@workflow/nitro@4.1.9':
-    resolution: {integrity: sha512-FnICFFQ4Qq4Nk2Ajse520QyDulDNqMDynAWcdDiVR/nZFQZy8TDMBKmo8Tgk5K4UAoEvSILhVkY+ZuUaw7pM0A==}
 
   '@workflow/nuxt@4.0.11':
     resolution: {integrity: sha512-CXfsux7T0GpOwxzf/0UxZjrpA5XC7QhiwGh0umNnn37CAqDGYETGy4QZtKluEVKB/rZElssNjkJk1b0ufBAgOw==}
@@ -5521,8 +5556,8 @@ packages:
   '@workflow/nuxt@4.0.16':
     resolution: {integrity: sha512-/8ZCm8MbpiD0bxopICewXVmRkhuN147m4fP09Csly5CRhIEFKqRwFMRqLtg/t2uLLo+SqAykX86cjaTMwlmMVA==}
 
-  '@workflow/nuxt@4.0.19':
-    resolution: {integrity: sha512-aAKrfmVoS67L/YW5VgG2ty3BQpOKUJLLapbpeGqbeXzfsvulE27wvQ7AburI2zEyHg2cALg5t2hA02dnL1wKiQ==}
+  '@workflow/nuxt@4.0.20':
+    resolution: {integrity: sha512-fVXLkhmlcazZV/IJI1Hn0hfokIfgqZOwqRuChZFE3kS8Zqrb2kQzEmpDqigzI0bH6a+WXzgx9+g4tUAWFNFDWw==}
 
   '@workflow/rollup@4.0.10':
     resolution: {integrity: sha512-gRKQv/pYOsCCXHSyg27a5mf054ucaWT3nBq+YU15LpwlOvGf2Z68k5H7D2oZYyAtwHa3v4vp6tTdEBvhzsIBQw==}
@@ -5530,8 +5565,8 @@ packages:
   '@workflow/rollup@4.0.15':
     resolution: {integrity: sha512-dssflZeWYWe3jq9m6hI1t15PaFd4sJt2XQ332+m29GM1uyL0HGsLigoyLbNs76JpQdcO0wdHTllzOZkslCEkow==}
 
-  '@workflow/rollup@4.0.18':
-    resolution: {integrity: sha512-UExirEIuZs6hBTzPRqqba2huI918wC/sMRUtnh+Ct9tQVI8xhGfi5/uYbq+uGDffq0qH+eVy/QHlLp3ENUCnZg==}
+  '@workflow/rollup@4.0.19':
+    resolution: {integrity: sha512-2UJ4tWoL4WkNEmfECPoeeKYV27NiHMTI7awi0Ty8GQOyvOrklRcTh+kJhkaOIGdE1HJmmFIQgzbmHOCP7lLKDg==}
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
@@ -5551,8 +5586,8 @@ packages:
   '@workflow/sveltekit@4.0.15':
     resolution: {integrity: sha512-292/PjhCeECrTLfD9xMb+hqN0gO3ht5hPFuYfas4bLt06YevpyL1DUgiM+18UM0W+jj0vHsfswhMl+dqvDq2pQ==}
 
-  '@workflow/sveltekit@4.0.18':
-    resolution: {integrity: sha512-iVNUr42uuxVcUw8VZliSNcimYExeDLsd14FfGVQoNpjPZhqrRVKaCj5Q98YdSCUEZciAci7VP4rvP6FsxFDg/w==}
+  '@workflow/sveltekit@4.0.19':
+    resolution: {integrity: sha512-llt1kqfrHoy/ADmjDVUVoH/IaYkS3wlfwoNOl982Vzt8H5iWQPdkzJM1wGTyVmTl8VoIoh14sHozvIqtlWoj5Q==}
 
   '@workflow/swc-plugin@4.1.1':
     resolution: {integrity: sha512-Bi1K/z7Fjxzf5DY9BCBZHMd6Y4SvuCPOAyslydcDD9m38Suz3xCcfrEDvXo8R5mnEnTuLIB4GEJyB54CkMuuiQ==}
@@ -5581,8 +5616,8 @@ packages:
   '@workflow/vite@4.0.15':
     resolution: {integrity: sha512-xDyyXsKYr+k2L1opaD5ITCiUNEohUH0tANUSGEkiVUDiGfE5Esi2v6trKqfmkyGhgAv03I/4kkPTUb6TBYJ3RQ==}
 
-  '@workflow/vite@4.0.18':
-    resolution: {integrity: sha512-iRiwfqKDZ9KSk7vLvJIPYDusVaf49xbKtUN6CKfMlGLtM40vYPHy+/3V1/59wavawL1jNsDq6+XhvIjXbDk7SA==}
+  '@workflow/vite@4.0.19':
+    resolution: {integrity: sha512-2CB7frgRlAA+ThN5FBrevIAiWy58z9NEIudj/yD5nwh6nJpsSpEPIs+TFLj6Q0VQDvNSWVHv9K8ujWIUOpGBsA==}
 
   '@workflow/web@4.1.11':
     resolution: {integrity: sha512-0IsUJ4BpViEg4LH2jijgP/yfddFcbQS/l3VShx/YwvsLirC57h8FN+r+XcUZeUn3B7yyY69OBBB6pl+5bmGQMg==}
@@ -5590,8 +5625,8 @@ packages:
   '@workflow/web@4.1.16':
     resolution: {integrity: sha512-TgXV6ryqJWlBqiifV+tX/vIuU2cY6z0DojKbJWIqpx2JWdxsRkkZuvF9AvWd90OkCSDfqs8iLVRMvs1yHg9HeA==}
 
-  '@workflow/web@4.1.19':
-    resolution: {integrity: sha512-1+KJ/n3/M2vilySnhKjxZcrPYnwUj2y5WazTCDJyvj9uVwu7Fm446L0fIK3K11Bx+JRbsDyF6bDiQ1mp111ZFA==}
+  '@workflow/web@4.1.20':
+    resolution: {integrity: sha512-HE1pMgczwnSau2kWChnizovieihmihpnJJfVg/vStnMMz3qfawRMhRMj6HzfiLN9G6AnKp1mgCfrhO1va9gMjw==}
 
   '@workflow/world-local@4.2.0':
     resolution: {integrity: sha512-gsJSl9PeenbF8TECSsaev+6/LQAW3AIL/WMxpAQzQOgFocOAGAsch669fHeY2TuwJBchretVw7V6HN0pyTvLeQ==}
@@ -5603,6 +5638,14 @@ packages:
 
   '@workflow/world-local@4.2.4':
     resolution: {integrity: sha512-MCsoTTNyPp6cTV8z3wqniTaJUdwlcggMjKRMadU4jHjX5UOhEFrUE9EeOBnJY2eFUyEGW//Z/WpRFm2b982lcg==}
+    peerDependencies:
+      '@opentelemetry/api': '1'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
+  '@workflow/world-local@4.3.0':
+    resolution: {integrity: sha512-L5FGVcGUxMKiH2KhXnmyPHqjHc4kucVs737hXzBzXDZ49H+/9ccD/Phq9gl8w2C1OtpEW3h2sjuv/Ef8CZBMZA==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -5625,8 +5668,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/world-vercel@4.6.2':
-    resolution: {integrity: sha512-wkhYRgR8SOyYHNFt6Ns4MN9pWQFugDpV0GFIMcbzD9lkPx5rh7qgUWJNnHdNKVmmS4p25uWDBcLu8h6t42Yp3g==}
+  '@workflow/world-vercel@4.7.0':
+    resolution: {integrity: sha512-+XP4J0e0YsDhHCRV+BwXv5Wn52LLtuuOF4wCf7GmB3dy0S5VQBg6csSmRBoL5iRCEXbdLlCYcCXjD/SXcIuBsw==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -5640,6 +5683,9 @@ packages:
 
   '@workflow/world@4.3.1':
     resolution: {integrity: sha512-gT67yCzMsm6SS5+2ho+b6dSd8qknTlDkfHvKnuWWt9fwkvpRr0WLWFOPvzILj3IY/mptDj3pFNDS9a6RWxEqQQ==}
+
+  '@workflow/world@4.4.0':
+    resolution: {integrity: sha512-rlq2qr0VFWG3YYqMpD9k95Tz5h5zqr24Bg8PheZ+rJgkgWZBXWLHS5BkiTA7K3l58NC8M78qkMGakU2/gb3Aag==}
 
   '@xhmikosr/archive-type@8.1.0':
     resolution: {integrity: sha512-EXOjEbnZFE5c/nFMf4FOrEURVanzHpnkPYmnmr78u02/8hAhE0FMq8p9TK1IM0/bFr5VcyBUY0gfLm8f7dKy+Q==}
@@ -5850,12 +5896,6 @@ packages:
   ai@6.0.242:
     resolution: {integrity: sha512-xP8coqeurX5qqp6TB2niOcwq82v1sFTZ9/wdwKdilnpGlnAIj2uKdLa32CeGrHJQtg54lq9Xae0khhur0RgeQQ==}
     engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ai@7.0.52:
-    resolution: {integrity: sha512-sEgRnYA+ddJ1rJSz1uKBjkGbOXhXdon1nvno49fVk3tabnlf8v5SaceLBpPDMtmDuLKQFztc/YbRsoCQoPzKZw==}
-    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -10966,8 +11006,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.10.10:
-    resolution: {integrity: sha512-/90KTW+USzvYOPmafRZHVKLBsHXQ5810Ao/HdtJYAqguIhZ+XruS6eIUjqJUDtrSxaZYynNFht68qckGKAOWTA==}
+  turbo@2.10.11:
+    resolution: {integrity: sha512-yQfwQVoRXwOuyX1LxiJFBFNg6VfuYh+/RyZLd82+isgyLkBXw3S5XRRzvcck1FAjSCG5sVyLd+O1eDMvYa3J7g==}
     hasBin: true
 
   type-check@0.4.0:
@@ -11069,6 +11109,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
 
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
@@ -11790,8 +11834,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  workflow@4.8.3:
-    resolution: {integrity: sha512-boZkE92hdaLlf0Iy2UD7tRYKhm99rWC8aPdAxAmjI2MGMTbwvVcsjaI9eASoYv6PbBAYlHvSz0nl3xv79gYSrQ==}
+  workflow@4.8.4:
+    resolution: {integrity: sha512-WYX9I+Qwqs4PGD4psPWLJ5Ne7+AuFCokPtg+PKW9GKXvpYo3PtCHTa4r4GBCDFaoZLEDLI80MeYXe8GmzTIm8g==}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': '1'
@@ -11985,29 +12029,21 @@ snapshots:
   '@ai-sdk/anthropic@3.0.105(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
   '@ai-sdk/anthropic@3.0.75(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
-      zod: 4.3.6
-    optional: true
-
-  '@ai-sdk/gateway@3.0.143(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.13
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
-      '@vercel/oidc': 3.2.0
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
   '@ai-sdk/gateway@3.0.164(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.3.6)
       '@vercel/oidc': 3.2.0
       zod: 4.3.6
     optional: true
@@ -12015,14 +12051,7 @@ snapshots:
   '@ai-sdk/gateway@3.0.164(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
-  '@ai-sdk/gateway@4.0.41(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.5
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
@@ -12036,63 +12065,112 @@ snapshots:
   '@ai-sdk/google@3.0.103(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
   '@ai-sdk/google@3.0.68(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
   '@ai-sdk/mcp@1.0.58(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.13
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.35(zod@4.4.3)
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
   '@ai-sdk/openai-compatible@2.0.46(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
   '@ai-sdk/openai-compatible@2.0.63(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
   '@ai-sdk/openai@3.0.62(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
   '@ai-sdk/openai@3.0.90(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
-  '@ai-sdk/provider-utils@5.0.28(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.26(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/provider-utils@4.0.35(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.41(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      undici: 5.29.0
+      zod: 4.3.6
+    optional: true
+
+  '@ai-sdk/provider-utils@4.0.41(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      undici: 5.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.21(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.5
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.27(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       undici: 7.29.0
-      zod: 4.3.6
-    optional: true
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.28(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.29(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
@@ -12123,17 +12201,17 @@ snapshots:
 
   '@ai-sdk/vue@3.0.242(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
-      ai: 6.0.242(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.4.3)
+      ai: 7.0.70(zod@4.4.3)
       swrv: 1.2.0(vue@3.5.40(typescript@6.0.3))
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/vue@4.0.52(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
+  '@ai-sdk/vue@4.0.77(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
-      ai: 7.0.52(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.29(zod@4.4.3)
+      ai: 7.0.70(zod@4.4.3)
       swrv: 1.2.0(vue@3.5.40(typescript@6.0.3))
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:
@@ -12142,8 +12220,16 @@ snapshots:
   '@ai-sdk/workflow@1.0.52(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.5
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
-      ai: 7.0.52(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.21(zod@4.4.3)
+      ai: 7.0.70(zod@4.4.3)
+      ajv: 8.20.0
+      zod: 4.4.3
+
+  '@ai-sdk/workflow@1.0.70(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
+      ai: 7.0.70(zod@4.4.3)
       ajv: 8.20.0
       zod: 4.4.3
 
@@ -12151,7 +12237,7 @@ snapshots:
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.63(zod@4.3.6)
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
@@ -12159,7 +12245,7 @@ snapshots:
     dependencies:
       '@ai-sdk/openai-compatible': 2.0.46(zod@4.3.6)
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.3.6)
       zod: 4.3.6
     optional: true
 
@@ -12615,30 +12701,30 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@chat-adapter/github@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)':
+  '@chat-adapter/github@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)':
     dependencies:
-      '@chat-adapter/shared': 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
+      '@chat-adapter/shared': 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
       '@octokit/auth-app': 8.3.0
       '@octokit/rest': 22.0.1
-      chat: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
+      chat: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - workflow
       - zod
 
-  '@chat-adapter/shared@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)':
+  '@chat-adapter/shared@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)':
     dependencies:
-      chat: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
+      chat: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
       - workflow
       - zod
 
-  '@chat-adapter/state-memory@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)':
+  '@chat-adapter/state-memory@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)':
     dependencies:
-      chat: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
+      chat: 4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -13202,6 +13288,8 @@ snapshots:
 
   '@fastify/accept-negotiator@2.0.1':
     optional: true
+
+  '@fastify/busboy@2.1.1': {}
 
   '@fingerprintjs/botd@2.0.0': {}
 
@@ -15042,7 +15130,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/ui@4.10.0(8265228d6fdebdaad844c7635a7fae23)':
+  '@nuxt/ui@4.10.0(840a2fc52df9989e23eb9278fa885470)':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@iconify/vue': 5.0.1(vue@3.5.40(typescript@6.0.3))
@@ -15112,7 +15200,7 @@ snapshots:
       '@internationalized/date': 3.12.3
       '@internationalized/number': 3.6.7
       '@nuxt/content': 3.15.0(@libsql/client@0.17.4)(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260702.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.11.1)(pg@8.22.0))(esbuild@0.28.1)(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.2)(rollup@4.62.4)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
-      ai: 7.0.52(zod@4.4.3)
+      ai: 7.0.70(zod@4.4.3)
       valibot: 1.4.2(typescript@6.0.3)
       vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       zod: 4.4.3
@@ -17247,22 +17335,22 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@turbo/darwin-64@2.10.10':
+  '@turbo/darwin-64@2.10.11':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.10':
+  '@turbo/darwin-arm64@2.10.11':
     optional: true
 
-  '@turbo/linux-64@2.10.10':
+  '@turbo/linux-64@2.10.11':
     optional: true
 
-  '@turbo/linux-arm64@2.10.10':
+  '@turbo/linux-arm64@2.10.11':
     optional: true
 
-  '@turbo/windows-64@2.10.10':
+  '@turbo/windows-64@2.10.11':
     optional: true
 
-  '@turbo/windows-arm64@2.10.10':
+  '@turbo/windows-arm64@2.10.11':
     optional: true
 
   '@turf/boolean-point-in-polygon@7.4.0':
@@ -18313,18 +18401,18 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@ai-sdk/anthropic': 3.0.75(zod@4.3.6)
-      '@ai-sdk/gateway': 3.0.143(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.164(zod@4.3.6)
       '@ai-sdk/google': 3.0.68(zod@4.3.6)
       '@ai-sdk/openai': 3.0.62(zod@4.3.6)
       '@ai-sdk/xai': 3.0.88(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
 
-  '@workflow/ai@4.2.0(@opentelemetry/api@1.9.0)(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))':
+  '@workflow/ai@4.2.0(@opentelemetry/api@1.9.0)(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@workflow/serde': 4.1.2
       ai: 6.0.242(zod@4.4.3)
-      workflow: 4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1)
+      workflow: 4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1)
       zod: 4.3.6
     optionalDependencies:
       '@ai-sdk/anthropic': 3.0.105(zod@4.3.6)
@@ -18334,11 +18422,11 @@ snapshots:
       '@ai-sdk/xai': 3.0.114(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
 
-  '@workflow/ai@4.2.0(@opentelemetry/api@1.9.0)(ai@7.0.52(zod@4.4.3))(workflow@4.8.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))':
+  '@workflow/ai@4.2.0(@opentelemetry/api@1.9.0)(ai@7.0.70(zod@4.4.3))(workflow@4.8.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@workflow/serde': 4.1.2
-      ai: 7.0.52(zod@4.4.3)
+      ai: 7.0.70(zod@4.4.3)
       workflow: 4.8.0(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1)
       zod: 4.3.6
     optionalDependencies:
@@ -18378,13 +18466,13 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/astro@4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/astro@4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/rollup': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/vite': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/vite': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       exsolve: 1.1.1
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -18432,10 +18520,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/builders@4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/builders@4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.3(@opentelemetry/api@1.9.0)(ws@8.21.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.0)(ws@8.21.1)
       '@workflow/errors': 4.2.1
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       '@workflow/utils': 4.1.4
@@ -18527,21 +18615,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/cli@4.3.7(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/cli@4.3.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/core': 4.8.3(@opentelemetry/api@1.9.0)(ws@8.21.1)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.0)(ws@8.21.1)
       '@workflow/errors': 4.2.1
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       '@workflow/utils': 4.1.4
-      '@workflow/web': 4.1.19
-      '@workflow/world': 4.3.1
-      '@workflow/world-local': 4.2.4(@opentelemetry/api@1.9.0)
-      '@workflow/world-vercel': 4.6.2(@opentelemetry/api@1.9.0)
+      '@workflow/web': 4.1.20
+      '@workflow/world': 4.4.0
+      '@workflow/world-local': 4.3.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.7.0(@opentelemetry/api@1.9.0)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -18618,7 +18706,7 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/core@4.8.3(@opentelemetry/api@1.9.0)(ws@8.21.1)':
+  '@workflow/core@4.8.4(@opentelemetry/api@1.9.0)(ws@8.21.1)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
@@ -18628,9 +18716,9 @@ snapshots:
       '@workflow/errors': 4.2.1
       '@workflow/serde': 4.1.2
       '@workflow/utils': 4.1.4
-      '@workflow/world': 4.3.1
-      '@workflow/world-local': 4.2.4(@opentelemetry/api@1.9.0)
-      '@workflow/world-vercel': 4.6.2(@opentelemetry/api@1.9.0)
+      '@workflow/world': 4.4.0
+      '@workflow/world-local': 4.3.0(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.7.0(@opentelemetry/api@1.9.0)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.8.1
       ms: 2.1.3
@@ -18684,13 +18772,13 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nest@4.0.19(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/nest@4.0.20(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@nestjs/common': 11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0)
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -18726,11 +18814,11 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/next@4.1.7(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/next@4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/core': 4.8.3(@opentelemetry/api@1.9.0)(ws@8.21.1)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.0)(ws@8.21.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       semver: 7.7.4
       watchpack: 2.5.1
@@ -18756,6 +18844,23 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
+  '@workflow/nitro@4.1.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+    dependencies:
+      '@swc/core': 1.15.3(@swc/helpers@0.5.23)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.0)(ws@8.21.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/vite': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/web': 4.1.20
+      exsolve: 1.0.8
+      pathe: 2.0.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@swc/helpers'
+      - supports-color
+      - ws
+
   '@workflow/nitro@4.1.6(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
@@ -18765,23 +18870,6 @@ snapshots:
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       '@workflow/vite': 4.0.15(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       '@workflow/web': 4.1.16
-      exsolve: 1.0.8
-      pathe: 2.0.3
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@swc/helpers'
-      - supports-color
-      - ws
-
-  '@workflow/nitro@4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
-    dependencies:
-      '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/core': 4.8.3(@opentelemetry/api@1.9.0)(ws@8.21.1)
-      '@workflow/rollup': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/vite': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/web': 4.1.19
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -18811,10 +18899,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nuxt@4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(magicast@0.5.4)(ws@8.21.1)':
+  '@workflow/nuxt@4.0.20(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(magicast@0.5.4)(ws@8.21.1)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.4)
-      '@workflow/nitro': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/nitro': 4.1.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -18845,10 +18933,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/rollup@4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/rollup@4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -18896,14 +18984,14 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/sveltekit@4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/sveltekit@4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
       '@sveltejs/load-config': 0.2.3
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/rollup': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/vite': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/vite': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       exsolve: 1.1.1
       fs-extra: 11.4.0
       pathe: 2.0.3
@@ -18950,9 +19038,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/vite@4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
+  '@workflow/vite@4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)':
     dependencies:
-      '@workflow/builders': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/builders': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -18971,7 +19059,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@workflow/web@4.1.19':
+  '@workflow/web@4.1.20':
     dependencies:
       express: 5.2.1
     transitivePeerDependencies:
@@ -19003,6 +19091,19 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@workflow/world-local@4.3.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@vercel/queue': 0.3.1
+      '@workflow/errors': 4.2.1
+      '@workflow/utils': 4.1.4
+      '@workflow/world': 4.4.0
+      async-sema: 3.1.1
+      ulid: 3.0.2
+      undici: 7.28.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@workflow/world-vercel@4.4.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@vercel/oidc': 3.2.0
@@ -19027,12 +19128,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@workflow/world-vercel@4.6.2(@opentelemetry/api@1.9.0)':
+  '@workflow/world-vercel@4.7.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@vercel/queue': 0.3.1
       '@workflow/errors': 4.2.1
-      '@workflow/world': 4.3.1
+      '@workflow/world': 4.4.0
       cbor-x: 1.6.0
       undici: 7.28.0
       zod: 4.3.6
@@ -19045,6 +19146,11 @@ snapshots:
       zod: 4.3.6
 
   '@workflow/world@4.3.1':
+    dependencies:
+      ulid: 3.0.2
+      zod: 4.3.6
+
+  '@workflow/world@4.4.0':
     dependencies:
       ulid: 3.0.2
       zod: 4.3.6
@@ -19243,15 +19349,8 @@ snapshots:
     dependencies:
       '@ai-sdk/gateway': 3.0.164(zod@4.4.3)
       '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.41(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 4.4.3
-
-  ai@7.0.52(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 4.0.41(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.5
-      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
       zod: 4.4.3
 
   ai@7.0.70(zod@4.4.3):
@@ -19670,7 +19769,7 @@ snapshots:
 
   chardet@2.2.0: {}
 
-  chat@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3):
+  chat@4.38.1(ai@6.0.242(zod@4.4.3))(workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -19681,7 +19780,7 @@ snapshots:
       unified: 11.0.5
     optionalDependencies:
       ai: 6.0.242(zod@4.4.3)
-      workflow: 4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1)
+      workflow: 4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -26065,14 +26164,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.10.10:
+  turbo@2.10.11:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.10
-      '@turbo/darwin-arm64': 2.10.10
-      '@turbo/linux-64': 2.10.10
-      '@turbo/linux-arm64': 2.10.10
-      '@turbo/windows-64': 2.10.10
-      '@turbo/windows-arm64': 2.10.10
+      '@turbo/darwin-64': 2.10.11
+      '@turbo/darwin-arm64': 2.10.11
+      '@turbo/linux-64': 2.10.11
+      '@turbo/linux-arm64': 2.10.11
+      '@turbo/windows-64': 2.10.11
+      '@turbo/windows-arm64': 2.10.11
 
   type-check@0.4.0:
     dependencies:
@@ -26178,6 +26277,10 @@ snapshots:
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   undici-types@8.3.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@6.28.0: {}
 
@@ -26990,18 +27093,18 @@ snapshots:
       - typescript
       - ws
 
-  workflow@4.8.3(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1):
+  workflow@4.8.4(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.4)(typescript@6.0.3)(ws@8.21.1):
     dependencies:
-      '@workflow/astro': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/cli': 4.3.7(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/core': 4.8.3(@opentelemetry/api@1.9.0)(ws@8.21.1)
+      '@workflow/astro': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/cli': 4.3.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/core': 4.8.4(@opentelemetry/api@1.9.0)(ws@8.21.1)
       '@workflow/errors': 4.2.1
-      '@workflow/nest': 4.0.19(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/next': 4.1.7(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/nitro': 4.1.9(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/nuxt': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(magicast@0.5.4)(ws@8.21.1)
-      '@workflow/rollup': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
-      '@workflow/sveltekit': 4.0.18(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/nest': 4.0.20(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/next': 4.1.8(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/nitro': 4.1.10(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/nuxt': 4.0.20(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(magicast@0.5.4)(ws@8.21.1)
+      '@workflow/rollup': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
+      '@workflow/sveltekit': 4.0.19(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.23)(ws@8.21.1)
       '@workflow/typescript-plugin': 4.0.3(typescript@6.0.3)
       '@workflow/utils': 4.1.4
       ms: 2.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,5 +33,6 @@ minimumReleaseAgeExclude:
   - 'create-eve'
 
 overrides:
-  '@ai-sdk/provider-utils': 5.0.28
+  '@ai-sdk/vue>ai': 7.0.70
+  '@ai-sdk/workflow>ai': 7.0.70
 


### PR DESCRIPTION
eve 0.44 validates every dynamic-tool callback, spreading SDK formatters dropped the whole GitHub toolset. The inline callback only closes over the tool name, same as execute after #51.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:

### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- chat (the chat application)
- deps (dependencies)
- docs (the documentation site)
- eve (the eve extension package)
- sdk (the @github-tools/sdk package)
-->

### 🔗 Linked issue

Closes #99 

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
