### PR TITLE
docs: add production templates and Connect references

### DIFF
--- a/apps/docs/content/docs/3.examples/1.overview.md
+++ b/apps/docs/content/docs/3.examples/1.overview.md
@@ -55,6 +55,24 @@ Each page below is a complete, runnable agent: every file it needs, not just the
 
 Shorter, single-file snippets (toolpick, evlog, selective approval) live on the [Recipes](/examples/recipes) page.
 
+## Production eve templates
+
+For larger, production-ready agents, start with one of these complete eve templates:
+
+### Software Factory
+
+[Foreman](https://github.com/vercel-labs/eve-software-factory-template) takes work from GitHub and Linear through four specialist agents: classifier, analyst, implementer, and reviewer. It finishes with a reviewed draft pull request for a person to approve and merge.
+
+[Deploy the Software Factory](https://vercel.com/templates/eve/eve-software-factory) | [Learn More](https://vercel.com/kb/guide/eve-software-factory)
+
+### Incident Response Agent
+
+[`sre`](https://github.com/vercel-labs/eve-sre-agent-template) investigates production alerts using live Datadog, GitHub, and Vercel data. It tests hypotheses, records findings with source links, and keeps investigations read-only by default. Start an investigation from Slack, a watched alert channel, or a webhook.
+
+[Deploy the Incident Response Agent](https://vercel.com/templates/eve/eve-incident-response-agent) | [Learn More](https://vercel.com/kb/guide/eve-incident-sre-agent)
+
+Both templates use [`@github-tools/eve-extension`](/frameworks/eve-extension) and [Vercel Connect](/guide/vercel-connect) for scoped GitHub access without long-lived credentials.
+
 ## Every example uses Vercel Connect
 
 Each example mints its GitHub token from a [Vercel Connect](/guide/vercel-connect) connector instead of a long-lived `GITHUB_TOKEN`: nothing to store or rotate, and scopes derived from the preset. Swap `connectGithubTools` for `createGithubTools({ token: process.env.GITHUB_TOKEN })` if you'd rather manage a PAT yourself, see [Tokens & Auth](/guide/tokens-and-auth) for the trade-offs.
@@ -68,3 +86,5 @@ The [Frameworks](/frameworks/eve-extension) section shows the shape of each inte
 - [Vercel Connect documentation](https://vercel.com/docs/connect)
 - [eve documentation](https://eve.dev)
 - [AI SDK agents](https://ai-sdk.dev/docs/agents)
+- [Build a software factory with eve](https://vercel.com/kb/guide/eve-software-factory)
+- [Build an incident response sre agent with eve](https://vercel.com/kb/guide/eve-incident-sre-agent)

--- a/apps/docs/content/docs/4.guide/5.vercel-connect.md
+++ b/apps/docs/content/docs/4.guide/5.vercel-connect.md
@@ -192,3 +192,5 @@ If you need full control over every `ConnectTokenParams` field, call `getToken` 
 
 - [Vercel Connect documentation](https://vercel.com/docs/connect)
 - [Vercel Connect SDK reference](https://vercel.com/docs/connect/ts-sdk-reference)
+- [The end of credential sprawl for agents](https://vercel.com/blog/the-end-of-credential-sprawl-for-agents)
+- [The Complete Guide to Vercel Connect](https://vercel.com/kb/guide/vercel-connect)


### PR DESCRIPTION
Adds a production eve templates section to the examples overview, linking the Software Factory and Incident Response Agent sources, deploy pages, and guides.

Adds the Vercel Connect guide and credential-sprawl article to the Connect documentation.