### PR TITLE
docs: link production eve templates

### DIFF
--- a/apps/docs/content/docs/2.frameworks/1.eve-extension.md
+++ b/apps/docs/content/docs/2.frameworks/1.eve-extension.md
@@ -88,6 +88,12 @@ npx eve dev
 
 You now have a GitHub agent that can read repos, review PRs, triage issues, and manage CI, with every write operation gated behind durable approval by default. The full example lives in [`examples/eve/`](https://github.com/vercel-labs/github-tools/tree/main/examples/eve) (or `pnpm dev:eve` from the monorepo root).
 
+<br>
+
+For complete production implementations, see the [Software Factory and Incident Response Agent](/examples/overview#production-eve-templates). Both use the eve extension with [Vercel Connect](https://vercel.com/connect), while scoping GitHub access for different operational needs.
+
+<br>
+
 ## Install
 
 :::code-group

--- a/apps/docs/content/docs/3.examples/1.overview.md
+++ b/apps/docs/content/docs/3.examples/1.overview.md
@@ -63,13 +63,21 @@ For larger, production-ready agents, start with one of these complete eve templa
 
 [Foreman](https://github.com/vercel-labs/eve-software-factory-template) takes work from GitHub and Linear through four specialist agents: classifier, analyst, implementer, and reviewer. It finishes with a reviewed draft pull request for a person to approve and merge.
 
+<br>
+
 [Deploy the Software Factory](https://vercel.com/templates/eve/eve-software-factory) | [Learn More](https://vercel.com/kb/guide/eve-software-factory)
+
+<br>
 
 ### Incident Response Agent
 
 [`sre`](https://github.com/vercel-labs/eve-sre-agent-template) investigates production alerts using live Datadog, GitHub, and Vercel data. It tests hypotheses, records findings with source links, and keeps investigations read-only by default. Start an investigation from Slack, a watched alert channel, or a webhook.
 
+<br>
+
 [Deploy the Incident Response Agent](https://vercel.com/templates/eve/eve-incident-response-agent) | [Learn More](https://vercel.com/kb/guide/eve-incident-sre-agent)
+
+<br>
 
 Both templates use [`@github-tools/eve-extension`](/frameworks/eve-extension) and [Vercel Connect](/guide/vercel-connect) for scoped GitHub access without long-lived credentials.
 

--- a/apps/docs/content/docs/4.guide/5.vercel-connect.md
+++ b/apps/docs/content/docs/4.guide/5.vercel-connect.md
@@ -63,6 +63,12 @@ export default githubExtension({
 
 See [`examples/eve`](https://github.com/vercel-labs/github-tools/tree/main/examples/eve) for a runnable example.
 
+<br>
+
+For production implementations, see the [Software Factory and Incident Response Agent](/examples/overview#production-eve-templates). Both use [Vercel Connect](https://vercel.com/connect) to give eve agents scoped GitHub access without storing long-lived credentials.
+
+<br>
+
 ## eve agent
 
 ::callout{icon="i-lucide-alert-triangle"}


### PR DESCRIPTION
Links the eve extension and Vercel Connect guides to the Software Factory and Incident Response Agent examples.

Adds explicit spacing between template descriptions, resources, and related guidance so each section renders clearly.