### PR TITLE
fix(sdk): skip empty REST update when only toggling PR draft

### DIFF
--- a/.changeset/update-pr-draft-only.md
+++ b/.changeset/update-pr-draft-only.md
@@ -1,0 +1,5 @@
+---
+'@github-tools/sdk': patch
+---
+
+Skip the REST update when `updatePullRequest` is called with only `draft`. Octokit was sending an empty PATCH body (`''`), which GitHub rejects with 400 before the GraphQL draft mutation could run.

--- a/packages/github-tools/src/core/pull-requests.ts
+++ b/packages/github-tools/src/core/pull-requests.ts
@@ -128,7 +128,10 @@ export const updatePullRequestDescription = 'Update a pull request — title, bo
 /** Not idempotent — each call applies a new revision. */
 export async function updatePullRequestCore({ token, owner, repo, pullNumber, title, body, state, base, draft }: { token: string, owner: string, repo: string, pullNumber: number, title?: string, body?: string, state?: 'open' | 'closed', base?: string, draft?: boolean }) {
   const octokit = createOctokit(token)
-  const { data } = await octokit.rest.pulls.update({ owner, repo, pull_number: pullNumber, title, body, state, base })
+  const hasRestUpdate = title !== undefined || body !== undefined || state !== undefined || base !== undefined
+  const { data } = hasRestUpdate
+    ? await octokit.rest.pulls.update({ owner, repo, pull_number: pullNumber, title, body, state, base })
+    : await octokit.rest.pulls.get({ owner, repo, pull_number: pullNumber })
 
   if (draft !== undefined && draft !== data.draft) {
     await octokit.graphql(draft ? CONVERT_TO_DRAFT_MUTATION : MARK_READY_FOR_REVIEW_MUTATION, { pullRequestId: data.node_id })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@ai-sdk/vue>ai': 7.0.70
   '@ai-sdk/workflow>ai': 7.0.70
+  undici@5: 6.28.0
 
 importers:
 
@@ -1588,10 +1589,6 @@ packages:
 
   '@fastify/accept-negotiator@2.0.1':
     resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@fingerprintjs/botd@2.0.0':
     resolution: {integrity: sha512-yhuz23NKEcBDTHmGz/ULrXlGnbHenO+xZmVwuBkuqHUkqvaZ5TAA0kAgcRy4Wyo5dIBdkIf57UXX8/c9UlMLJg==}
@@ -11110,10 +11107,6 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
@@ -12131,7 +12124,7 @@ snapshots:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
-      undici: 5.29.0
+      undici: 6.28.0
       zod: 4.3.6
     optional: true
 
@@ -12140,7 +12133,7 @@ snapshots:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
-      undici: 5.29.0
+      undici: 6.28.0
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.21(zod@4.4.3)':
@@ -13288,8 +13281,6 @@ snapshots:
 
   '@fastify/accept-negotiator@2.0.1':
     optional: true
-
-  '@fastify/busboy@2.1.1': {}
 
   '@fingerprintjs/botd@2.0.0': {}
 
@@ -26277,10 +26268,6 @@ snapshots:
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.2)(rollup@4.62.4)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   undici-types@8.3.0: {}
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   undici@6.28.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,4 +35,5 @@ minimumReleaseAgeExclude:
 overrides:
   '@ai-sdk/vue>ai': 7.0.70
   '@ai-sdk/workflow>ai': 7.0.70
+  'undici@5': 6.28.0
 


### PR DESCRIPTION
Octokit serializes a PATCH with all REST fields undefined to an empty body, which GitHub rejects before the GraphQL draft mutation runs.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:

### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- chat (the chat application)
- deps (dependencies)
- docs (the documentation site)
- eve (the eve extension package)
- sdk (the @github-tools/sdk package)
-->

### 🔗 Linked issue

Closes #89 

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
